### PR TITLE
OBPIH-3259 Formatting Changes to Stock Movement Design

### DIFF
--- a/src/js/components/stock-movement-wizard/StockMovement.scss
+++ b/src/js/components/stock-movement-wizard/StockMovement.scss
@@ -141,16 +141,23 @@
 
         .add-button {
             position: absolute;
+            margin-top: 0;
             top: -40px;
+        }
+    }
 
-            button {
-                height: 32px;
-                background-color: #fff;
-                border: none;
-                box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.09);
-                color: #30a64a;
-                padding: 4px 8px;
-            }
+    .add-button {
+        display: flex;
+        align-items: center;
+        margin-top: 10px;
+
+        button {
+            height: 32px;
+            background-color: #fff;
+            border: none;
+            box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.09);
+            color: #30a64a;
+            padding: 4px 8px;
         }
     }
 
@@ -193,7 +200,7 @@
 
         .btn-xs {
             background-color: #eee;
-            color: grey;
+            color: #28a745;
             box-shadow: none !important;
         }
     }

--- a/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
@@ -62,6 +62,7 @@ const NO_STOCKLIST_FIELDS = {
     }) => (
       <button
         type="button"
+        id="addButton"
         className="btn btn-outline-success btn-xs"
         disabled={showOnly}
         onClick={() => {
@@ -118,6 +119,7 @@ const NO_STOCKLIST_FIELDS = {
         type: TextField,
         label: 'react.stockMovement.quantity.label',
         defaultMessage: 'Quantity',
+        headerAlign: 'left',
         flexWidth: '2.5',
         attributes: {
           type: 'number',
@@ -133,6 +135,7 @@ const NO_STOCKLIST_FIELDS = {
       recipient: {
         type: SelectField,
         label: 'react.stockMovement.recipient.label',
+        headerAlign: 'left',
         defaultMessage: 'Recipient',
         flexWidth: '2.5',
         fieldKey: '',
@@ -181,6 +184,7 @@ const STOCKLIST_FIELDS = {
     }) => (
       <button
         type="button"
+        id="addButton"
         className="btn btn-outline-success btn-xs"
         onClick={() => {
           updateTotalCount(1);
@@ -1086,6 +1090,16 @@ class AddItemsPage extends Component {
                   isFirstPageLoaded: this.state.isFirstPageLoaded,
                 }))}
               </div>
+              <div className="text-center add-button">
+                <button
+                  type="button"
+                  className="btn btn-outline-success btn-xs"
+                  disabled={showOnly}
+                  onClick={() => { document.getElementById('addButton').click(); }
+        }
+                ><span><i className="fa fa-plus pr-2" /><Translate id="react.default.button.addLine.label" defaultMessage="Add line" /></span>
+                </button>
+              </div>
               <div className="submit-buttons">
                 <button
                   type="submit"
@@ -1167,6 +1181,10 @@ AddItemsPage.propTypes = {
   /** Return true if pagination is enabled */
   isPaginated: PropTypes.bool.isRequired,
   /** Return true if show only */
-  showOnly: PropTypes.bool.isRequired,
+  showOnly: PropTypes.bool,
   pageSize: PropTypes.number.isRequired,
+};
+
+AddItemsPage.defaultProps = {
+  showOnly: false,
 };

--- a/src/js/components/stock-movement-wizard/outbound/EditPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/EditPage.jsx
@@ -67,7 +67,7 @@ const FIELDS = {
           formatValue: value => (
             <span className="d-flex">
               <span className="text-truncate">
-                {value.label || value.name}
+                {value.name || ''}
               </span>
               {renderHandlingIcons(value ? value.handlingIcons : null)}
             </span>
@@ -158,6 +158,7 @@ const FIELDS = {
         type: TextField,
         fieldKey: 'statusCode',
         flexWidth: '1',
+        headerAlign: 'left',
         attributes: {
           type: 'number',
         },

--- a/src/js/components/stock-movement-wizard/outbound/PackingPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/PackingPage.jsx
@@ -47,7 +47,7 @@ const FIELDS = {
         type: LabelField,
         label: 'react.stockMovement.productName.label',
         defaultMessage: 'Product Name',
-        flexWidth: '3',
+        flexWidth: '3.5',
         headerAlign: 'left',
         attributes: {
           className: 'text-left ml-1',
@@ -98,7 +98,8 @@ const FIELDS = {
         type: SelectField,
         label: 'react.stockMovement.recipient.label',
         defaultMessage: 'Recipient',
-        flexWidth: '2.5',
+        flexWidth: '2',
+        headerAlign: 'left',
         fieldKey: '',
         attributes: {
           async: true,

--- a/src/js/components/stock-movement-wizard/outbound/SendMovementPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/SendMovementPage.jsx
@@ -162,21 +162,25 @@ const FIELDS = {
         type: LabelField,
         label: 'react.stockMovement.packLevel1.label',
         defaultMessage: 'Pack level 1',
+        flexWidth: '3.5',
       },
       boxName: {
         type: LabelField,
         label: 'react.stockMovement.packLevel2.label',
         defaultMessage: 'Pack level 2',
+        flexWidth: '3.5',
       },
       productCode: {
         type: LabelField,
         label: 'react.stockMovement.code.label',
         defaultMessage: 'Code',
+        flexWidth: '3.5',
       },
       product: {
         type: LabelField,
         label: 'react.stockMovement.product.label',
         defaultMessage: 'Product',
+        flexWidth: '6',
         headerAlign: 'left',
         attributes: {
           className: 'text-left',
@@ -194,11 +198,13 @@ const FIELDS = {
         type: LabelField,
         label: 'react.stockMovement.lot.label',
         defaultMessage: 'Lot',
+        flexWidth: '3.5',
       },
       expirationDate: {
         type: LabelField,
         label: 'react.stockMovement.expiry.label',
         defaultMessage: 'Expiry',
+        flexWidth: '3.5',
       },
       quantityShipped: {
         type: LabelField,
@@ -209,6 +215,7 @@ const FIELDS = {
       binLocationName: {
         type: LabelField,
         label: 'react.stockMovement.binLocation.label',
+        flexWidth: '3.5',
         defaultMessage: 'Bin Location',
         getDynamicAttr: ({ hasBinLocationSupport }) => ({
           hide: !hasBinLocationSupport,
@@ -216,6 +223,7 @@ const FIELDS = {
       },
       'recipient.name': {
         type: LabelField,
+        flexWidth: '3.5',
         label: 'react.stockMovement.recipient.label',
         defaultMessage: 'Recipient',
       },

--- a/src/js/components/wizard/WizardSteps.scss
+++ b/src/js/components/wizard/WizardSteps.scss
@@ -45,6 +45,7 @@
                     position: absolute;
                     top: 30px;
                     font-size: small;
+                    font-weight: bold;
                 }
             }
         }


### PR DESCRIPTION
Header information should all show as text inputs, but should be tinted as read only if not editable. --> This part will be done in this ticket as it was the same part OBPIH-3260 : Stock movement design header and page fit changes