### PR TITLE
OBPIH-1157 Tweak stock movement name

### DIFF
--- a/src/groovy/org/pih/warehouse/api/StockMovement.groovy
+++ b/src/groovy/org/pih/warehouse/api/StockMovement.groovy
@@ -122,7 +122,7 @@ class StockMovement {
         if (stocklist?.name) name += ".${stocklist.name}"
         if (trackingNumber) name += ".${trackingNumber}"
         if (description) name += ".${description}"
-        name = name.toUpperCase().replace(" ", "")
+        name = name.replace(" ", "")
         return name
     }
 

--- a/src/js/components/stock-movement-wizard/StockMovement.jsx
+++ b/src/js/components/stock-movement-wizard/StockMovement.jsx
@@ -61,7 +61,7 @@ class StockMovements extends Component {
       const stocklistPart = stockList.name ? `${stockList.name}.` : '';
       const dateReq = moment(dateRequested, 'MM/DD/YYYY').format('DDMMMYYYY');
       const newName = `${origin.name}.${destination.name}.${dateReq}.${stocklistPart}${trackingNumber}.${description}`;
-      return newName.toUpperCase().replace(/ /gi, '');
+      return newName.replace(/ /gi, '');
     }
     return this.props.shipmentName;
   }


### PR DESCRIPTION
To make the stock movement name easier to read, use capital or lower case letter according to how those pieces are named in the system rather than defaulting to all caps.