### PR TITLE
OBPIH-4218 Fix logging includes.

### DIFF
--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -10,15 +10,19 @@
 
 import org.codehaus.groovy.grails.test.junit4.JUnit4GrailsTestType
 import org.codehaus.groovy.grails.test.support.GrailsTestMode
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+Logger log = LoggerFactory.getLogger("org.pih.warehouse._Events")
 
 /*loadtest setup*/
 def testTypeName = "loadtest"
 def testDirectory = "loadtest"
 def testMode = new GrailsTestMode(autowire: true, wrapInTransaction: true, wrapInRequestEnvironment: true)
 def loadtestTestType = new JUnit4GrailsTestType(testTypeName, testDirectory, testMode)
- 
+
 loadtestTests = [loadtestTestType]
- 
+
 loadtestTestPhasePreparation = {
        integrationTestPhasePreparation()
 }
@@ -69,7 +73,7 @@ eventWarStart = {
 	//ant.copy(todir:"${basedir}/target/classes", failonerror:true, overwrite:true) {
 	//	fileset(dir:"${basedir}/grails-app/migrations", includes:"**/*")
 	//}
-	
+
 }
 
 eventRunAppStart = {
@@ -113,7 +117,7 @@ eventCreateWarStart = { warName, stagingDir ->
 	def revisionNumber = determineGitRevisionNumber()
     def branchName = determineGitBranchName()
 	def buildNumber = System.getProperty("build.number", metadata.'app.buildNumber')
-	
+
 	log.info("Setting BUILD_NUMBER to " + buildNumber)
 
 

--- a/src/groovy/util/LiquibaseUtil.groovy
+++ b/src/groovy/util/LiquibaseUtil.groovy
@@ -13,12 +13,8 @@ import liquibase.DatabaseChangeLogLock
 import liquibase.database.DatabaseFactory
 import liquibase.lock.LockHandler
 import org.codehaus.groovy.grails.commons.ApplicationHolder
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 
 class LiquibaseUtil {
-
-    private static final transient Logger log = LoggerFactory.getLogger(LiquibaseUtil.class)
 
     static getDatabase() {
         def ctx = ApplicationHolder.getApplication().getMainContext()


### PR DESCRIPTION
Oops! The previous PR removed a log that was in use, and kept one that was a no-op.

Testing: I checked that this change restores the liquibase changelog files via `jar tf`, and verified that the resultant warfile launches successfully with Tomcat 7 on my machine.