### PR TITLE
OBPIH-3259 Formatting Changes to Stock Movement Design

### DIFF
--- a/src/js/components/stock-movement-wizard/StockMovement.scss
+++ b/src/js/components/stock-movement-wizard/StockMovement.scss
@@ -155,6 +155,7 @@
             >div {
                 border-bottom: none !important;
                 height: inherit;
+                margin-right: 0 !important;
 
                 >div {
                     display: flex;
@@ -166,6 +167,7 @@
                         .text-truncate {
                             // Do not truncate text
                             white-space: pre-wrap !important;
+                            margin-right: 0 !important;
                         }
                     }
                 }

--- a/src/js/components/stock-movement-wizard/outbound/SendMovementPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/SendMovementPage.jsx
@@ -172,13 +172,13 @@ const FIELDS = {
         type: LabelField,
         label: 'react.stockMovement.packLevel1.label',
         defaultMessage: 'Pack level 1',
-        flexWidth: '3.5',
+        flexWidth: '3',
       },
       boxName: {
         type: LabelField,
         label: 'react.stockMovement.packLevel2.label',
         defaultMessage: 'Pack level 2',
-        flexWidth: '3.5',
+        flexWidth: '3',
       },
       productCode: {
         type: LabelField,
@@ -190,7 +190,7 @@ const FIELDS = {
         type: LabelField,
         label: 'react.stockMovement.product.label',
         defaultMessage: 'Product',
-        flexWidth: '6',
+        flexWidth: '7',
         attributes: {
           className: 'text-left',
           formatValue: value => (


### PR DESCRIPTION
- Reducing the size of pack1 et pack 2 to have more space for product name in the send.

- Bin location header centered in the send page.

- Pack level 1, pack level 2, split line align in the pack page