### PR TITLE
OBPIH-1292 Add validation to prevent negative qty

### DIFF
--- a/src/js/components/receiving/PartialReceivingPage.jsx
+++ b/src/js/components/receiving/PartialReceivingPage.jsx
@@ -280,11 +280,12 @@ class PartialReceivingPage extends Component {
     if (isReceived(true, shipmentItem)) {
       return shipmentItem;
     }
+    const autofillQuantity = _.toInteger(shipmentItem.quantityShipped) -
+          _.toInteger(shipmentItem.quantityReceived);
 
     return {
       ...shipmentItem,
-      quantityReceiving: clearValue ? null
-        : _.toInteger(shipmentItem.quantityShipped) - _.toInteger(shipmentItem.quantityReceived),
+      quantityReceiving: clearValue || autofillQuantity < 0 ? null : autofillQuantity,
     };
   }
 

--- a/src/js/components/receiving/ReceivingPage.jsx
+++ b/src/js/components/receiving/ReceivingPage.jsx
@@ -14,6 +14,7 @@ import { showSpinner, hideSpinner } from '../../actions';
 
 function validate(values) {
   const errors = {};
+  errors.containers = [];
 
   if (!values.dateDelivered) {
     errors.dateDelivered = 'This field is required';
@@ -23,6 +24,14 @@ function validate(values) {
       errors.dateDelivered = 'The date cannot be in the future';
     }
   }
+  _.forEach(values.containers, (container, key) => {
+    errors.containers[key] = { shipmentItems: [] };
+    _.forEach(container.shipmentItems, (item, key2) => {
+      if (item.quantityReceiving < 0) {
+        errors.containers[key].shipmentItems[key2] = { quantityReceiving: 'Quantity to receive can\'t be negative' };
+      }
+    });
+  });
 
   return errors;
 }

--- a/src/js/components/receiving/modals/EditLineModal.jsx
+++ b/src/js/components/receiving/modals/EditLineModal.jsx
@@ -90,6 +90,9 @@ function validate(values) {
     if (line && _.isNil(line.quantityShipped)) {
       errors.lines[key] = { quantityShipped: 'Enter quantity shipped' };
     }
+    if (line.quantityShipped < 0) {
+      errors.lines[key] = { quantityShipped: 'Quantity shipped can\'t be negative' };
+    }
   });
 
   return errors;

--- a/src/js/components/stock-movement-wizard/EditPage.jsx
+++ b/src/js/components/stock-movement-wizard/EditPage.jsx
@@ -171,6 +171,9 @@ function validate(values) {
     if (!_.isEmpty(item.quantityRevised) && (item.quantityRevised > item.quantityAvailable)) {
       errors.editPageItems[key] = { quantityRevised: 'Revised quantity exceeds quantity available' };
     }
+    if (!_.isEmpty(item.quantityRevised) && (item.quantityRevised < 0)) {
+      errors.editPageItems[key] = { quantityRevised: 'Revised quantity can\'t be negative' };
+    }
   });
   return errors;
 }

--- a/src/js/components/stock-movement-wizard/modals/AdjustInventoryModal.jsx
+++ b/src/js/components/stock-movement-wizard/modals/AdjustInventoryModal.jsx
@@ -69,6 +69,19 @@ const FIELDS = {
   },
 };
 
+function validate(values) {
+  const errors = {};
+  errors.adjustInventory = [];
+
+  _.forEach(values.adjustInventory, (item, key) => {
+    if (item.quantityAdjusted < 0) {
+      errors.adjustInventory[key] = { quantityAdjusted: 'Adjusted quantity can\'t be negative' };
+    }
+  });
+  return errors;
+}
+
+
 /** Modal window where user can adjust existing inventory or add a new one. */
 class AdjustInventoryModal extends Component {
   constructor(props) {
@@ -166,6 +179,7 @@ class AdjustInventoryModal extends Component {
         onOpen={this.onOpen}
         onSave={this.onSave}
         fields={FIELDS}
+        validate={validate}
         initialValues={this.state.formValues}
         formProps={{
           bins: this.props.bins,

--- a/src/js/components/stock-movement-wizard/modals/EditPickModal.jsx
+++ b/src/js/components/stock-movement-wizard/modals/EditPickModal.jsx
@@ -62,6 +62,9 @@ function validate(values) {
     if (item.quantityPicked > item.quantityAvailable) {
       errors.availableItems[key] = { quantityPicked: 'Picked quantity is higher than available' };
     }
+    if (item.quantityPicked < 0) {
+      errors.availableItems[key] = { quantityPicked: 'Picked quantity can\'t be negative' };
+    }
   });
 
   const pickedSum = _.reduce(

--- a/src/js/components/stock-movement-wizard/modals/PackingSplitLineModal.jsx
+++ b/src/js/components/stock-movement-wizard/modals/PackingSplitLineModal.jsx
@@ -171,6 +171,9 @@ class PackingSplitLineModal extends Component {
       if (shippedQty !== splitItemsQty) {
         errors.splitLineItems[key] = { quantityShipped: 'Sum of all quantities must equal the original quantity' };
       }
+      if (item.quantityShipped < 0) {
+        errors.splitLineItems[key] = { quantityShipped: 'Shipped quantity can\'t be negative' };
+      }
     });
 
     return errors;

--- a/src/js/components/stock-movement-wizard/modals/SubstitutionsModal.jsx
+++ b/src/js/components/stock-movement-wizard/modals/SubstitutionsModal.jsx
@@ -70,6 +70,9 @@ function validate(values) {
     if (item.quantitySelected > item.quantityAvailable) {
       errors.substitutions[key] = { quantitySelected: 'Selected quantity is higher than available' };
     }
+    if (item.quantitySelected < 0) {
+      errors.substitutions[key] = { quantitySelected: 'Selected quantity can\'t be negative' };
+    }
   });
 
   if (!values.reasonCode) {


### PR DESCRIPTION
1. "autofill qtys" button on receipt page should not autofill a negative qty if shipped - received <0. Calculation should be max(0, shipped - received)
2. If a user has entered a negative quantity, a validation error should occur when they click next that does not let them move to the final page without changing the amount to a positive qty.