### PR TITLE
OBPIH-2150: Find or create new organization on location page

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/core/LocationController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/core/LocationController.groovy
@@ -81,8 +81,11 @@ class LocationController {
 
             locationInstance.properties = params
 
-            if (locationInstance.id == null && locationInstance.organization == null) {
-                locationInstance.organization = organizationService.findOrCreateOrganizationFromLocation(locationInstance)
+            if (!locationInstance.id && !locationInstance.organization) {
+                if (locationInstance?.locationType?.locationTypeCode == LocationTypeCode.SUPPLIER) {
+                    locationInstance.organization =
+                            organizationService.findOrCreateSupplierOrganization(locationInstance.name, locationInstance.locationNumber)
+                }
             }
 
             if (locationInstance.validate() && !locationInstance.hasErrors()) {

--- a/grails-app/controllers/org/pih/warehouse/core/LocationController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/core/LocationController.groovy
@@ -21,6 +21,7 @@ class LocationController {
     def inventoryService
     def locationService
     def dataService
+    def organizationService
 
     /**
      * Controllers for managing other locations (besides warehouses)
@@ -79,6 +80,10 @@ class LocationController {
             }
 
             locationInstance.properties = params
+
+            if (locationInstance.id == null && locationInstance.organization == null) {
+                locationInstance.organization = organizationService.findOrCreateOrganizationFromLocation(locationInstance)
+            }
 
             if (locationInstance.validate() && !locationInstance.hasErrors()) {
                 try {

--- a/grails-app/domain/org/pih/warehouse/core/Organization.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Organization.groovy
@@ -59,4 +59,9 @@ class Organization extends Party {
 
     }
 
+    Boolean hasRoleType(PartyRole partyRole) {
+        def partyRoles = [partyRole]
+        return roles.any { PartyRole role -> partyRoles.contains(role.roleType) }
+    }
+
 }

--- a/grails-app/domain/org/pih/warehouse/core/Organization.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Organization.groovy
@@ -59,9 +59,8 @@ class Organization extends Party {
 
     }
 
-    Boolean hasRoleType(PartyRole partyRole) {
-        def partyRoles = [partyRole]
-        return roles.any { PartyRole role -> partyRoles.contains(role.roleType) }
+    Boolean hasRoleType(RoleType roleType) {
+        return roles.any { PartyRole role -> role.roleType == roleType }
     }
 
 }

--- a/grails-app/services/org/pih/warehouse/core/OrganizationService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/OrganizationService.groovy
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2012 Partners In Health.  All rights reserved.
+ * The use and distribution terms for this software are covered by the
+ * Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+ * which can be found in the file epl-v10.html at the root of this distribution.
+ * By using this software in any fashion, you are agreeing to be bound by
+ * the terms of this license.
+ * You must not remove this notice, or any other, from this software.
+ **/
+package org.pih.warehouse.core
+
+import grails.validation.ValidationException
+
+class OrganizationService {
+
+    def grailsApplication
+    def identifierService
+    boolean transactional = true
+    
+    Organization findOrCreateOrganizationFromLocation(Location locationInstance) {
+        Organization organization = Organization.findByName(locationInstance.name)
+        PartyRole supplier = PartyRole.findByRoleType(RoleType.ROLE_SUPPLIER)
+        PartyRole manufacturer = PartyRole.findByRoleType(RoleType.ROLE_MANUFACTURER)
+
+        if (organization == null) {
+            organization = new Organization()
+        } else if (locationInstance.locationType.locationTypeCode == LocationTypeCode.SUPPLIER) {
+            if (!organization.hasRoleType(supplier)) {
+                organization.addToRoles(supplier)
+            }
+            if (!organization.hasRoleType(manufacturer)) {
+                organization.addToRoles(manufacturer)
+            }
+            return organization.save(flush: true)
+        } else {
+            return organization
+        }
+
+        organization.partyType = PartyType.findByName('Organization')
+        organization.name = locationInstance.name
+        organization.code = identifierService.generateOrganizationIdentifier(locationInstance.name)
+
+        if (locationInstance.locationType.locationTypeCode == LocationTypeCode.SUPPLIER) {
+            organization.addToRoles(supplier)
+            organization.addToRoles(manufacturer)
+        }
+
+        if (organization.validate() && !organization.hasErrors()) {
+            return organization.save(flush: true)
+        } else {
+            throw new ValidationException("Organization is not valid", organization.errors)
+        }
+    }
+
+}


### PR DESCRIPTION
@jmiranda I found weird behavior here, hence "needs help". Could you review the code and this issue: 
When I create a location with supplier type, the proper organization is created and it has proper roles (Supplier and Manufacturer). That's good but when I create the second location with a supplier type, then the new organization is created (this is good), the proper roles are assigned (this is good) but these roles are removed from the first organization (I think this is wrong). This will happen for every new organization that is created (only the newest has assigned roles). Am I missing something here? Is it expected or I forgot about something?

