### PR TITLE
OBPIH-4305 Add clone-remote-database to source control.

### DIFF
--- a/scripts/support/clone-remote-database
+++ b/scripts/support/clone-remote-database
@@ -1,0 +1,115 @@
+#!/bin/bash
+set -euo pipefail
+start_tm=$(date '+%s')
+export TIME="%C %E"
+
+usage()
+{
+	set +xv
+	echo 1>&2 "$0 - clone a remote mysql database to a local machine for testing"
+	echo 1>&2 ""
+	echo 1>&2 "Usage: $0 [-l <LOCAL_DB>] [-r <REMOTE_DB>] REMOTE_HOST"
+	echo 1>&2 "REMOTE_HOST -- name or ip of remote host (passed to ssh)"
+	echo 1>&2 "LOCAL_DB -- name of new database to create locally (default: 'openboxes')"
+	echo 1>&2 "REMOTE_DB -- name of database to clone from REMOTE_HOST (default: 'openboxes')"
+	echo 1>&2 ""
+	echo 1>&2 "Use with care -- this script will destroy \$LOCAL_DB if it exists!!"
+	exit 1
+}
+
+#
+# Pretty-print the difference between two timestamps, $1 and $2.
+#
+elapsed_tm()
+{
+	set +e
+	# guess whether we're running GNU date: thanks for nothing, POSIX
+	date -j >/dev/null 2>&-
+	if [ $? -ne 0 ]
+	then
+		# GNU/linux
+		date -ud@$(($2 - $1)) "+%H:%M:%S"
+	else
+		# macOS/BSD
+		date -juf "%s" $(($2 - $1)) "+%H:%M:%S"
+	fi
+	set -e
+}
+
+LOCAL_DB="openboxes"
+REMOTE_DB="openboxes"
+while getopts "hl:r:" o
+do
+	case "${o}" in
+	l)
+		LOCAL_DB=${OPTARG}
+		[ "$LOCAL_DB" ] || usage
+		;;
+	r)
+		REMOTE_DB=${OPTARG}
+		[ "$REMOTE_DB" ] || usage
+		;;
+	h)
+		usage
+		;;
+	*)
+		usage
+		;;
+	esac
+done
+shift $((OPTIND-1))
+
+[ "$1" ] && [ "$#" -eq 1 ] || usage
+REMOTE_HOST="$1"
+
+
+
+SQL_BASENAME="$REMOTE_HOST-$REMOTE_DB"
+
+echo "Clobbering local database $LOCAL_DB ..."
+mysql -e "drop database if exists \`$LOCAL_DB\`; create database \`$LOCAL_DB\` default charset utf8; grant all on \`$LOCAL_DB\`.* to 'openboxes'@'localhost' identified by 'openboxes';"
+mysql $LOCAL_DB -e 'select 1' > /dev/null
+
+# prevent "ERROR 2006 (HY000): MySQL server has gone away"
+# see also https://stackoverflow.com/questions/10474922/error-2006-hy000-mysql-server-has-gone-away
+mysql -e "set global max_allowed_packet=1024*1024*1024;"
+
+echo -n "Counting products in remote database $REMOTE_HOST:$REMOTE_DB ..."
+remote_product_cnt=$(ssh "$REMOTE_HOST" "mysql $REMOTE_DB -Nse 'select count(*) from product;'")
+echo " $remote_product_cnt"
+
+echo "Exporting schema from remote database $REMOTE_HOST:$REMOTE_DB ..."
+/usr/bin/time ssh $REMOTE_HOST "mysqldump --allow-keywords --single-transaction --skip-comments --skip-extended-insert --no-data --routines $REMOTE_DB | gzip -cf" | gunzip -c > $SQL_BASENAME-schema.sql
+
+echo "Importing schema into local database $LOCAL_DB ..."
+/usr/bin/time mysql $LOCAL_DB < $SQL_BASENAME-schema.sql
+
+echo "Examining tables in remote database $REMOTE_HOST:$REMOTE_DB ..."
+IGNORED_TABLES=$(ssh "$REMOTE_HOST" "mysql -Nse 'select table_name from information_schema.tables where (table_schema like \"$REMOTE_DB\") and (table_name like \"%_dimension\" or table_name like \"%_fact\" or table_name like \"%_snapshot\");'")
+
+declare -a IGNORED_REMOTE_TABLES
+for it in $IGNORED_TABLES
+do
+	echo " - ignoring \`$it\`"
+	IGNORED_REMOTE_TABLES+=("--ignore-table=$REMOTE_DB.$it")
+done
+
+echo "Exporting data (ignoring ${#IGNORED_REMOTE_TABLES[@]} tables) from remote database $REMOTE_HOST:$REMOTE_DB ..."
+/usr/bin/time ssh $REMOTE_HOST "mysqldump --allow-keywords --single-transaction --skip-comments --skip-extended-insert --no-create-info ${IGNORED_REMOTE_TABLES[@]} $REMOTE_DB | gzip -cf" | gunzip -c > $SQL_BASENAME-data.sql
+
+echo "Importing data into local database $LOCAL_DB (this may take 30+ minutes) ..."
+/usr/bin/time mysql $LOCAL_DB < $SQL_BASENAME-data.sql --max-allowed-packet=1G --reconnect --wait
+
+echo -n "Counting products in local database $REMOTE_HOST:$LOCAL_DB ..."
+local_product_cnt=$(mysql $LOCAL_DB -Nse 'select count(*) from product;')
+echo " $local_product_cnt"
+
+end_tm=$(date '+%s')
+
+echo "Cloned data in $(elapsed_tm $start_tm $end_tm)"
+
+if [ ! "$remote_product_cnt" -eq "$local_product_cnt" ]
+then
+	echo >&2 "Oh, no! Wrong number of product entries after copy! Do not use local DB!"
+	exit 2
+fi

