### PR TITLE
OBPIH-4250 fix `from` email address on dev instance + OBS-1053 don't crash if smtp server is unavailable

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -72,12 +72,11 @@ grails.project.dependency.resolution = {
         // Required for barcode4j
         compile 'com.google.zxing:javase:2.0'
 
-        // Required by MailService (should replace with grails mail plugin)
-        compile 'org.apache.commons:commons-email:1.3'
-        compile 'org.apache.commons:commons-text:1.3'
+        compile "org.apache.commons:commons-email:1.5"
+        compile "org.apache.commons:commons-text:1.3"  // last Java 7-compatible release
         compile 'commons-lang:commons-lang:2.6'
         compile "org.jadira.usertype:usertype.jodatime:1.9"
-        compile 'org.apache.commons:commons-csv:1.6'
+        compile "org.apache.commons:commons-csv:1.6"  // last Java 7-compatible release
 
         // Required by LDAP
         compile "com.unboundid:unboundid-ldapsdk:2.3.6"
@@ -118,8 +117,11 @@ grails.project.dependency.resolution = {
         compile ("fr.opensagres.xdocreport:org.odftoolkit.odfdom.converter.pdf:1.0.6")
         compile "org.apache.xmlgraphics:batik-util:1.7"
 
-        // Fake SMTP server
-        test 'dumbster:dumbster:1.6'
+        /*
+         * This test SMTP client is the latest release that works with Grails 1,
+         * and Java 7, although it depends on a junit release we can't use (yet).
+         */
+        test("com.icegreen:greenmail:1.5.10") { excludes "junit" }
 
         // Required for GPars
         compile "org.codehaus.gpars:gpars:0.12"

--- a/grails-app/controllers/org/pih/warehouse/admin/AdminController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/admin/AdminController.groovy
@@ -105,24 +105,16 @@ class AdminController {
                 withForm {
                     MultipartFile multipartFile = request.getFile('file')
                     if (!multipartFile.empty) {
-                        byte[] bytes = multipartFile.bytes
-
-                        println multipartFile.contentType
-                        println multipartFile.originalFilename
-                        println multipartFile.name
-
-                        def emailMessageMap = [
-                                from          : session?.user?.email,
-                                to            : params.list("to"),
-                                cc            : [],
-                                bcc           : [],
-                                subject       : params["subject"],
-                                body          : params["message"],
-                                attachment    : multipartFile?.bytes,
-                                attachmentName: multipartFile?.originalFilename,
-                                mimeType      : multipartFile?.contentType
-                        ]
-                        mailService.sendHtmlMailWithAttachment(emailMessageMap)
+                        mailService.sendHtmlMailWithAttachment(
+                                session?.user,
+                                params.list("to"),
+                                null,
+                                params["subject"],
+                                params["message"],
+                                multipartFile?.bytes,
+                                multipartFile?.originalFilename,
+                                multipartFile?.contentType
+                        )
                         flash.message = "Multipart email with subject ${params.subject} and attachment ${multipartFile.originalFilename} has been sent to ${params.to}"
                     } else {
                         if (params.includesHtml) {

--- a/grails-app/controllers/org/pih/warehouse/admin/AdminController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/admin/AdminController.groovy
@@ -105,7 +105,7 @@ class AdminController {
                 withForm {
                     MultipartFile multipartFile = request.getFile('file')
                     if (!multipartFile.empty) {
-                        mailService.sendHtmlMailWithAttachment(
+                        def success = mailService.sendHtmlMailWithAttachment(
                                 session?.user,
                                 params.list("to"),
                                 null,
@@ -115,7 +115,12 @@ class AdminController {
                                 multipartFile?.originalFilename,
                                 multipartFile?.contentType
                         )
-                        flash.message = "Multipart email with subject ${params.subject} and attachment ${multipartFile.originalFilename} has been sent to ${params.to}"
+
+                        if (success) {
+                            flash.message = "Multipart email with subject ${params.subject} and attachment ${multipartFile.originalFilename} has been sent to ${params.to}"
+                        } else {
+                            flash.message = "Could not send email with subject ${params.subject} and attachment ${multipartFile.originalFilename} to ${params.to}"
+                        }
                     } else {
                         if (params.includesHtml) {
                             mailService.sendHtmlMail(params.subject, params.message, params.to)

--- a/grails-app/controllers/org/pih/warehouse/core/ErrorsController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/core/ErrorsController.groovy
@@ -114,26 +114,20 @@ class ErrorsController {
 
         if (enabled) {
             def recipients = grailsApplication.config.openboxes.mail.feedback.recipients
-
             def jsonObject = JSON.parse(params.data)
             byte[] attachment = jsonObject[1].replace("data:image/png;base64,", "").decodeBase64()
-
-            def emailMessage = [
-                    from          : session?.user?.email,
-                    to            : recipients,
-                    cc            : [],
-                    bcc           : [],
-                    subject       : jsonObject[0]["summary"],
-                    body          : jsonObject[0]["description"],
-                    attachment    : attachment,
-                    attachmentName: "screenshot.png",
-                    mimeType      : "image/png"
-
-            ]
-            mailService.sendHtmlMailWithAttachment(emailMessage)
+            mailService.sendHtmlMailWithAttachment(
+                    session?.user,
+                    recipients,
+                    null,
+                    jsonObject[0]["summary"],
+                    jsonObject[0]["description"],
+                    attachment,
+                    "screenshot.png",
+                    "image/png"
+            )
         }
         render "OK"
-
     }
 
 

--- a/grails-app/migrations/install/baseline.sql
+++ b/grails-app/migrations/install/baseline.sql
@@ -1012,7 +1012,7 @@ CREATE TABLE `person` (
 
 LOCK TABLES `person` WRITE;
 /*!40000 ALTER TABLE `person` DISABLE KEYS */;
-INSERT INTO `person` VALUES ('1',1,'2010-08-25 00:00:00','admin@pih.org','Miss','Administrator','2010-08-25 00:00:00',NULL),('2',5,'2010-08-25 00:00:00','manager@pih.org','Mister','Manager','2010-08-25 00:00:00',NULL),('3',1,'2010-08-25 00:00:00','jmiranda@pih.org','Justin','Miranda','2010-08-25 00:00:00',NULL),('4',1,'2010-08-25 00:00:00','inactive@pih.org','In','Active','2010-08-25 00:00:00',NULL);
+INSERT INTO `person` VALUES ('1',1,'2010-08-25 00:00:00','openboxes@pih.org','Miss','Administrator','2010-08-25 00:00:00',NULL),('2',5,'2010-08-25 00:00:00','openboxes@pih.org','Mister','Manager','2010-08-25 00:00:00',NULL),('3',1,'2010-08-25 00:00:00','openboxes@pih.org','Justin','Miranda','2010-08-25 00:00:00',NULL),('4',1,'2010-08-25 00:00:00','openboxes@pih.org','In','Active','2010-08-25 00:00:00',NULL);
 /*!40000 ALTER TABLE `person` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/grails-app/services/org/pih/warehouse/core/MailService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/MailService.groovy
@@ -57,67 +57,67 @@ class MailService {
         return grailsApplication.config.grails.mail.enabled.toBoolean()
     }
 
-    void sendMail(String subject, String msg, String to) {
-        sendMailImpl(subject, msg, null, null, Collections.singleton(to), null, null, null, false, false)
+    Boolean sendMail(String subject, String msg, String to) {
+        return sendMailImpl(subject, msg, null, null, Collections.singleton(to), null, null, null, false, false)
     }
 
-    void sendMail(String subject, String msg, Collection to, Integer port) {
-        sendMailImpl(subject, msg, null, null, to, null, null, port, false, false)
+    Boolean sendMail(String subject, String msg, Collection to, Integer port) {
+        return sendMailImpl(subject, msg, null, null, to, null, null, port, false, false)
     }
 
-    void sendHtmlMail(String subject, String htmlMessage, String[] to) {
-        sendMailImpl(subject, body, null, null, to.toList(), null, null, null, true, false)
+    Boolean sendHtmlMail(String subject, String htmlMessage, String[] to) {
+        return sendMailImpl(subject, body, null, null, to.toList(), null, null, null, true, false)
     }
 
-    void sendHtmlMail(String subject, String htmlMessage, String to) {
-        sendMailImpl(subject, htmlMessage, null, null, Collections.singleton(to), null, null, null, true, false)
+    Boolean sendHtmlMail(String subject, String htmlMessage, String to) {
+        return sendMailImpl(subject, htmlMessage, null, null, Collections.singleton(to), null, null, null, true, false)
     }
 
-    void sendHtmlMail(String subject, String htmlMessage, String to, Integer port) {
-        sendMailImpl(subject, htmlMessage, null, null, Collections.singleton(to), null, null, port, true, false)
+    Boolean sendHtmlMail(String subject, String htmlMessage, String to, Integer port) {
+        return sendMailImpl(subject, htmlMessage, null, null, Collections.singleton(to), null, null, port, true, false)
     }
 
-    void sendHtmlMail(String subject, String htmlMessage, String to, Integer port, Boolean override) {
-        sendMailImpl(subject, htmlMessage, null, null, Collections.singleton(to), null, null, port, true, override)
+    Boolean sendHtmlMail(String subject, String htmlMessage, String to, Integer port, Boolean override) {
+        return sendMailImpl(subject, htmlMessage, null, null, Collections.singleton(to), null, null, port, true, override)
     }
 
-    void sendHtmlMail(String subject, String body, Collection to) {
-        sendMailImpl(subject, body, null, null, to, null, null, null, true, false)
+    Boolean sendHtmlMail(String subject, String body, Collection to) {
+        return sendMailImpl(subject, body, null, null, to, null, null, null, true, false)
     }
 
-    void sendHtmlMail(String subject, String body, Collection to, Integer port, Boolean override) {
-        sendMailImpl(subject, body, null, null, to, null, null, port, true, override)
+    Boolean sendHtmlMail(String subject, String body, Collection to, Integer port, Boolean override) {
+        return sendMailImpl(subject, body, null, null, to, null, null, port, true, override)
     }
 
-    def sendHtmlMailWithAttachment(String to, String subject, String body, byte[] bytes, String name, String mimeType) {
-        sendMailImpl(subject, body, null, null, Collections.singleton(to), ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
+    Boolean sendHtmlMailWithAttachment(String to, String subject, String body, byte[] bytes, String name, String mimeType) {
+        return sendMailImpl(subject, body, null, null, Collections.singleton(to), ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
     }
 
     /**
      * This particular flavor sends an email to the user, from the user, and may not work with sendgrid.
      */
-    def sendHtmlMailWithAttachment(User userInstance, String subject, String body, byte[] bytes, String name, String mimeType) {
-        sendMailImpl(subject, body, userInstance?.email, null, Collections.singleton(userInstance?.email), null, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
+    Boolean sendHtmlMailWithAttachment(User userInstance, String subject, String body, byte[] bytes, String name, String mimeType) {
+        return sendMailImpl(subject, body, userInstance?.email, null, Collections.singleton(userInstance?.email), null, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
     }
 
-    def sendHtmlMailWithAttachment(Collection toList, String subject, String body, List<Attachment> attachments) {
-        sendMailImpl(subject, body, null, null, toList, null, attachments, null, true, false)
+    Boolean sendHtmlMailWithAttachment(Collection toList, String subject, String body, List<Attachment> attachments) {
+        return sendMailImpl(subject, body, null, null, toList, null, attachments, null, true, false)
     }
 
-    def sendHtmlMailWithAttachment(Collection toList, Collection ccList, String subject, String body, byte[] bytes, String name, String mimeType) {
-        sendMailImpl(subject, body, null, null, toList, ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
+    Boolean sendHtmlMailWithAttachment(Collection toList, Collection ccList, String subject, String body, byte[] bytes, String name, String mimeType) {
+        return sendMailImpl(subject, body, null, null, toList, ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
     }
 
-    def sendHtmlMailWithAttachment(User fromUser, Collection toList, Collection ccList, String subject, String body, byte[] bytes, String name, String mimeType) {
-        sendMailImpl(subject, body, fromUser?.email, fromUser?.name, toList, ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
+    Boolean sendHtmlMailWithAttachment(User fromUser, Collection toList, Collection ccList, String subject, String body, byte[] bytes, String name, String mimeType) {
+        return sendMailImpl(subject, body, fromUser?.email, fromUser?.name, toList, ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
     }
 
-    def sendHtmlMailWithAttachment(User fromUser, Collection toList, Collection ccList, String subject, String body, byte[] bytes, String name, String mimeType, Integer port) {
-        sendMailImpl(subject, body, fromUser?.email, fromUser?.name, toList, ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), port, true, false)
+    Boolean sendHtmlMailWithAttachment(User fromUser, Collection toList, Collection ccList, String subject, String body, byte[] bytes, String name, String mimeType, Integer port) {
+        return sendMailImpl(subject, body, fromUser?.email, fromUser?.name, toList, ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), port, true, false)
     }
 
-    def sendHtmlMailWithAttachment(User fromUser, Collection toList, Collection ccList, String subject, String body, List<Attachment> attachments, Integer port) {
-        sendMailImpl(subject, body, fromUser?.email, fromUser?.name, toList, ccList, attachments, port, true, false)
+    Boolean sendHtmlMailWithAttachment(User fromUser, Collection toList, Collection ccList, String subject, String body, List<Attachment> attachments, Integer port) {
+        return sendMailImpl(subject, body, fromUser?.email, fromUser?.name, toList, ccList, attachments, port, true, false)
     }
 
     /**
@@ -133,8 +133,9 @@ class MailService {
      * @param port
      * @param useHtml
      * @param override
+     * @return true if an email was sent, false otherwise.
      */
-    void sendMailImpl(
+    Boolean sendMailImpl(
             String subject,
             String body,
             String from,
@@ -146,23 +147,25 @@ class MailService {
             boolean useHtml,
             boolean override) {
 
+        Email email
         def summary = "email with subject '${subject}' to ${to} from ${from ?: defaultFrom} via ${defaultHost}:${port ?: defaultPort}"
 
         if (!isMailEnabled && !override) {
             log.info "email disabled: not sending ${summary}"
-            return
+            return false
         }
 
-        log.info "sending ${summmary}"
-
         try {
-            Email email
             if (useHtml) {
                 HtmlEmail htmlEmail = new HtmlEmail()
                 htmlEmail.setHtmlMsg(body)
                 attachments.each {
-                    htmlEmail.attach(new ByteArrayDataSource(it.bytes, it.mimeType),
-                            it.name, it.name, EmailAttachment.ATTACHMENT)
+                    if (it.bytes && it.mimeType && it.name) {
+                        htmlEmail.attach(new ByteArrayDataSource(it.bytes, it.mimeType),
+                                it.name, it.name, EmailAttachment.ATTACHMENT)
+                    } else {
+                        log.warn "skipping incompletely-declared attachment"
+                    }
                 }
                 email = htmlEmail
             } else {
@@ -188,11 +191,19 @@ class MailService {
             if (startTlsEnabled) {
                 email.setStartTLSEnabled(startTlsEnabled)
             }
-
-            email.send()
         } catch (Exception e) {
-            log.error("Error sending ${summary}", e)
-            throw e
+            log.error("could not create ${summary}", e)
+            return false
         }
+
+        try {
+            log.info "sending ${summary}"
+            email.send()
+            return true
+        } catch (Exception e) {
+            log.error("could not send ${summary}", e)
+            return false
+        }
+        return false
     }
 }

--- a/grails-app/services/org/pih/warehouse/core/MailService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/MailService.groovy
@@ -9,12 +9,12 @@
  **/
 package org.pih.warehouse.core
 
-import org.apache.commons.mail.ByteArrayDataSource
+import org.apache.commons.mail.Email
 import org.apache.commons.mail.EmailAttachment
 import org.apache.commons.mail.HtmlEmail
 import org.apache.commons.mail.SimpleEmail
 
-import javax.mail.internet.InternetAddress
+import javax.mail.util.ByteArrayDataSource
 
 class MailService {
 
@@ -30,7 +30,7 @@ class MailService {
     }
 
     Integer getDefaultPort() {
-        Integer.valueOf(grailsApplication.config.grails.mail.port)
+        return Integer.valueOf(grailsApplication.config.grails.mail.port)
     }
 
     String getUsername() {
@@ -53,353 +53,146 @@ class MailService {
         return grailsApplication.config.grails.mail.props["mail.smtp.starttls.enable"]
     }
 
-    /**
-     * @return
-     */
-    def getIsMailEnabled() {
-        Boolean mailEnabled = grailsApplication.config.grails.mail.enabled.toBoolean()
-        log.info(mailEnabled ? "Mail is enabled" : "Mail is disabled")
-        return mailEnabled
+    Boolean getIsMailEnabled() {
+        return grailsApplication.config.grails.mail.enabled.toBoolean()
     }
 
-    /**
-     * @param subject
-     * @param msg
-     * @param to
-     * @return
-     */
-    def sendMail(String subject, String msg, String to) {
-        sendMail(subject, msg, [to], null)
+    void sendMail(String subject, String msg, String to) {
+        sendMailImpl(subject, msg, null, null, Collections.singleton(to), null, null, null, false, false)
     }
 
-    /**
-     * @param subject
-     * @param msg
-     * @param to
-     * @return
-     */
-    def sendMail(String subject, String msg, Collection to, Integer port) {
-        if (isMailEnabled) {
-            log.info "Sending text email '" + subject + "' to " + to
-            try {
-                //SimpleEmail is the class which will do all the hard work for you
-                SimpleEmail email = new SimpleEmail()
-                email.setCharset("UTF-8")
-                email.setHostName(defaultHost)
-
-                // override port
-                email.setSmtpPort(port ?: defaultPort)
-
-                to.each {
-                    email.addTo(it)
-                }
-
-                email.setFrom(defaultFrom)
-                email.setSubject("${prefix} " + subject)
-                email.setMsg(msg)
-
-                if (debug) {
-                    email.setDebug(debug)
-
-                }
-                // Authenticate
-                if (username && password) {
-                    email.setAuthentication(username, password)
-                }
-
-                if (startTlsEnabled) {
-                    email.setStartTLSEnabled(startTlsEnabled)
-                }
-
-                email.send()
-            } catch (Exception e) {
-                log.error("Error sending plaintext email message with subject " + subject + " to " + to, e)
-                throw e
-            }
-        }
+    void sendMail(String subject, String msg, Collection to, Integer port) {
+        sendMailImpl(subject, msg, null, null, to, null, null, port, false, false)
     }
 
-
-    /**
-     * Send html email
-     *
-     * @param subject
-     * @param htmlMessage
-     * @param to
-     * @return
-     */
-    def sendHtmlMail(String subject, String htmlMessage, String[] to) {
-        log.debug "Sending email to array " + to
-        sendHtmlMail(subject, htmlMessage, to, null)
-
+    void sendHtmlMail(String subject, String htmlMessage, String[] to) {
+        sendMailImpl(subject, body, null, null, to.toList(), null, null, null, true, false)
     }
 
-
-    /**
-     *
-     * @param subject
-     * @param htmlMessage
-     * @param to
-     * @return
-     */
-    def sendHtmlMail(String subject, String htmlMessage, String to) {
-        sendHtmlMail(subject, htmlMessage, [to], null, false)
+    void sendHtmlMail(String subject, String htmlMessage, String to) {
+        sendMailImpl(subject, htmlMessage, null, null, Collections.singleton(to), null, null, null, true, false)
     }
 
-    def sendHtmlMail(String subject, String htmlMessage, String to, Integer port) {
-        sendHtmlMail(subject, htmlMessage, [to], port, false)
+    void sendHtmlMail(String subject, String htmlMessage, String to, Integer port) {
+        sendMailImpl(subject, htmlMessage, null, null, Collections.singleton(to), null, null, port, true, false)
     }
 
-    def sendHtmlMail(String subject, String htmlMessage, String to, Integer port, Boolean override) {
-        sendHtmlMail(subject, htmlMessage, [to], port, override)
+    void sendHtmlMail(String subject, String htmlMessage, String to, Integer port, Boolean override) {
+        sendMailImpl(subject, htmlMessage, null, null, Collections.singleton(to), null, null, port, true, override)
     }
 
-
-    def sendHtmlMail(String subject, String body, Collection to) {
-        sendHtmlMail(subject, body, to, null, false)
+    void sendHtmlMail(String subject, String body, Collection to) {
+        sendMailImpl(subject, body, null, null, to, null, null, null, true, false)
     }
 
-    /**
-     * @param subject
-     * @param body
-     * @param to
-     * @return
-     */
-    def sendHtmlMail(String subject, String body, Collection to, Integer port, Boolean override) {
-        log.info "Sending email with subject ${subject} to ${to} from ${getDefaultFrom()} via ${defaultHost}:${port?:defaultPort}"
-        if (isMailEnabled || override) {
-            log.info "Sending html email '" + subject + "' to " + to
-            try {
-                // Create the email message
-                HtmlEmail email = new HtmlEmail()
-                email.setCharset("UTF-8")
-                email.setHostName(defaultHost)
-                to.each {
-                    email.addTo(it)
-                }
-
-                email.setFrom(defaultFrom)
-                email.setSmtpPort(port ?: defaultPort)
-                email.setSubject("${prefix} " + subject)
-                email.setHtmlMsg(body)
-                email.setTextMsg(subject)
-
-                // Authenticate
-                if (username && password) {
-                    email.setAuthentication(username, password)
-                }
-
-                if (startTlsEnabled) {
-                    email.setStartTLSEnabled(startTlsEnabled)
-                }
-
-                email.send()
-            } catch (Exception e) {
-                log.error("Error sending HTML email message with subject " + subject + " to " + to, e)
-                throw e
-            }
-        }
+    void sendHtmlMail(String subject, String body, Collection to, Integer port, Boolean override) {
+        sendMailImpl(subject, body, null, null, to, null, null, port, true, override)
     }
 
-
-    /**
-     *
-     * @param to
-     * @param subject
-     * @param body
-     * @param bytes
-     * @param name
-     * @param mimeType
-     * @return
-     */
     def sendHtmlMailWithAttachment(String to, String subject, String body, byte[] bytes, String name, String mimeType) {
-        def toList = new ArrayList()
-        toList.add(to)
-        sendHtmlMailWithAttachment(null, toList, subject, body, bytes, name, mimeType, null)
+        sendMailImpl(subject, body, null, null, Collections.singleton(to), ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
     }
 
     /**
-     *
-     * @param userInstance
-     * @param subject
-     * @param body
-     * @param bytes
-     * @param name
-     * @param mimeType
-     * @return
+     * This particular flavor sends an email to the user, from the user, and may not work with sendgrid.
      */
     def sendHtmlMailWithAttachment(User userInstance, String subject, String body, byte[] bytes, String name, String mimeType) {
-        sendHtmlMailWithAttachment(userInstance, userInstance?.email, subject, body, bytes, name, mimeType, null)
+        sendMailImpl(subject, body, userInstance?.email, null, Collections.singleton(userInstance?.email), null, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
     }
 
-    /**
-     *
-     * @param toList
-     * @param subject
-     * @param body
-     * @param attachments
-     * @return
-     */
     def sendHtmlMailWithAttachment(Collection toList, String subject, String body, List<Attachment> attachments) {
-        sendHtmlMailWithAttachment(null, toList, [], subject, body, attachments, null)
+        sendMailImpl(subject, body, null, null, toList, null, attachments, null, true, false)
     }
 
-    /**
-     *
-     * @param toList
-     * @param ccList
-     * @param subject
-     * @param body
-     * @param bytes
-     * @param name
-     * @param mimeType
-     * @return
-     */
     def sendHtmlMailWithAttachment(Collection toList, Collection ccList, String subject, String body, byte[] bytes, String name, String mimeType) {
-        sendHtmlMailWithAttachment(null, toList, ccList, subject, body, bytes, name, mimeType, null)
+        sendMailImpl(subject, body, null, null, toList, ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
     }
 
-    /**
-     *
-     * @param toList
-     * @param ccList
-     * @param subject
-     * @param body
-     * @param bytes
-     * @param name
-     * @param mimeType
-     * @return
-     */
     def sendHtmlMailWithAttachment(User fromUser, Collection toList, Collection ccList, String subject, String body, byte[] bytes, String name, String mimeType) {
-        sendHtmlMailWithAttachment(fromUser, toList, ccList, subject, body, bytes, name, mimeType, null)
+        sendMailImpl(subject, body, fromUser?.email, fromUser?.name, toList, ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
     }
 
-    /**
-     *
-     * @param fromUser
-     * @param toList
-     * @param ccList
-     * @param subject
-     * @param body
-     * @param bytes
-     * @param name
-     * @param mimeType
-     * @params port* @return
-     */
     def sendHtmlMailWithAttachment(User fromUser, Collection toList, Collection ccList, String subject, String body, byte[] bytes, String name, String mimeType, Integer port) {
-        List<Attachment> attachments = []
-        Attachment attachment = new Attachment(name: name, mimeType: mimeType, bytes: bytes)
-        attachments.add(attachment)
-        sendHtmlMailWithAttachment(fromUser, toList, ccList, subject, body, attachments, port)
+        sendMailImpl(subject, body, fromUser?.email, fromUser?.name, toList, ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), port, true, false)
+    }
+
+    def sendHtmlMailWithAttachment(User fromUser, Collection toList, Collection ccList, String subject, String body, List<Attachment> attachments, Integer port) {
+        sendMailImpl(subject, body, fromUser?.email, fromUser?.name, toList, ccList, attachments, port, true, false)
     }
 
     /**
+     * Send an email.
      *
-     * @param toList
-     * @param ccList
      * @param subject
      * @param body
+     * @param from
+     * @param fromName
+     * @param to
+     * @param cc
      * @param attachments
      * @param port
-     * @return
+     * @param useHtml
+     * @param override
      */
-    def sendHtmlMailWithAttachment(User fromUser, Collection toList, Collection ccList, String subject, String body, List<Attachment> attachments, Integer port) {
-        log.info("Sending email with attachment " + toList)
-        if (isMailEnabled) {
-            try {
-                // Create the email message
-                HtmlEmail email = new HtmlEmail()
-                email.setCharset("UTF-8")
-                email.setHostName(defaultHost)
+    void sendMailImpl(
+            String subject,
+            String body,
+            String from,
+            String fromName,
+            Collection<String> to,
+            Collection<String> cc,
+            Collection<Attachment> attachments,
+            Integer port,
+            boolean useHtml,
+            boolean override) {
 
-                // Override smtp port
-                email.setSmtpPort(port ?: defaultPort)
+        def summary = "email with subject '${subject}' to ${to} from ${from ?: defaultFrom} via ${defaultHost}:${port ?: defaultPort}"
 
-                email.setFrom(defaultFrom)
-                toList.each { to -> email.addTo(to) }
-                if (ccList) {
-                    ccList.each { cc -> email.addCc(cc) }
-                }
+        if (!isMailEnabled && !override) {
+            log.info "email disabled: not sending ${summary}"
+            return
+        }
 
-                email.setSubject("${prefix} " + subject)
-                email.setHtmlMsg(body)
+        log.info "sending ${summmary}"
 
-                // Override from user
-                if (fromUser) {
-                    email.setFrom(fromUser.email, fromUser.name)
-                }
-
-                // Authenticate
-                if (username && password) {
-                    email.setAuthentication(username, password)
-                }
-
-                // add the attachment
+        try {
+            Email email
+            if (useHtml) {
+                HtmlEmail htmlEmail = new HtmlEmail()
+                htmlEmail.setHtmlMsg(body)
                 attachments.each {
-                    email.attach(new ByteArrayDataSource(it.bytes, it.mimeType),
+                    htmlEmail.attach(new ByteArrayDataSource(it.bytes, it.mimeType),
                             it.name, it.name, EmailAttachment.ATTACHMENT)
                 }
-
-                if (startTlsEnabled) {
-                    email.setStartTLSEnabled(startTlsEnabled)
-                }
-
-                // send the email
-                email.send()
-            } catch (Exception e) {
-                log.error "Problem sending email $e.message", e
+                email = htmlEmail
+            } else {
+                email = new SimpleEmail()
+                email.setMsg(body)
             }
-        }
-    }
 
-    /**
-     *
-     * @param toList
-     * @param ccList
-     * @param subject
-     * @param body
-     * @param bytes
-     * @param name
-     * @param mimeType
-     * @return
-     */
-    def sendHtmlMailWithAttachment(message) {
-        log.info("Sending email with attachment " + message.to)
-
-        if (isMailEnabled) {
-            try {
-                // Create the email message
-                HtmlEmail email = new HtmlEmail()
-                email.setCharset("UTF-8")
-                email.setHostName(message.host ?: defaultHost)
-                email.setSmtpPort(message.port ?: defaultPort)
-
-                // Set from, to, cc, subject, and body
-                email.setFrom(message.from ?: defaultFrom)
-                email.setSubject("${prefix} ${message.subject}")
-                email.setHtmlMsg(message.body)
-                email.setTo(message.to.collect { new InternetAddress(it) })
-                if (message.cc) email.setCc(message.cc.collect { new InternetAddress(it) })
-                if (message.bcc) email.setBcc(message.bcc.collect { new InternetAddress(it) })
-
-                // Authenticate
-                if (username && password) {
-                    email.setAuthentication(username, password)
-                }
-
-                if (startTlsEnabled) {
-                    email.setStartTLSEnabled(startTlsEnabled)
-                }
-
-                // add the attachment
-                email.attach(new ByteArrayDataSource(message.attachment, message.mimeType),
-                        message.attachmentName, message.attachmentName, EmailAttachment.ATTACHMENT)
-
-                // send the email
-                email.send()
-            } catch (Exception e) {
-                log.error "Problem sending email $e.message", e
+            email.setCharset("UTF-8")
+            email.setFrom(from ?: defaultFrom, fromName)
+            email.setHostName(defaultHost)
+            email.setSmtpPort(port ?: defaultPort)
+            email.setSubject("${prefix} ${subject}")
+            to.each {
+                email.addTo(it)
             }
+
+            if (debug) {
+                email.setDebug(debug)
+            }
+            if (username && password) {
+                email.setAuthentication(username, password)
+            }
+            if (startTlsEnabled) {
+                email.setStartTLSEnabled(startTlsEnabled)
+            }
+
+            email.send()
+        } catch (Exception e) {
+            log.error("Error sending ${summary}", e)
+            throw e
         }
     }
 }

--- a/grails-app/services/org/pih/warehouse/core/MailService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/MailService.groovy
@@ -58,66 +58,66 @@ class MailService {
     }
 
     Boolean sendMail(String subject, String msg, String to) {
-        return sendMailImpl(subject, msg, null, null, Collections.singleton(to), null, null, null, false, false)
+        return doSendMail(subject, msg, null, null, Collections.singleton(to), null, null, null, false, false)
     }
 
     Boolean sendMail(String subject, String msg, Collection to, Integer port) {
-        return sendMailImpl(subject, msg, null, null, to, null, null, port, false, false)
+        return doSendMail(subject, msg, null, null, to, null, null, port, false, false)
     }
 
     Boolean sendHtmlMail(String subject, String htmlMessage, String[] to) {
-        return sendMailImpl(subject, body, null, null, to.toList(), null, null, null, true, false)
+        return doSendMail(subject, body, null, null, to.toList(), null, null, null, true, false)
     }
 
     Boolean sendHtmlMail(String subject, String htmlMessage, String to) {
-        return sendMailImpl(subject, htmlMessage, null, null, Collections.singleton(to), null, null, null, true, false)
+        return doSendMail(subject, htmlMessage, null, null, Collections.singleton(to), null, null, null, true, false)
     }
 
     Boolean sendHtmlMail(String subject, String htmlMessage, String to, Integer port) {
-        return sendMailImpl(subject, htmlMessage, null, null, Collections.singleton(to), null, null, port, true, false)
+        return doSendMail(subject, htmlMessage, null, null, Collections.singleton(to), null, null, port, true, false)
     }
 
     Boolean sendHtmlMail(String subject, String htmlMessage, String to, Integer port, Boolean override) {
-        return sendMailImpl(subject, htmlMessage, null, null, Collections.singleton(to), null, null, port, true, override)
+        return doSendMail(subject, htmlMessage, null, null, Collections.singleton(to), null, null, port, true, override)
     }
 
     Boolean sendHtmlMail(String subject, String body, Collection to) {
-        return sendMailImpl(subject, body, null, null, to, null, null, null, true, false)
+        return doSendMail(subject, body, null, null, to, null, null, null, true, false)
     }
 
     Boolean sendHtmlMail(String subject, String body, Collection to, Integer port, Boolean override) {
-        return sendMailImpl(subject, body, null, null, to, null, null, port, true, override)
+        return doSendMail(subject, body, null, null, to, null, null, port, true, override)
     }
 
     Boolean sendHtmlMailWithAttachment(String to, String subject, String body, byte[] bytes, String name, String mimeType) {
-        return sendMailImpl(subject, body, null, null, Collections.singleton(to), ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
+        return doSendMail(subject, body, null, null, Collections.singleton(to), ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
     }
 
     /**
      * This particular flavor sends an email to the user, from the user, and may not work with sendgrid.
      */
     Boolean sendHtmlMailWithAttachment(User userInstance, String subject, String body, byte[] bytes, String name, String mimeType) {
-        return sendMailImpl(subject, body, userInstance?.email, null, Collections.singleton(userInstance?.email), null, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
+        return doSendMail(subject, body, userInstance?.email, null, Collections.singleton(userInstance?.email), null, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
     }
 
     Boolean sendHtmlMailWithAttachment(Collection toList, String subject, String body, List<Attachment> attachments) {
-        return sendMailImpl(subject, body, null, null, toList, null, attachments, null, true, false)
+        return doSendMail(subject, body, null, null, toList, null, attachments, null, true, false)
     }
 
     Boolean sendHtmlMailWithAttachment(Collection toList, Collection ccList, String subject, String body, byte[] bytes, String name, String mimeType) {
-        return sendMailImpl(subject, body, null, null, toList, ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
+        return doSendMail(subject, body, null, null, toList, ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
     }
 
     Boolean sendHtmlMailWithAttachment(User fromUser, Collection toList, Collection ccList, String subject, String body, byte[] bytes, String name, String mimeType) {
-        return sendMailImpl(subject, body, fromUser?.email, fromUser?.name, toList, ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
+        return doSendMail(subject, body, fromUser?.email, fromUser?.name, toList, ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), null, true, false)
     }
 
     Boolean sendHtmlMailWithAttachment(User fromUser, Collection toList, Collection ccList, String subject, String body, byte[] bytes, String name, String mimeType, Integer port) {
-        return sendMailImpl(subject, body, fromUser?.email, fromUser?.name, toList, ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), port, true, false)
+        return doSendMail(subject, body, fromUser?.email, fromUser?.name, toList, ccList, Collections.singleton(new Attachment(name: name, mimeType: mimeType, bytes: bytes)), port, true, false)
     }
 
     Boolean sendHtmlMailWithAttachment(User fromUser, Collection toList, Collection ccList, String subject, String body, List<Attachment> attachments, Integer port) {
-        return sendMailImpl(subject, body, fromUser?.email, fromUser?.name, toList, ccList, attachments, port, true, false)
+        return doSendMail(subject, body, fromUser?.email, fromUser?.name, toList, ccList, attachments, port, true, false)
     }
 
     /**
@@ -135,17 +135,17 @@ class MailService {
      * @param override
      * @return true if an email was sent, false otherwise.
      */
-    Boolean sendMailImpl(
-            String subject,
-            String body,
-            String from,
-            String fromName,
-            Collection<String> to,
-            Collection<String> cc,
-            Collection<Attachment> attachments,
-            Integer port,
-            boolean useHtml,
-            boolean override) {
+    Boolean doSendMail(
+        String subject,
+        String body,
+        String from,
+        String fromName,
+        Collection<String> to,
+        Collection<String> cc,
+        Collection<Attachment> attachments,
+        Integer port,
+        boolean useHtml,
+        boolean override) {
 
         Email email
         def summary = "email with subject '${subject}' to ${to} from ${from ?: defaultFrom} via ${defaultHost}:${port ?: defaultPort}"

--- a/grails-app/services/org/pih/warehouse/core/MailService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/MailService.groovy
@@ -144,8 +144,8 @@ class MailService {
         Collection<String> cc,
         Collection<Attachment> attachments,
         Integer port,
-        boolean useHtml,
-        boolean override) {
+        Boolean useHtml,
+        Boolean override) {
 
         Email email
         def summary = "email with subject '${subject}' to ${to} from ${from ?: defaultFrom} via ${defaultHost}:${port ?: defaultPort}"

--- a/grails-app/views/admin/sendMail.gsp
+++ b/grails-app/views/admin/sendMail.gsp
@@ -37,7 +37,7 @@
                                     <label><warehouse:message code="mail.from.label" default="From"/></label>
                                 </td>
                                 <td class="value">
-                                    <g:textField name="from" value="info@openboxes.com" class="text" size="60"/>
+                                    <g:textField name="from" value="${grailsApplication.config.grails.mail.from}" class="text" size="60"/>
                                 </td>
                             </tr>
                             <tr class="prop">

--- a/test/integration/org/pih/warehouse/core/MailServiceTests.groovy
+++ b/test/integration/org/pih/warehouse/core/MailServiceTests.groovy
@@ -49,8 +49,22 @@ class MailServiceTests extends GrailsUnitTestCase {
 	@Test
 	void sendHtmlMailShouldNotRaiseExceptionIfSmtpServerIsDown() {
 		testSmtpService.stop()
+		// should not raise org.apache.commons.mail.EmailException
 		def sent = mailService.sendHtmlMail("undeliverable", "this message will not send", "anybody@anywhere.com", null, true)
 		assertFalse(sent)
+	}
+
+	@Test
+	void sendHtmlMailShouldNotRaiseExceptionIfPortIsInvalid() {
+		def oldPort = grailsApplication.config.grails.mail.port = ServerSetupTest.SMTP.port
+		grailsApplication.config.grails.mail.port = -1
+		try {
+			// should not raise java.lang.IllegalArgumentException
+			def sent = mailService.sendHtmlMail("invalid port", "this message will not send", "anybody@anywhere.com", null, true)
+			assertFalse(sent)
+		} finally {
+			grailsApplication.config.grails.mail.port = oldPort
+		}
 	}
 
 	@Test
@@ -62,6 +76,7 @@ class MailServiceTests extends GrailsUnitTestCase {
 			def shouldSend = mailService.sendMail("deliverable", "this message will send", "anybody@anywhere.com")
 			assertTrue(shouldSend)
 			testSmtpService.stop()
+			// should not raise org.apache.commons.mail.EmailException
 			def shouldNotSend = mailService.sendMail("undeliverable", "this message will not send", "anybody@anywhere.com")
 			assertFalse(shouldNotSend)
 		} finally {
@@ -82,6 +97,7 @@ class MailServiceTests extends GrailsUnitTestCase {
 				"right_" + grailsApplication.config.grails.mail.username,
 				"right_" + grailsApplication.config.grails.mail.password
 			)
+			// should not raise org.apache.commons.mail.EmailException
 			def sent = mailService.sendHtmlMail("unauthorized", "this message will not send", "anybody@anywhere.com", null, true)
 			assertFalse(sent)
 		} finally {

--- a/test/integration/org/pih/warehouse/core/MailServiceTests.groovy
+++ b/test/integration/org/pih/warehouse/core/MailServiceTests.groovy
@@ -1,16 +1,19 @@
 package org.pih.warehouse.core
 
+import com.icegreen.greenmail.user.GreenMailUser
 import com.icegreen.greenmail.util.GreenMail
 import com.icegreen.greenmail.util.GreenMailUtil
 import com.icegreen.greenmail.util.ServerSetupTest
+import com.sun.mail.imap.IMAPStore
 import grails.test.GrailsUnitTestCase
 import org.junit.Test
 
 import javax.mail.Message
+import javax.mail.Quota
 
 class MailServiceTests extends GrailsUnitTestCase {
 
-	def mailService
+	MailService mailService
 	def grailsApplication
 
 	static GreenMail testSmtpService
@@ -33,9 +36,10 @@ class MailServiceTests extends GrailsUnitTestCase {
 	}
 
 	@Test
-	void sendHtmlMail_shouldHandleAccentedCharactersCorrectly() {
+	void sendHtmlMailShouldHandleAccentedCharactersCorrectly() {
 		def sent = mailService.sendHtmlMail("sübĵéçt", "This Is Spın̈al Tap", "anybody@anywhere.com", null, true)
 		assertTrue(sent)
+		testSmtpService.waitForIncomingEmail(10000, 1)
 		Message[] messages = testSmtpService.receivedMessages
 		assertEquals(1, messages.length)
 		assertEquals("[OpenBoxes] sübĵéçt", messages[0].subject)
@@ -43,19 +47,79 @@ class MailServiceTests extends GrailsUnitTestCase {
 	}
 
 	@Test
-	void sendHtmlMail_shouldNotRaiseExceptionIfSmtpServerIsDown() {
+	void sendHtmlMailShouldNotRaiseExceptionIfSmtpServerIsDown() {
 		testSmtpService.stop()
 		def sent = mailService.sendHtmlMail("undeliverable", "this message will not send", "anybody@anywhere.com", null, true)
 		assertFalse(sent)
 	}
 
 	@Test
-	void sendMail_shouldNotRaiseExceptionIfSmtpServerIsDown() {
+	void sendMailShouldNotRaiseExceptionIfSmtpServerIsDown() {
+		Boolean oldEnabled = grailsApplication.config.grails.mail.enabled
 		grailsApplication.config.grails.mail.enabled = true
-		def shouldSend = mailService.sendMail("deliverable", "this message will send", "anybody@anywhere.com")
-		assertTrue(shouldSend)
-		testSmtpService.stop()
-		def shouldNotSend = mailService.sendMail("undeliverable", "this message will not send", "anybody@anywhere.com")
-		assertFalse(shouldNotSend)
+
+		try {
+			def shouldSend = mailService.sendMail("deliverable", "this message will send", "anybody@anywhere.com")
+			assertTrue(shouldSend)
+			testSmtpService.stop()
+			def shouldNotSend = mailService.sendMail("undeliverable", "this message will not send", "anybody@anywhere.com")
+			assertFalse(shouldNotSend)
+		} finally {
+			grailsApplication.config.grails.mail.enabled = oldEnabled
+		}
+	}
+
+	@Test
+	void sendHtmlMailShouldNotRaiseExceptionIfCredentialsAreWrong() {
+		String oldUsername = grailsApplication.config.grails.mail.username
+		grailsApplication.config.grails.mail.username = "wrong_" + grailsApplication.config.grails.mail.username
+		String oldPassword = grailsApplication.config.grails.mail.password
+		grailsApplication.config.grails.mail.password = "wrong_" + grailsApplication.config.grails.mail.password
+
+		try {
+			GreenMailUser user = testSmtpService.setUser(
+				grailsApplication.config.grails.mail.from,
+				"right_" + grailsApplication.config.grails.mail.username,
+				"right_" + grailsApplication.config.grails.mail.password
+			)
+			def sent = mailService.sendHtmlMail("unauthorized", "this message will not send", "anybody@anywhere.com", null, true)
+			assertFalse(sent)
+		} finally {
+			grailsApplication.config.grails.mail.username = oldUsername
+			grailsApplication.config.grails.mail.password = oldPassword
+		}
+	}
+
+	@Test
+	void sendMailShouldNotRaiseExceptionIfSmtpServerIsFull() {
+		Boolean oldEnabled = grailsApplication.config.grails.mail.enabled
+		grailsApplication.config.grails.mail.enabled = true
+
+		try {
+			testSmtpService.setQuotaSupported(true)
+			GreenMailUser recipient = testSmtpService.setUser(
+				"anybody@anywhere.com",
+				"recipient"
+			)
+
+			IMAPStore store = testSmtpService.imap.createStore()
+			store.connect(
+				"anybody@anywhere.com",
+				"recipient"
+			)
+
+			Quota testQuota = new Quota("INBOX")
+			testQuota.setResourceLimit("MESSAGES", 1)
+
+			store.quota = testQuota
+			GreenMailUtil.setQuota(recipient, testQuota)
+
+			def shouldSend = mailService.sendMail("under_quota", "this message will send", "anybody@anywhere.com")
+			assertTrue(shouldSend)
+			def shouldAlsoSend = mailService.sendMail("over_quota", "this message will send but not arrive", "anybody@anywhere.com")
+			assertTrue(shouldAlsoSend)
+		} finally {
+			grailsApplication.config.grails.mail.enabled = oldEnabled
+		}
 	}
 }


### PR DESCRIPTION
I'm pretty sure the dev failures were caused by invalid email addresses in the test database. "Miss Administrator" and "Mister Manager" now have `openboxes@pih.org` as their email address.

While I was at it, I consolidated disparate implementations in MailService, removing 150-200 lines of code, fixed a broken test, and added tests for what happens if an SMTP server is down (no exception is thrown) (OBS-1053). I also updated the tools we use to send and test email.

GitHub is showing a sea of red ink which is making review difficult. I preserved fifteen(!?) existing function signatures, removing only one that took a map as input. (This one was used only in AdminController and ErrorsController and was easy to refactor.) The rest all route to a new function called `sendMailImpl()`. The previous implementations differed somewhat in logging and error behavior and I thought it would be less of a support headache going forward if there were just one way to do it.