### PR TITLE
OBPIH-917 change quantity remaining field's look when it is canceled

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -481,3 +481,7 @@ div.crossed-out .table-inner-row:before {
   content: "\f0e2";
   color: $blue-gamma;
 }
+
+.strike-through {
+  text-decoration: line-through;
+}

--- a/src/js/components/receiving/ReceivingCheckScreen.jsx
+++ b/src/js/components/receiving/ReceivingCheckScreen.jsx
@@ -103,8 +103,12 @@ const FIELDS = {
         type: params => (params.subfield ? <LabelField {...params} /> : null),
         label: 'Remaining',
         fixedWidth: '95px',
+        fieldKey: '',
+        attributes: {
+          formatValue: fieldValue => (fieldValue.quantityRemaining),
+        },
         getDynamicAttr: ({ fieldValue }) => ({
-          className: !fieldValue ? '' : 'text-danger',
+          className: fieldValue.cancelRemaining ? 'strike-through' : 'text-danger',
         }),
       },
       cancelRemaining: {


### PR DESCRIPTION
Strike through quantity remaining when checkbox is checked so user can be sure it is canceled. 