### PR TITLE
Update _Events.groovy

### DIFF
--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -36,7 +36,7 @@ eventAllTestsStart = {
     }
 }
 
-private determineGitRevisionNumber = {
+def determineGitRevisionNumber = {
     String revisionNumber = 'dev'
     try {
         revisionNumber = 'git describe --match v* --always'.execute().text.trim()


### PR DESCRIPTION
Grails 2.5.2 test build does not allow declaration of "private" in this instance.
We declared the "def" variable to eliminate the error messages this was producing.
