### PR TITLE
Improve getLocationsSupportingActivity performance

### DIFF
--- a/grails-app/services/org/pih/warehouse/core/LocationService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/LocationService.groovy
@@ -292,8 +292,17 @@ class LocationService {
     }
 
     List getLocationsSupportingActivity(ActivityCode activity) {
-        return getAllLocations()?.findAll { it.supports(activity) }
+        def locations = [:]
 
+        Location.executeQuery('select l from Location l join l.supportedActivities s where s = :activity', [ activity: activity.id ]).each {
+            locations[it.id] = it
+        }
+
+        Location.executeQuery('select l from Location l join l.locationType t join t.supportedActivities s where s = :activity', [ activity: activity.id ]).each {
+            locations[it.id] = it
+        }
+
+        return locations.values().toList()
     }
 
     List getShipmentOrigins() {


### PR DESCRIPTION
This method is a tad inefficient when you have many locations, since it needs to retrieve all the records from the database and hydrate them before filtering.

With the proposed changes the filtering is done on the database, which improves performance for this use case.

Anecdotal benchmark: On our instance with 150K locations it cut down the load time of the New Purchase Order page from 60+ seconds to 0.2 seconds.