### PR TITLE
OBPIH-4217 Update lodash to fix a critical security vulnerability.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11824,9 +11824,9 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash-es": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.11.tgz",
-      "integrity": "sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash._basefor": {
       "version": "3.0.3",


### PR DESCRIPTION
While looking into the log4j issue, I ran a few scanners that pointed out other security vulnerabilities. This and a few others (forthcoming) were straightforward remedies. I don't think this needs to go out in the next release, so I've targeted develop. Let me know if I should aim it elsewhere. Thanks!