### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/openboxes/openboxes.png?label=ready&title=Ready)](https://waffle.io/openboxes/openboxes)
 [![Build Status](https://travis-ci.org/openboxes/openboxes.svg?branch=master)](https://travis-ci.org/openboxes/openboxes)
 [![Documentation Status](https://readthedocs.org/projects/openboxes/badge/?version=latest)](https://readthedocs.org/projects/openboxes/?badge=latest)
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/openboxes/openboxes

This was requested by a real person (user jmiranda) on waffle.io, we're not trying to spam you.