### PR TITLE
Hotfix/release 0.7.28

### DIFF
--- a/grails-app/services/org/pih/warehouse/shipping/ShipmentService.groovy
+++ b/grails-app/services/org/pih/warehouse/shipping/ShipmentService.groovy
@@ -1923,6 +1923,9 @@ class ShipmentService {
 				deleteOutboundTransactions(shipmentInstance)
 				deleteEvent(shipmentInstance, eventInstance)
 			}
+			else {
+				deleteEvent(shipmentInstance, eventInstance)
+			}
 			
 		} catch (Exception e) {
 			log.error("Error rolling back most recent event", e)

--- a/grails-app/taglib/org/pih/warehouse/SelectTagLib.groovy
+++ b/grails-app/taglib/org/pih/warehouse/SelectTagLib.groovy
@@ -109,7 +109,7 @@ class SelectTagLib {
     def selectRequisitionTemplate = { attrs, body ->
         def requisitionCriteria = new Requisition(isTemplate: true)
         requisitionCriteria.destination = session.warehouse
-        def requisitionTemplates = requisitionService.getAllRequisitionTemplates(requisitionCriteria, [:])
+        def requisitionTemplates = requisitionService.getAllRequisitionTemplates(requisitionCriteria, [max: -1, offset: 0])
         requisitionTemplates.sort { it.origin.name }
         attrs.from = requisitionTemplates
         attrs.optionKey = "id"


### PR DESCRIPTION
* OBPIH-733 Allow rollback of all shipment events, not just sending and receiving
* OBPIH-740 Fixed bug with Create Stock Requisition workflow where stock list dropdown was only showing the first 10 stock lists