--- a/scripts/support/clone-remote-database
+++ b/scripts/support/clone-remote-database
@@ -8,12 +8,12 @@ usage()
 	set +xv
 	echo 1>&2 "$0 - clone a remote mysql database to a local machine for testing"
 	echo 1>&2 ""
-	echo 1>&2 "Usage: $0 [-l <LOCAL_DB>] [-r <REMOTE_DB>] REMOTE_HOST"
+	echo 1>&2 "Usage: $0 [-f] [-l <LOCAL_DB>] [-r <REMOTE_DB>] REMOTE_HOST"
 	echo 1>&2 "REMOTE_HOST -- name or ip of remote host (passed to ssh)"
 	echo 1>&2 "LOCAL_DB -- name of new database to create locally (default: 'openboxes')"
 	echo 1>&2 "REMOTE_DB -- name of database to clone from REMOTE_HOST (default: 'openboxes')"
 	echo 1>&2 ""
-	echo 1>&2 "Use with care -- this script will destroy \$LOCAL_DB if it exists!!"
+	echo 1>&2 "Use with care -- this script will destroy \$LOCAL_DB if it exists and you set -f!!"
 	exit 1
 }
 
@@ -36,11 +36,15 @@ elapsed_tm()
 	set -e
 }
 
+DO_CLOBBER=0
 LOCAL_DB="openboxes"
 REMOTE_DB="openboxes"
-while getopts "hl:r:" o
+while getopts "fhl:r:" o
 do
 	case "${o}" in
+	f)
+		DO_CLOBBER=1
+		;;
 	l)
 		LOCAL_DB=${OPTARG}
 		[ "$LOCAL_DB" ] || usage
@@ -62,29 +66,34 @@ shift $((OPTIND-1))
 [ "$1" ] && [ "$#" -eq 1 ] || usage
 REMOTE_HOST="$1"
 
-
-
 SQL_BASENAME="$REMOTE_HOST-$REMOTE_DB"
 
