### PR TITLE
OBS-1077 Resolve a null.toImport() regression.

### DIFF
--- a/grails-app/services/org/pih/warehouse/order/OrderService.groovy
+++ b/grails-app/services/org/pih/warehouse/order/OrderService.groovy
@@ -818,10 +818,12 @@ class OrderService {
             propertiesMap.each {
                 def excludedProperties = it.deny
                 excludedProperties.each { property ->
-                    def existingValue = existingOrderItem.toImport()."${property}"
-                    def importedValue = orderItem."${property}"
-                    if (order.status == it.status && (existingValue != importedValue)) {
-                        throw new IllegalArgumentException("Import must not change ${property} of item ${orderItem.productCode}, before: ${existingValue}, after: ${importedValue}")
+                    if (order.status == it.status) {
+                        def existingValue = existingOrderItem.toImport()."${property}"
+                        def importedValue = orderItem."${property}"
+                        if (existingValue != importedValue) {
+                            throw new IllegalArgumentException("Import must not change ${property} of item ${orderItem.productCode}, before: ${existingValue}, after: ${importedValue}")
+                        }
                     }
                 }
             }


### PR DESCRIPTION
I introduced this bug as part of OBPIH-4058 (Improve logging on PO CSV parse errors). When I edited this block, I inadvertently removed an `&&` that, by short-circuiting, served as a null guard.