### PR TITLE
OBS-1089 Fix stocklist PDF export

### DIFF
--- a/grails-app/views/stocklist/_itemList.gsp
+++ b/grails-app/views/stocklist/_itemList.gsp
@@ -34,7 +34,7 @@
                 </g:if>
                 <tr>
                     <td class="b-t0 b-r0">${requisitionItem?.product?.productCode}</td>
-                    <td class="b-t0 b-r0">${requisitionItem?.product?.name}</td>
+                    <td class="b-t0 b-r0">${requisitionItem?.product?.name?.encodeAsHTML()}</td>
                     <td class="b-t0 b-r0">${requisitionItem?.productPackage ? requisitionItem.productPackage.uom?.code + "/" + requisitionItem.productPackage.quantity + " -- " + requisitionItem.productPackage.uom?.name : 'EA/1'}</td>
                     <td class="b-t0 b-r0">${requisitionItem.quantity}</td>
                     <td class="b-t0 b-r0"></td>


### PR DESCRIPTION
I couldn't reproduce [OBS-1089](https://pihemr.atlassian.net/browse/OBS-1089) on `develop`, but could on `master`; this one-line commit from @awalkowiak is the reason why. Any objection to a patch release to unblock a colleague on the pharmacy team?

argument in favor:
- this change has been soaking in develop since October

possible argument against:
- there may be other commits on develop that might need to come along for the ride

An alternative solution would be to target this patch to the specific template(s) affected by this bug. But I thought I'd go with the easiest fix first! :-)