-echo "Clobbering local database $LOCAL_DB ..."
-mysql -e "drop database if exists \`$LOCAL_DB\`; create database \`$LOCAL_DB\` default charset utf8; grant all on \`$LOCAL_DB\`.* to 'openboxes'@'localhost' identified by 'openboxes';"
-mysql $LOCAL_DB -e 'select 1' > /dev/null
-
-# prevent "ERROR 2006 (HY000): MySQL server has gone away"
-# see also https://stackoverflow.com/questions/10474922/error-2006-hy000-mysql-server-has-gone-away
-mysql -e "set global max_allowed_packet=1024*1024*1024;"
-
 echo -n "Counting products in remote database $REMOTE_HOST:$REMOTE_DB ..."
-remote_product_cnt=$(ssh "$REMOTE_HOST" "mysql $REMOTE_DB -Nse 'select count(*) from product;'")
+remote_product_cnt=$(ssh "$REMOTE_HOST" "mysql $REMOTE_DB -Nse 'select count(id) from product;'")
 echo " $remote_product_cnt"
 
 echo "Exporting schema from remote database $REMOTE_HOST:$REMOTE_DB ..."
 /usr/bin/time ssh $REMOTE_HOST "mysqldump --allow-keywords --single-transaction --skip-comments --skip-extended-insert --no-data --routines $REMOTE_DB | gzip -cf" | gunzip -c > $SQL_BASENAME-schema.sql
 
+database_exists=$(mysql -Nse "select count(schema_name) from information_schema.schemata where schema_name = '$LOCAL_DB';")
+if [ "$DO_CLOBBER" -eq 1 ]
+then
+	echo "Clobbering local database $LOCAL_DB ..."
+	mysql -e "drop database if exists \`$LOCAL_DB\`;"
+elif [ "$database_exists" -ne 0 ]
+then
+	echo >&2 "Database \`$LOCAL_DB\` exists and -f was not set!"
+	exit 2
+fi
+
+echo "Initializing local database $LOCAL_DB ..."
+mysql -e "create database \`$LOCAL_DB\` default charset utf8; grant all on \`$LOCAL_DB\`.* to 'openboxes'@'localhost' identified by 'openboxes';"
+mysql $LOCAL_DB -e 'select 1' > /dev/null
+
 echo "Importing schema into local database $LOCAL_DB ..."
 /usr/bin/time mysql $LOCAL_DB < $SQL_BASENAME-schema.sql
 
-echo "Examining tables in remote database $REMOTE_HOST:$REMOTE_DB ..."
+echo "Listing tables in remote database $REMOTE_HOST:$REMOTE_DB ..."
 IGNORED_TABLES=$(ssh "$REMOTE_HOST" "mysql -Nse 'select table_name from information_schema.tables where (table_schema like \"$REMOTE_DB\") and (table_name like \"%_dimension\" or table_name like \"%_fact\" or table_name like \"%_snapshot\");'")
 
 declare -a IGNORED_REMOTE_TABLES
@@ -98,10 +107,10 @@ echo "Exporting data (ignoring ${#IGNORED_REMOTE_TABLES[@]} tables) from remote 
 /usr/bin/time ssh $REMOTE_HOST "mysqldump --allow-keywords --single-transaction --skip-comments --skip-extended-insert --no-create-info ${IGNORED_REMOTE_TABLES[@]} $REMOTE_DB | gzip -cf" | gunzip -c > $SQL_BASENAME-data.sql
 
 echo "Importing data into local database $LOCAL_DB (this may take 30+ minutes) ..."
-/usr/bin/time mysql $LOCAL_DB < $SQL_BASENAME-data.sql --max-allowed-packet=1G --reconnect --wait
+/usr/bin/time mysql $LOCAL_DB < $SQL_BASENAME-data.sql --reconnect --wait
 
 echo -n "Counting products in local database $REMOTE_HOST:$LOCAL_DB ..."
