### PR TITLE
OBPIH-1156 Format quantities with commas

### DIFF
--- a/src/js/components/put-away/PutAwayCheckPage.jsx
+++ b/src/js/components/put-away/PutAwayCheckPage.jsx
@@ -84,6 +84,7 @@ class PutAwayCheckPage extends Component {
       Header: 'QTY',
       accessor: 'quantity',
       style: { whiteSpace: 'normal' },
+      Cell: props => <span>{props.value ? props.value.toLocaleString('en-US') : props.value}</span>,
     }, {
       Header: 'Current bin',
       accessor: 'currentBins',

--- a/src/js/components/put-away/PutAwayPage.jsx
+++ b/src/js/components/put-away/PutAwayPage.jsx
@@ -91,6 +91,7 @@ class PutAwayPage extends Component {
       Header: 'Qty in receiving',
       accessor: 'quantity',
       style: { whiteSpace: 'normal' },
+      Cell: props => <span>{props.value ? props.value.toLocaleString('en-US') : props.value}</span>,
     }, {
       Header: 'Stock Movement',
       accessor: 'stockMovement.name',

--- a/src/js/components/put-away/PutAwaySecondPage.jsx
+++ b/src/js/components/put-away/PutAwaySecondPage.jsx
@@ -92,6 +92,7 @@ class PutAwaySecondPage extends Component {
       Header: 'QTY',
       accessor: 'quantity',
       style: { whiteSpace: 'normal' },
+      Cell: props => <span>{props.value ? props.value.toLocaleString('en-US') : props.value}</span>,
     }, {
       Header: 'Current bin',
       accessor: 'currentBins',

--- a/src/js/components/receiving/PartialReceivingPage.jsx
+++ b/src/js/components/receiving/PartialReceivingPage.jsx
@@ -134,13 +134,16 @@ const FIELDS = {
         type: params => (params.subfield ? <LabelField {...params} /> : null),
         label: 'Shipped',
         fixedWidth: '75px',
+        attributes: {
+          formatValue: value => (value ? (value.toLocaleString('en-US')) : value),
+        },
       },
       quantityReceived: {
         type: params => (params.subfield ? <LabelField {...params} /> : null),
         label: 'Received',
         fixedWidth: '75px',
         attributes: {
-          formatValue: value => (value || '0'),
+          formatValue: value => (value ? value.toLocaleString('en-US') : '0'),
         },
       },
       quantityReceiving: {

--- a/src/js/components/receiving/ReceivingCheckScreen.jsx
+++ b/src/js/components/receiving/ReceivingCheckScreen.jsx
@@ -98,6 +98,9 @@ const FIELDS = {
         type: params => (params.subfield ? <LabelField {...params} /> : null),
         label: 'Receiving Now',
         fixedWidth: '115px',
+        attributes: {
+          formatValue: value => (value ? (value.toLocaleString('en-US')) : value),
+        },
       },
       quantityRemaining: {
         type: params => (params.subfield ? <LabelField {...params} /> : null),
@@ -105,7 +108,7 @@ const FIELDS = {
         fixedWidth: '95px',
         fieldKey: '',
         attributes: {
-          formatValue: fieldValue => (fieldValue.quantityRemaining),
+          formatValue: fieldValue => (fieldValue.quantityRemaining ? fieldValue.quantityRemaining.toLocaleString('en-US') : fieldValue.quantityRemaining),
         },
         getDynamicAttr: ({ fieldValue }) => ({
           className: fieldValue.cancelRemaining ? 'strike-through' : 'text-danger',

--- a/src/js/components/stock-movement-wizard/EditPage.jsx
+++ b/src/js/components/stock-movement-wizard/EditPage.jsx
@@ -53,16 +53,25 @@ const FIELDS = {
         type: LabelField,
         label: 'Qty requested',
         flexWidth: '0.8',
+        attributes: {
+          formatValue: value => (value ? (value.toLocaleString('en-US')) : value),
+        },
       },
       quantityAvailable: {
         type: LabelField,
         label: 'Qty available',
         flexWidth: '0.8',
+        attributes: {
+          formatValue: value => (value ? (value.toLocaleString('en-US')) : value),
+        },
       },
       quantityConsumed: {
         type: LabelField,
         label: 'Monthly consumption',
         flexWidth: '1.35',
+        attributes: {
+          formatValue: value => (value ? (value.toLocaleString('en-US')) : value),
+        },
       },
       substituteButton: {
         label: 'Substitution',

--- a/src/js/components/stock-movement-wizard/PickPage.jsx
+++ b/src/js/components/stock-movement-wizard/PickPage.jsx
@@ -59,11 +59,17 @@ const FIELDS = {
         type: LabelField,
         label: 'Qty required',
         flexWidth: '0.9',
+        attributes: {
+          formatValue: value => (value ? (value.toLocaleString('en-US')) : value),
+        },
       },
       quantityPicked: {
         type: LabelField,
         label: 'Qty picked',
         flexWidth: '0.9',
+        attributes: {
+          formatValue: value => (value ? (value.toLocaleString('en-US')) : value),
+        },
       },
       buttonEditPick: {
         label: 'Edit Pick',

--- a/src/js/components/stock-movement-wizard/SendMovementPage.jsx
+++ b/src/js/components/stock-movement-wizard/SendMovementPage.jsx
@@ -331,7 +331,8 @@ class SendMovementPage extends Component {
                           {item.expirationDate}
                         </td>
                         <td style={{ width: '150px' }}>
-                          {item.quantityPicked || item.quantityRequested}
+                          {(item.quantityPicked ? item.quantityPicked.toLocaleString('en-US') : item.quantityPicked) ||
+                           (item.quantityRequested ? item.quantityRequested.toLocaleString('en-US') : item.quantityRequested)}
                         </td>
                         {!(this.state.supplier) &&
                           <td>{item['binLocation.name']}</td>

--- a/src/js/components/stock-movement-wizard/modals/AdjustInventoryModal.jsx
+++ b/src/js/components/stock-movement-wizard/modals/AdjustInventoryModal.jsx
@@ -50,6 +50,9 @@ const FIELDS = {
         type: LabelField,
         label: 'Previous Qty',
         fixedWidth: '150px',
+        attributes: {
+          formatValue: value => (value.toLocaleString('en-US')),
+        },
       },
       quantityAdjusted: {
         type: TextField,

--- a/src/js/components/stock-movement-wizard/modals/EditPickModal.jsx
+++ b/src/js/components/stock-movement-wizard/modals/EditPickModal.jsx
@@ -41,6 +41,9 @@ const FIELDS = {
         type: LabelField,
         label: 'Qty available',
         fixedWidth: '150px',
+        attributes: {
+          formatValue: value => (value.toLocaleString('en-US')),
+        },
       },
       quantityPicked: {
         type: TextField,

--- a/src/js/components/stock-movement-wizard/modals/SubstitutionsModal.jsx
+++ b/src/js/components/stock-movement-wizard/modals/SubstitutionsModal.jsx
@@ -44,6 +44,9 @@ const FIELDS = {
         type: LabelField,
         label: 'Qty Available',
         fixedWidth: '150px',
+        attributes: {
+          formatValue: value => (value.toLocaleString('en-US')),
+        },
       },
       quantitySelected: {
         type: TextField,


### PR DESCRIPTION
For all item quantities on new React pages, if number is over four digits, add comma(s) to make numbers easier to read.

