### PR TITLE
Move some API requests to redux

### DIFF
--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -1,4 +1,5 @@
-import { SHOW_SPINNER, HIDE_SPINNER } from './types';
+import { SHOW_SPINNER, HIDE_SPINNER, FETCH_LOCATIONS, FETCH_USERS, FETCH_PRODUCTS } from './types';
+import apiClient from '../utils/apiClient';
 
 export function showSpinner() {
   return {
@@ -11,5 +12,35 @@ export function hideSpinner() {
   return {
     type: HIDE_SPINNER,
     payload: false,
+  };
+}
+
+export function fetchLocations() {
+  const url = '/openboxes/api/locations';
+  const request = apiClient.get(url);
+
+  return {
+    type: FETCH_LOCATIONS,
+    payload: request,
+  };
+}
+
+export function fetchUsers() {
+  const url = '/openboxes/api/generic/person';
+  const request = apiClient.get(url);
+
+  return {
+    type: FETCH_USERS,
+    payload: request,
+  };
+}
+
+export function fetchProducts() {
+  const url = '/openboxes/api/products';
+  const request = apiClient.get(url);
+
+  return {
+    type: FETCH_PRODUCTS,
+    payload: request,
   };
 }

--- a/src/js/actions/types.js
+++ b/src/js/actions/types.js
@@ -1,2 +1,6 @@
 export const SHOW_SPINNER = 'SHOW_SPINNER';
 export const HIDE_SPINNER = 'HIDE_SPINNER';
+
+export const FETCH_LOCATIONS = 'FETCH_LOCATIONS';
+export const FETCH_USERS = 'FETCH_USERS';
+export const FETCH_PRODUCTS = 'FETCH_PRODUCTS';

--- a/src/js/components/stock-movement-wizard/CreateStockMovement.jsx
+++ b/src/js/components/stock-movement-wizard/CreateStockMovement.jsx
@@ -62,7 +62,7 @@ const FIELDS = {
       formName: 'stock-movement-wizard',
     },
     getDynamicAttr: () => ({
-      field: 'origin',
+      field: 'destination',
     }),
   },
   requestedBy: {

--- a/src/js/components/stock-movement-wizard/CreateStockMovement.jsx
+++ b/src/js/components/stock-movement-wizard/CreateStockMovement.jsx
@@ -11,7 +11,7 @@ import DateField from '../form-elements/DateField';
 import ValueSelectorField from '../form-elements/ValueSelectorField';
 import { renderFormField } from '../../utils/form-utils';
 import apiClient from '../../utils/apiClient';
-import { showSpinner, hideSpinner } from '../../actions';
+import { showSpinner, hideSpinner, fetchLocations, fetchUsers } from '../../actions';
 
 const FIELDS = {
   description: {
@@ -89,29 +89,24 @@ class CreateStockMovement extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      locations: [],
-      users: [],
       stockLists: [],
     };
     this.fetchStockLists = this.fetchStockLists.bind(this);
   }
 
   componentDidMount() {
-    this.fetchUsers();
-    this.fetchLocations();
+    if (!this.props.usersFetched) {
+      this.fetchData(this.props.fetchUsers);
+    }
+    if (!this.props.locationsFetched) {
+      this.fetchData(this.props.fetchLocations);
+    }
   }
 
-  fetchUsers() {
+  fetchData(fetchFunction) {
     this.props.showSpinner();
-    const url = '/openboxes/api/generic/person';
-
-    return apiClient.get(url)
-      .then((response) => {
-        const users = _.map(response.data.data, user => (
-          { value: user.id, label: user.name }
-        ));
-        this.setState({ users }, () => this.props.hideSpinner());
-      })
+    fetchFunction()
+      .then(() => this.props.hideSpinner())
       .catch(() => this.props.hideSpinner());
   }
 
@@ -129,31 +124,14 @@ class CreateStockMovement extends Component {
       .catch(() => this.props.hideSpinner());
   }
 
-  fetchLocations() {
-    this.props.showSpinner();
-    const url = '/openboxes/api/locations';
-
-    return apiClient.get(url)
-      .then((response) => {
-        const locations = _.map(response.data.data, location => (
-          {
-            value: { id: location.id, type: location.locationTypeCode, name: location.name },
-            label: `${location.name} [${location.locationTypeCode}]`,
-          }
-        ));
-        this.setState({ locations }, () => this.props.hideSpinner());
-      })
-      .catch(() => this.props.hideSpinner());
-  }
-
   render() {
     return (
       <form onSubmit={this.props.handleSubmit}>
         {_.map(
           FIELDS,
           (fieldConfig, fieldName) => renderFormField(fieldConfig, fieldName, {
-            users: this.state.users,
-            locations: this.state.locations,
+            users: this.props.users,
+            locations: this.props.locations,
             stockLists: this.state.stockLists,
             fetchStockLists: this.fetchStockLists,
           }),
@@ -168,15 +146,30 @@ class CreateStockMovement extends Component {
   }
 }
 
+const mapStateToProps = state => ({
+  locationsFetched: state.locations.fetched,
+  locations: state.locations.data,
+  usersFetched: state.users.fetched,
+  users: state.users.data,
+});
+
 export default reduxForm({
   form: 'stock-movement-wizard',
   destroyOnUnmount: false,
   forceUnregisterOnUnmount: true,
   validate,
-})(connect(null, { showSpinner, hideSpinner })(CreateStockMovement));
+})(connect(mapStateToProps, {
+  showSpinner, hideSpinner, fetchLocations, fetchUsers,
+})(CreateStockMovement));
 
 CreateStockMovement.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
   showSpinner: PropTypes.func.isRequired,
   hideSpinner: PropTypes.func.isRequired,
+  fetchLocations: PropTypes.func.isRequired,
+  locationsFetched: PropTypes.bool.isRequired,
+  locations: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  fetchUsers: PropTypes.func.isRequired,
+  usersFetched: PropTypes.bool.isRequired,
+  users: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
 };

--- a/src/js/reducers/index.jsx
+++ b/src/js/reducers/index.jsx
@@ -2,12 +2,18 @@ import { combineReducers } from 'redux';
 import { reducer as formReducer } from 'redux-form';
 import { localeReducer } from 'react-localize-redux';
 import spinnerReducer from './spinnerReducer';
+import locationsReducer from './locationsReducer';
+import usersReducer from './usersReducer';
+import productsReducer from './productsReducer';
 
 
 const rootReducer = combineReducers({
   form: formReducer,
   locale: localeReducer,
   spinner: spinnerReducer,
+  locations: locationsReducer,
+  users: usersReducer,
+  products: productsReducer,
 });
 
 export default rootReducer;

--- a/src/js/reducers/locationsReducer.jsx
+++ b/src/js/reducers/locationsReducer.jsx
@@ -1,0 +1,25 @@
+import _ from 'lodash';
+import { FETCH_LOCATIONS } from '../actions/types';
+
+const initialState = {
+  data: [],
+  fetched: false,
+};
+
+export default function (state = initialState, action) {
+  switch (action.type) {
+    case FETCH_LOCATIONS:
+      if (action.payload.data !== undefined) {
+        const locations = _.map(action.payload.data.data, location => (
+          {
+            value: { id: location.id, type: location.locationTypeCode, name: location.name },
+            label: `${location.name} [${location.locationTypeCode}]`,
+          }
+        ));
+        return { ...state, data: locations, fetched: true };
+      }
+      return state;
+    default:
+      return state;
+  }
+}

--- a/src/js/reducers/productsReducer.jsx
+++ b/src/js/reducers/productsReducer.jsx
@@ -1,0 +1,22 @@
+import _ from 'lodash';
+import { FETCH_PRODUCTS } from '../actions/types';
+
+const initialState = {
+  data: [],
+  fetched: false,
+};
+
+export default function (state = initialState, action) {
+  switch (action.type) {
+    case FETCH_PRODUCTS:
+      if (action.payload.data !== undefined) {
+        const products = _.map(action.payload.data.data, product => (
+          { value: product, label: product.name }
+        ));
+        return { ...state, data: products, fetched: true };
+      }
+      return state;
+    default:
+      return state;
+  }
+}

--- a/src/js/reducers/usersReducer.jsx
+++ b/src/js/reducers/usersReducer.jsx
@@ -1,0 +1,22 @@
+import _ from 'lodash';
+import { FETCH_USERS } from '../actions/types';
+
+const initialState = {
+  data: [],
+  fetched: false,
+};
+
+export default function (state = initialState, action) {
+  switch (action.type) {
+    case FETCH_USERS:
+      if (action.payload.data !== undefined) {
+        const users = _.map(action.payload.data.data, user => (
+          { value: user.id, label: user.name }
+        ));
+        return { ...state, data: users, fetched: true };
+      }
+      return state;
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
I moved some repeating api request to redux. Now we wont refetch some data that should not change frequently.
example:
Data from /api/generic/person is used on step 1 and 2, so we fetch this only once and store it in redux.