-local_product_cnt=$(mysql $LOCAL_DB -Nse 'select count(*) from product;')
+local_product_cnt=$(mysql $LOCAL_DB -Nse 'select count(id) from product;')
 echo " $local_product_cnt"
 
 end_tm=$(date '+%s')

--- a/scripts/support/clone-remote-database.sh
+++ b/scripts/support/clone-remote-database.sh
@@ -8,15 +8,16 @@ usage()
 	set +xv
 	echo >&2 "$0 - clone a remote mysql database to a local machine for testing"
 	echo >&2 ""
-	echo >&2 "Usage: $0 [-Pf] [-l <LOCAL_DB>] [-p <PATH> ] [-r <REMOTE_DB>] REMOTE_HOST"
+	echo >&2 "Usage: $0 [-fsP] [-l <LOCAL_DB>] [-p <PATH> ] [-r <REMOTE_DB>] REMOTE_HOST"
 	echo >&2 "REMOTE_HOST -- name or ip of remote host (passed to ssh)"
 	echo >&2 "LOCAL_DB -- name of new database to create locally (default: 'openboxes')"
 	echo >&2 "REMOTE_DB -- name of database to clone from REMOTE_HOST (default: 'openboxes')"
 	echo >&2 "PATH -- path under which mysql is installed on remote host"
 	echo >&2 ""
 	echo >&2 "Flags:"
-	echo >&2 "  -P Copy product_demand tables (will fail if refreshProductDemandData is running on remote)"
 	echo >&2 "  -f Completely delete \$LOCAL_DB, if it exists, before cloning -- use with care!"
+	echo >&2 "  -s use sudo when accessing local database (if using auth_socket for root)"
+	echo >&2 "  -P Copy product_demand tables (will fail if refreshProductDemandData is running on remote)"
 	exit 1
 }
 
@@ -42,6 +43,7 @@ LOCAL_DB="openboxes"
 LOCAL_DB_USERNAME="root"
 REMOTE_DB="openboxes"
 REMOTE_DB_USERNAME="root"
+local_sudo=
 
 MYSQL_PATH=/usr/bin:/usr/local/mysql/bin
 
@@ -57,7 +59,7 @@ fi
 
 set -u
 
-while getopts 'fhl:p:r:P' o
+while getopts 'fhl:p:r:sP' o
 do
 	case "${o}" in
 	f)
@@ -77,6 +79,9 @@ do
 	r)
 		REMOTE_DB=${OPTARG}
 		[ "$REMOTE_DB" ] || usage
+		;;
+	s)
+		local_sudo=sudo
 		;;
 	P)
 		do_copy_product_demand=1
@@ -124,11 +129,11 @@ fi
 echo "Exporting schema (ignoring ${#ignored_remote_tables[@]} tables) from remote database $REMOTE_HOST:$REMOTE_DB ..."
 /usr/bin/time ssh "$REMOTE_HOST" "PATH=${MYSQL_PATH} mysqldump -u '$REMOTE_DB_USERNAME' -p'$REMOTE_DB_PASSWORD' --opt --allow-keywords --single-transaction --no-data ${ignored_remote_tables[*]:-} '$REMOTE_DB' | gzip -cf" | gunzip -c > "${sql_basename}-schema.sql"
 
