### PR TITLE
OBPIH-1408 Enable save button on edit page

### DIFF
--- a/src/js/components/stock-movement-wizard/EditPage.jsx
+++ b/src/js/components/stock-movement-wizard/EditPage.jsx
@@ -272,7 +272,8 @@ class EditItemsPage extends Component {
             revision => revision.requisitionItemId === item.requisitionItemId,
           );
           return _.isEmpty(oldRevision) ? true :
-            (oldRevision.quantityRevised !== item.quantityRevised);
+            ((oldRevision.quantityRevised !== item.quantityRevised) ||
+             (oldRevision.reasonCode !== item.reasonCode));
         }
         return false;
       },
@@ -437,7 +438,7 @@ class EditItemsPage extends Component {
         validate={validate}
         mutators={{ ...arrayMutators }}
         initialValues={this.state.values}
-        render={({ handleSubmit, values, invalid }) => (
+        render={({ handleSubmit, values }) => (
           <div className="d-flex flex-column">
             <span>
               <button
@@ -449,7 +450,6 @@ class EditItemsPage extends Component {
               </button>
               <button
                 type="button"
-                disabled={invalid}
                 onClick={() => this.save(values)}
                 className="float-right mb-1 btn btn-outline-secondary align-self-end btn-xs"
               >


### PR DESCRIPTION
Enable save button on edit page and change condition in order to save revised items even if reason code is not given. item.reasonCode is not necessary in this condition because this field is always disabled if there is no quantityRevised.