### PR TITLE
OBPIH-1886 Add pricing information to stock list details page

### DIFF
--- a/grails-app/domain/org/pih/warehouse/requisition/Requisition.groovy
+++ b/grails-app/domain/org/pih/warehouse/requisition/Requisition.groovy
@@ -119,7 +119,7 @@ class Requisition implements Comparable<Requisition>, Serializable {
 
     // Removed comments, documents, events for the time being.
     //static hasMany = [ requisitionItems: RequisitionItem, comments : Comment, documents : Document, events : Event ]
-    static transients = ["sortedStocklistItems", "requisitionItemsByDateCreated", "requisitionItemsByOrderIndex", "requisitionItemsByCategory", "shipment"]
+    static transients = ["sortedStocklistItems", "requisitionItemsByDateCreated", "requisitionItemsByOrderIndex", "requisitionItemsByCategory", "shipment", "totalCost"]
     static hasOne = [picklist: Picklist]
     static hasMany = [requisitionItems: RequisitionItem, transactions: Transaction, shipments: Shipment]
     static mapping = {
@@ -347,6 +347,16 @@ class Requisition implements Comparable<Requisition>, Serializable {
             shipment = shipments.iterator().next()
         }
         return shipment
+    }
+
+    /**
+     * Return total value of the issued shipment
+     *
+     * @return
+     */
+    BigDecimal getTotalCost() {
+        def itemsWithPrice = requisitionItems?.findAll { it.product.pricePerUnit }
+        return itemsWithPrice.collect { it?.quantity * it?.product?.pricePerUnit }.sum()?:0
     }
 
 

--- a/grails-app/domain/org/pih/warehouse/requisition/RequisitionItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/requisition/RequisitionItem.groovy
@@ -85,7 +85,7 @@ class RequisitionItem implements Comparable<RequisitionItem>, Serializable {
     User updatedBy
 
 
-    static transients = [ "type", "substitutionItems", "monthlyDemand"]
+    static transients = [ "type", "substitutionItems", "monthlyDemand", 'totalCost']
 
 	static belongsTo = [ requisition: Requisition ]
 	static hasMany = [ requisitionItems: RequisitionItem, picklistItems: PicklistItem ] // requisitionItems:RequisitionItem,
@@ -582,6 +582,9 @@ class RequisitionItem implements Comparable<RequisitionItem>, Serializable {
         return requisition?.replenishmentPeriod ? Math.ceil(((Double) quantity) / requisition.replenishmentPeriod * 30) : null
     }
 
+    BigDecimal getTotalCost() {
+        return product.pricePerUnit ? quantity * product?.pricePerUnit : null
+    }
 
     def next() {
         def requisitionItems = requisition.requisitionItems as List

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -1856,6 +1856,9 @@ requisitionTemplate.replenishmentPeriod.label=Replenishment period
 requisitionTemplate.replenishmentPeriodUnit.label=days
 requisitionTemplate.requestedBy.label=Managed by
 requisitionTemplate.noReplenishmentPeriod.message=No replenishment period
+requisitionTemplate.unitCost.label=Unit cost
+requisitionTemplate.totalCost.label=Total cost
+requisitionTemplate.totalValue.label=Total value
 
 # Requisition type messages
 requisitionType.label							= Type

--- a/grails-app/views/requisitionTemplate/_header.gsp
+++ b/grails-app/views/requisitionTemplate/_header.gsp
@@ -66,6 +66,21 @@
                     </g:else>
                 </td>
             </tr>
+            <g:hasRoleFinance>
+                <tr class="prop">
+                    <td class="name">
+                        <label>
+                            <warehouse:message code="requisitionTemplate.totalValue.label" />
+                        </label>
+                    </td>
+                    <td>
+                        <span>
+                            ${g.formatNumber(number: (requisition?.totalCost?:0), format: '###,###,##0.00##')}
+                            ${grailsApplication.config.openboxes.locale.defaultCurrencyCode}
+                        </span>
+                    </td>
+                </tr>
+            </g:hasRoleFinance>
             <tr class="prop">
                 <td class="name">
                     <label><warehouse:message code="requisition.sortByCode.label" /></label>

--- a/grails-app/views/requisitionTemplate/edit.gsp
+++ b/grails-app/views/requisitionTemplate/edit.gsp
@@ -54,6 +54,10 @@
                             <th class="center"><warehouse:message code="requisitionTemplate.maxQuantity.label"/></th>
                             <th class="center"><warehouse:message code="unitOfMeasure.label"/></th>
                             <th class="center"><warehouse:message code="requisitionTemplate.monthlyQuantity.label"/></th>
+                            <g:hasRoleFinance>
+                                <th class="center"><warehouse:message code="requisitionTemplate.unitCost.label"/></th>
+                                <th class="center"><warehouse:message code="requisitionTemplate.totalCost.label"/></th>
+                            </g:hasRoleFinance>
                             <g:isUserAdmin>
                                 <th><warehouse:message code="default.actions.label"/></th>
                             </g:isUserAdmin>
@@ -81,6 +85,10 @@
                                           from="['EA/1']"/>
                             </td>
                             <td></td>
+                            <g:hasRoleFinance>
+                                <td></td>
+                                <td></td>
+                            </g:hasRoleFinance>
                             <g:isUserAdmin>
                                 <td>
                                     <button class="button icon add" id="add-requisition-item">
@@ -141,6 +149,16 @@
                                             <g:message code="requisitionTemplate.noReplenishmentPeriod.message"/>
                                         </g:else>
                                     </td>
+                                    <g:hasRoleFinance>
+                                        <td class="center middle">
+                                             ${g.formatNumber(number: (requisitionItem?.product?.pricePerUnit?:0), format: '###,###,##0.00##')}
+                                             ${grailsApplication.config.openboxes.locale.defaultCurrencyCode}
+                                        </td>
+                                        <td class="center middle">
+                                            ${g.formatNumber(number: (requisitionItem?.totalCost?:0), format: '###,###,##0.00##')}
+                                            ${grailsApplication.config.openboxes.locale.defaultCurrencyCode}
+                                        </td>
+                                    </g:hasRoleFinance>
                                     <g:isUserAdmin>
                                         <td>
                                             <g:link controller="requisitionTemplate" action="removeFromRequisitionItems" id="${requisition?.id}"

--- a/src/groovy/org/pih/warehouse/api/StocklistItem.groovy
+++ b/src/groovy/org/pih/warehouse/api/StocklistItem.groovy
@@ -6,6 +6,7 @@ class StocklistItem {
 
     RequisitionItem requisitionItem
     Integer monthlyDemand
+    BigDecimal totalCost
 
     String stocklistId
     Integer maxQuantity
@@ -13,8 +14,9 @@ class StocklistItem {
     static StocklistItem createFromRequisitionItem(RequisitionItem requisitionItem) {
         Integer replenishmentPeriod = requisitionItem?.requisition?.replenishmentPeriod
         Integer monthlyDemand = replenishmentPeriod ? Math.ceil(((Double) requisitionItem.quantity) / replenishmentPeriod * 30) : null
+        BigDecimal totalCost = requisitionItem.product.pricePerUnit ? requisitionItem.quantity * requisitionItem.product.pricePerUnit : null
 
-        return new StocklistItem(requisitionItem: requisitionItem, monthlyDemand: monthlyDemand)
+        return new StocklistItem(requisitionItem: requisitionItem, monthlyDemand: monthlyDemand, totalCost: totalCost)
     }
 
     Map toJson() {


### PR DESCRIPTION
-Add column for unit cost and total cost per line on stock list details page
-Add place for total stock list value on left hand panel
-Include pricing in Excel export (unformatted version)
-Pricing is ignored for import
-Pricing is not visible on the page or on export if a user does not have financial user permissions.