-database_exists=$(mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" -Nse "select count(schema_name) from information_schema.schemata where schema_name = '$LOCAL_DB';")
+database_exists=$($local_sudo mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" -Nse "select count(schema_name) from information_schema.schemata where schema_name = '$LOCAL_DB';")
 if [ "${do_clobber:-}" ]
 then
 	echo "Clobbering local database $LOCAL_DB ..."
-	mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" -e "drop database if exists \`$LOCAL_DB\`;"
+	$local_sudo mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" -e "drop database if exists \`$LOCAL_DB\`;"
 elif [ "$database_exists" -ne 0 ]
 then
 	echo >&2 "Database \`$LOCAL_DB\` exists and -f was not set!"
@@ -136,11 +141,11 @@ then
 fi
 
 echo "Initializing local database $LOCAL_DB ..."
-mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" -e "create database \`$LOCAL_DB\` default charset utf8; grant all on \`$LOCAL_DB\`.* to 'openboxes'@'localhost' identified by 'openboxes';"
-mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" "$LOCAL_DB" -e 'select 1' > /dev/null
+$local_sudo mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" -e "create database \`$LOCAL_DB\` default charset utf8; grant all on \`$LOCAL_DB\`.* to 'openboxes'@'localhost' identified by 'openboxes';"
+$local_sudo mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" "$LOCAL_DB" -e 'select 1' > /dev/null
 
 echo "Inserting schema into local database $LOCAL_DB ..."
-/usr/bin/time mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" "$LOCAL_DB" < "${sql_basename}-schema.sql"
+/usr/bin/time $local_sudo  mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" "$LOCAL_DB" < "${sql_basename}-schema.sql"
 
 echo "Listing tables in remote database $REMOTE_HOST:$REMOTE_DB ..."
 nocopy_tables=$(ssh "$REMOTE_HOST" "PATH=${MYSQL_PATH} mysql -u '$REMOTE_DB_USERNAME' -p'$REMOTE_DB_PASSWORD' -Nse 'select table_name from information_schema.tables where (table_schema like \"$REMOTE_DB\") and (table_name like \"%_dimension\" or table_name like \"%_fact\" or table_name like \"%_snapshot\");'")
@@ -162,24 +167,24 @@ echo "Exporting data (ignoring ${#ignored_remote_tables[@]} tables) from remote 
 #
 # see also https://stackoverflow.com/questions/10474922/error-2006-hy000-mysql-server-has-gone-away
 #
-curr_max_packet=$(mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" -Nse "select @@max_allowed_packet;")
+curr_max_packet=$($local_sudo mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" -Nse "select @@max_allowed_packet;")
 if [ "$curr_max_packet" -lt 16777216 ]
 then
 	echo "Temporarily increasing max_allowed_packet to 16M ..."
-	mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" -e "set global max_allowed_packet=16*1024*1024;"
+	$local_sudo mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" -e "set global max_allowed_packet=16*1024*1024;"
 fi
 
 echo "Inserting data into local database $LOCAL_DB (this may take several minutes) ..."
-/usr/bin/time mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" "$LOCAL_DB" < "${sql_basename}-data.sql" --max-allowed-packet=16M --reconnect --wait
+/usr/bin/time $local_sudo mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" "$LOCAL_DB" < "${sql_basename}-data.sql" --max-allowed-packet=16M --reconnect --wait
 
 if [ "$curr_max_packet" -lt 16777216 ]
 then
 	echo "Restoring previous max_allowed_packet ..."
-	mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" -e "set global max_allowed_packet=${curr_max_packet};"
+	$local_sudo mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" -e "set global max_allowed_packet=${curr_max_packet};"
 fi
 
 echo -n "Counting products in local database $REMOTE_HOST:$LOCAL_DB ..."
-local_product_cnt=$(mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" "$LOCAL_DB" -Nse 'select count(id) from product;')
+local_product_cnt=$($local_sudo mysql -u "$LOCAL_DB_USERNAME" -p"$LOCAL_DB_PASSWORD" "$LOCAL_DB" -Nse 'select count(id) from product;')
 echo " $local_product_cnt"
 
 end_tm=$(date '+%s')

--- a/scripts/support/clone-remote-database.sh
+++ b/scripts/support/clone-remote-database.sh
@@ -8,12 +8,14 @@ usage()
 	set +xv
 	echo 1>&2 "$0 - clone a remote mysql database to a local machine for testing"
 	echo 1>&2 ""
-	echo 1>&2 "Usage: $0 [-f] [-l <LOCAL_DB>] [-r <REMOTE_DB>] REMOTE_HOST"
+	echo 1>&2 "Usage: $0 [-fP] [-l <LOCAL_DB>] [-r <REMOTE_DB>] REMOTE_HOST"
 	echo 1>&2 "REMOTE_HOST -- name or ip of remote host (passed to ssh)"
 	echo 1>&2 "LOCAL_DB -- name of new database to create locally (default: 'openboxes')"
 	echo 1>&2 "REMOTE_DB -- name of database to clone from REMOTE_HOST (default: 'openboxes')"
 	echo 1>&2 ""
-	echo 1>&2 "Use with care -- this script will destroy \$LOCAL_DB if it exists and you set -f!!"
+	echo 1>&2 "Flags:"
+	echo 1>&2 "  -f Completely delete \$LOCAL_DB, if it exists, before cloning -- use with care!"
+	echo 1>&2 "  -P Copy product_demand tables (will fail if refreshProductDemandData is running on remote)"
 	exit 1
 }
 
@@ -24,26 +26,28 @@ elapsed_tm()
 {
 	set +e
 	# guess whether we're running GNU date: thanks for nothing, POSIX
-	date -j >/dev/null 2>&-
-	if [ $? -ne 0 ]
+	if date -j >/dev/null 2>&-
 	then
-		# GNU/linux
-		date -ud@$(($2 - $1)) "+%H:%M:%S"
-	else
-		# macOS/BSD
+		# macOS/BSD has the -j flag
 		date -juf "%s" $(($2 - $1)) "+%H:%M:%S"
+	else
+		# otherwise, assume we're running GNU/linux
+		date -ud@$(($2 - $1)) "+%H:%M:%S"
 	fi
 	set -e
 }
 
-DO_CLOBBER=0
 LOCAL_DB="openboxes"
 REMOTE_DB="openboxes"
-while getopts "fhl:r:" o
+
+while getopts "fhl:r:P" o
 do
 	case "${o}" in
 	f)
-		DO_CLOBBER=1
+		do_clobber=1
+		;;
+	h)
+		usage
 		;;
 	l)
 		LOCAL_DB=${OPTARG}
@@ -53,8 +57,8 @@ do
 		REMOTE_DB=${OPTARG}
 		[ "$REMOTE_DB" ] || usage
 		;;
-	h)
-		usage
+	P)
+		do_copy_product_demand=1
 		;;
 	*)
 		usage
@@ -65,18 +69,38 @@ shift $((OPTIND-1))
 
 [ "$1" ] && [ "$#" -eq 1 ] || usage
 REMOTE_HOST="$1"
-
-SQL_BASENAME="$REMOTE_HOST-$REMOTE_DB-$LOCAL_DB"
+sql_basename="$REMOTE_HOST-$REMOTE_DB-$LOCAL_DB"
+declare -a ignored_remote_tables
 
 echo -n "Counting products in remote database $REMOTE_HOST:$REMOTE_DB ..."
 remote_product_cnt=$(ssh "$REMOTE_HOST" "mysql $REMOTE_DB -Nse 'select count(id) from product;'")
 echo " $remote_product_cnt"
 
-echo "Exporting schema from remote database $REMOTE_HOST:$REMOTE_DB ..."
-/usr/bin/time ssh $REMOTE_HOST "mysqldump --allow-keywords --single-transaction --skip-comments --no-data --routines $REMOTE_DB | gzip -cf" | gunzip -c > $SQL_BASENAME-schema.sql
+if [ ! "${do_copy_product_demand:-}" ]
+then
+	#
+	# ReportService.refreshProductDemandData() drops tables while it works,
+	# which can generate "ERROR 1146 (42S02) at line XXXX: Table doesn't exist"
+	# errors and make dependent views un-reconstructable.
+	#
+	declare -a nocreate_tables=(
+		"product_demand_details"
+		"product_demand_details_tmp"
+		"product_expiry_summary"	# this view is invalid when product_demand_details is dropped
+	)
+	echo "Skipping tables overwritten by ReportService.refreshProductDemandData() ..."
+	for it in "${nocreate_tables[@]}"
+	do
+		echo " - will not create \`$it\`"
+		ignored_remote_tables+=("--ignore-table=$REMOTE_DB.$it")
+	done
+fi
+
+echo "Exporting schema (ignoring ${#ignored_remote_tables[@]} tables) from remote database $REMOTE_HOST:$REMOTE_DB ..."
+/usr/bin/time ssh "$REMOTE_HOST" "mysqldump --opt --allow-keywords --single-transaction --no-data ${ignored_remote_tables[*]:-} $REMOTE_DB | gzip -cf" | gunzip -c > "${sql_basename}-schema.sql"
 
 database_exists=$(mysql -Nse "select count(schema_name) from information_schema.schemata where schema_name = '$LOCAL_DB';")
-if [ "$DO_CLOBBER" -eq 1 ]
+if [ "${do_clobber:-}" ]
 then
 	echo "Clobbering local database $LOCAL_DB ..."
 	mysql -e "drop database if exists \`$LOCAL_DB\`;"
@@ -88,37 +112,57 @@ fi
 
 echo "Initializing local database $LOCAL_DB ..."
 mysql -e "create database \`$LOCAL_DB\` default charset utf8; grant all on \`$LOCAL_DB\`.* to 'openboxes'@'localhost' identified by 'openboxes';"
-mysql $LOCAL_DB -e 'select 1' > /dev/null
+mysql "$LOCAL_DB" -e 'select 1' > /dev/null
 
-echo "Importing schema into local database $LOCAL_DB ..."
-/usr/bin/time mysql $LOCAL_DB < $SQL_BASENAME-schema.sql
+echo "Inserting schema into local database $LOCAL_DB ..."
+/usr/bin/time mysql "$LOCAL_DB" < "${sql_basename}-schema.sql"
 
 echo "Listing tables in remote database $REMOTE_HOST:$REMOTE_DB ..."
-IGNORED_TABLES=$(ssh "$REMOTE_HOST" "mysql -Nse 'select table_name from information_schema.tables where (table_schema like \"$REMOTE_DB\") and (table_name like \"%_dimension\" or table_name like \"%_fact\" or table_name like \"%_snapshot\");'")
+nocopy_tables=$(ssh "$REMOTE_HOST" "mysql -Nse 'select table_name from information_schema.tables where (table_schema like \"$REMOTE_DB\") and (table_name like \"%_dimension\" or table_name like \"%_fact\" or table_name like \"%_snapshot\");'")
 
-declare -a IGNORED_REMOTE_TABLES
-for it in $IGNORED_TABLES
+for it in $nocopy_tables
 do
-	echo " - ignoring \`$it\`"
-	IGNORED_REMOTE_TABLES+=("--ignore-table=$REMOTE_DB.$it")
+	echo " - will not copy \`$it\`"
+	ignored_remote_tables+=("--ignore-table=$REMOTE_DB.$it")
 done
 
-echo "Exporting data (ignoring ${#IGNORED_REMOTE_TABLES[@]} tables) from remote database $REMOTE_HOST:$REMOTE_DB ..."
-/usr/bin/time ssh $REMOTE_HOST "mysqldump --allow-keywords --single-transaction --skip-comments --no-create-info ${IGNORED_REMOTE_TABLES[@]} $REMOTE_DB | gzip -cf" | gunzip -c > $SQL_BASENAME-data.sql
+echo "Exporting data (ignoring ${#ignored_remote_tables[@]} tables) from remote database $REMOTE_HOST:$REMOTE_DB ..."
+/usr/bin/time ssh "$REMOTE_HOST" "mysqldump --opt --allow-keywords --single-transaction --no-create-info ${ignored_remote_tables[*]:-} $REMOTE_DB | gzip -cf" | gunzip -c > "${sql_basename}-data.sql"
 
-echo "Importing data into local database $LOCAL_DB (this may take 10+ minutes) ..."
-/usr/bin/time mysql $LOCAL_DB < $SQL_BASENAME-data.sql --reconnect --wait
+#
+# Prevent "ERROR 2006 (HY000): MySQL server has gone away" by temporarily
+# increasing max_allowed_packet, if needed. MySQL 5.7's default value of 4M
+# may not be enough to consistently copy a production OB database, but if the
+# local server has already increased it, we don't need, or want, to change it.
+#
+# see also https://stackoverflow.com/questions/10474922/error-2006-hy000-mysql-server-has-gone-away
+#
+curr_max_packet=$(mysql -Nse "select @@max_allowed_packet;")
+if [ "$curr_max_packet" -lt 16777216 ]
+then
+	echo "Temporarily increasing max_allowed_packet to 16M ..."
+	mysql -e "set global max_allowed_packet=16*1024*1024;"
+fi
+
+echo "Inserting data into local database $LOCAL_DB (this may take several minutes) ..."
+/usr/bin/time mysql "$LOCAL_DB" < "${sql_basename}-data.sql" --max-allowed-packet=16M --reconnect --wait
+
+if [ "$curr_max_packet" -lt 16777216 ]
+then
+	echo "Restoring previous max_allowed_packet ..."
+	mysql -e "set global max_allowed_packet=${curr_max_packet};"
+fi
 
 echo -n "Counting products in local database $REMOTE_HOST:$LOCAL_DB ..."
-local_product_cnt=$(mysql $LOCAL_DB -Nse 'select count(id) from product;')
+local_product_cnt=$(mysql "$LOCAL_DB" -Nse 'select count(id) from product;')
 echo " $local_product_cnt"
 
 end_tm=$(date '+%s')
 
-echo "Cloned data in $(elapsed_tm $start_tm $end_tm)"
+echo "Cloned data in $(elapsed_tm "$start_tm" "$end_tm")"
 
 if [ ! "$remote_product_cnt" -eq "$local_product_cnt" ]
 then
-	echo >&2 "Oh, no! Wrong number of product entries after copy! Do not use local DB!"
+	echo >&2 "Oh, no! Wrong number of product entries after copy! Do not use local DB $LOCAL_DB!"
 	exit 2
 fi


### PR DESCRIPTION
Justin,

I updated the script you sent me via Slack. It Works For Me™ copying the latest `prd` bits to my Mac, where I was able to reproduce OBS-1076 locally with it. Let me know if you have any trouble running it on Linux.

While I was working on this, I encountered the occasional `ERROR 2006 (HY000): MySQL server has gone away` error message, which I resolved by setting `max_allowed_packet` to its [legal maximum](https://dev.mysql.com/doc/refman/5.7/en/packet-too-large.html). The docs say "It is safe to increase the value of this variable because the extra memory is allocated only when needed," but if a 1G ceiling concerns you I can look into this more.

OpenBoxes takes about 10 minutes to start up after this script runs, with logs like
```
2022-03-01 11:10:51,970 [DefaultPluginScheduler_Worker-3] INFO  data.DataService  - Updated 0 rows in 2 ms
2022-03-01 11:10:51,973 [DefaultPluginScheduler_Worker-3] INFO  jobs.RefreshStockoutDataJob  - Refreshed stockout data in 1158 ms
2022-03-01 11:10:54,784 [ForkJoinPool-1-worker-6] INFO  inventory.ProductAvailabilityService  - Refreshing product availability location (BHI: SL Stock), forceRefresh (true) ...
...
...
...
2022-03-01 11:20:07,999 [DefaultPluginScheduler_Worker-5] INFO  inventory.ProductAvailabilityService  - Refreshed product availability in 557048ms
2022-03-01 11:20:08,017 [DefaultPluginScheduler_Worker-5] INFO  jobs.RefreshProductAvailabilityJob  - Finished refreshing product availability data in 557075 ms
```

Not a huge deal, since the script itself takes 30 minutes to fully clone `prd`. But it makes me wonder if I'm missing something when I did the copy, or if these services run automagically when the service starts and just run more slowly than I'm used to because the dataset is so much larger.