### PR TITLE
OBPIH-4324 Drop domains when views expire

### DIFF
--- a/grails-app/conf/AccessLogFilters.groovy
+++ b/grails-app/conf/AccessLogFilters.groovy
@@ -8,6 +8,7 @@
  * You must not remove this notice, or any other, from this software.
  **/
 class AccessLogFilters {
+    def dependsOn = [SecurityFilters]  // don't run until session.user is sane
 
     def filters = {
         all(controller: '*', action: '*') {

--- a/grails-app/conf/LoggingFilters.groovy
+++ b/grails-app/conf/LoggingFilters.groovy
@@ -13,6 +13,8 @@ import org.codehaus.groovy.grails.commons.ConfigurationHolder as CH
 import org.slf4j.MDC
 
 class LoggingFilters {
+    def dependsOn = [SecurityFilters]  // don't run until session.user is sane
+
     def filters = {
         all(controller: '*', action: '*') {
             before = {


### PR DESCRIPTION
@jmiranda per our conversation about (re)setting session.user and session.warehouse in SecurityFilters, they look sane when that class starts up, and I didn't see any effect from assigning `[User|Location].get()` to them. I did make a few tweaks, namely

1. explicitly `discard`-ing old user/session data when a view expires before removing it from their respective `ThreadLocal`s
2. removing unnecessary calls to get() in the `before` closure
3. Noting that `InitializationFilters` and `SecurityFilters` both inspect User and Session objects, while the logging Filters access them, I used `dependsOn` to give grails hints as to which order to run them in. This should prevent the warning message I occasionally see when starting OB:

```
                log.warn(":::::::::::::::::::::::::::::::::::::::::::::::")
                log.warn("::   Cyclical Filter dependencies detected   ::")
                log.warn("::   Continuing with original filter order   ::")
                log.warn(":::::::::::::::::::::::::::::::::::::::::::::::")
```