### PR TITLE
Improve getCurrentInventory performance

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
@@ -290,7 +290,7 @@ class InventoryService implements ApplicationContextAware {
 		products = products?.sort() { map1, map2 -> map1.category <=> map2.category ?: map1.name <=> map2.name };
         log.info "Sort products " + (System.currentTimeMillis() - startTime) + " ms"
 
-		def inventoryLevelMap = InventoryLevel.findAllByInventory(commandInstance?.warehouseInstance?.inventory)?.groupBy { it.product }
+		def inventoryLevelMap = InventoryLevel.findAllByInventory(commandInstance?.warehouseInstance?.inventory)?.groupBy { it.productId }
         log.debug "Get inventory level map: " + (System.currentTimeMillis() - startTime) + " ms"
 		startTime = System.currentTimeMillis()
 
@@ -298,7 +298,7 @@ class InventoryService implements ApplicationContextAware {
 
 		products.each { product ->
 			def innerStartTime = System.currentTimeMillis()
-			def inventoryLevel = (inventoryLevelMap[product])?inventoryLevelMap[product][0]:null
+			def inventoryLevel = (inventoryLevelMap[product.id])?inventoryLevelMap[product.id][0]:null
 			if (inventoryLevel && inventoryLevel instanceof ArrayList) {
 				throw new Exception("Cannot have multiple inventory levels for a single product [" + product.productCode + ":" + product.name + "]: " + inventoryLevel)
 			}


### PR DESCRIPTION
It doesn't seem to be necessary to hydrate the entire product object when retrieving the inventory level map. Grouping by product id works just as well and it provides a significant speed up (up to 8x in our informal testing) in the Browse inventory page.