### PR TITLE
OBPIH-3046 fix of the location not loading well

### DIFF
--- a/src/js/components/tablero/Tablero.jsx
+++ b/src/js/components/tablero/Tablero.jsx
@@ -131,13 +131,15 @@ class Tablero extends Component {
   }
 
   componentDidMount() {
-    this.fetchData();
+    if (this.props.currentLocation !== '') {
+      this.fetchData();
+    }
   }
 
   componentDidUpdate(prevProps) {
     const prevLocation = prevProps.currentLocation;
     const newLocation = this.props.currentLocation;
-    if (prevLocation !== '' && prevLocation !== newLocation) {
+    if (prevLocation !== newLocation) {
       this.fetchData();
     }
   }


### PR DESCRIPTION
In the end the problem was just that the componentDidUpdate was always checking if the last locationId was = ' ' and was never executed. I changed it to the componentDidAmount which shouldn't be executed if the currentLocation is = ' '