### PR TITLE
OBPIH-4325 Do not use withNewSession in event handlers.

### DIFF
--- a/grails-app/domain/org/pih/warehouse/core/BudgetCode.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/BudgetCode.groovy
@@ -14,18 +14,11 @@ import org.pih.warehouse.auth.AuthService
 class BudgetCode implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser.get()
     }
 
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser.get()
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/core/GlAccount.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/GlAccount.groovy
@@ -14,18 +14,11 @@ import org.pih.warehouse.auth.AuthService
 class GlAccount implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser.get()
     }
 
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser.get()
     }
     String id
     String code

--- a/grails-app/domain/org/pih/warehouse/core/GlAccountType.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/GlAccountType.groovy
@@ -14,18 +14,11 @@ import org.pih.warehouse.auth.AuthService
 class GlAccountType implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser.get()
     }
 
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser.get()
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/core/PreferenceType.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/PreferenceType.groovy
@@ -14,18 +14,11 @@ import org.pih.warehouse.auth.AuthService
 class PreferenceType implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser.get()
     }
 
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser.get()
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/core/ProductPrice.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/ProductPrice.groovy
@@ -16,17 +16,11 @@ import org.pih.warehouse.product.ProductSupplier
 class ProductPrice implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser.get()
     }
+
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser.get()
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/core/Synonym.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Synonym.groovy
@@ -16,21 +16,11 @@ import org.pih.warehouse.product.Product
 class Synonym implements Serializable {
 
     def beforeInsert = {
-        User.withNewSession {
-            def currentUser = AuthService.currentUser.get()
-            if (currentUser) {
-                createdBy = currentUser
-                updatedBy = currentUser
-            }
-        }
+        createdBy = AuthService.currentUser.get()
     }
+
     def beforeUpdate = {
-        User.withNewSession {
-            def currentUser = AuthService.currentUser.get()
-            if (currentUser) {
-                updatedBy = currentUser
-            }
-        }
+        updatedBy = AuthService.currentUser.get()
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/core/Tag.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Tag.groovy
@@ -16,21 +16,11 @@ import org.pih.warehouse.product.Product
 class Tag implements Serializable {
 
     def beforeInsert = {
-        User.withNewSession {
-            def currentUser = AuthService.currentUser.get()
-            if (currentUser) {
-                createdBy = currentUser
-                updatedBy = currentUser
-            }
-        }
+        createdBy = AuthService.currentUser.get()
     }
+
     def beforeUpdate = {
-        User.withNewSession {
-            def currentUser = AuthService.currentUser.get()
-            if (currentUser) {
-                updatedBy = currentUser
-            }
-        }
+        updatedBy = AuthService.currentUser.get()
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/core/UnitOfMeasure.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/UnitOfMeasure.groovy
@@ -17,6 +17,7 @@ class UnitOfMeasure implements Serializable {
     def beforeInsert = {
         createdBy = AuthService.currentUser.get()
     }
+
     def beforeUpdate = {
         updatedBy = AuthService.currentUser.get()
     }

--- a/grails-app/domain/org/pih/warehouse/core/UnitOfMeasureClass.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/UnitOfMeasureClass.groovy
@@ -17,6 +17,7 @@ class UnitOfMeasureClass implements Serializable {
     def beforeInsert = {
         createdBy = AuthService.currentUser.get()
     }
+
     def beforeUpdate = {
         updatedBy = AuthService.currentUser.get()
     }

--- a/grails-app/domain/org/pih/warehouse/inventory/Transaction.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/Transaction.groovy
@@ -37,17 +37,11 @@ import org.pih.warehouse.shipping.Shipment
 class Transaction implements Comparable, Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser.get()
     }
+
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser.get()
     }
 
     def publishSaveEvent = {

--- a/grails-app/domain/org/pih/warehouse/invoice/Invoice.groovy
+++ b/grails-app/domain/org/pih/warehouse/invoice/Invoice.groovy
@@ -25,18 +25,11 @@ import org.pih.warehouse.shipping.Shipment
 class Invoice implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser.get()
     }
 
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser.get()
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/invoice/InvoiceItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/invoice/InvoiceItem.groovy
@@ -25,18 +25,11 @@ import org.pih.warehouse.shipping.ShipmentItem
 class InvoiceItem implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser.get()
     }
 
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser.get()
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/invoice/InvoiceType.groovy
+++ b/grails-app/domain/org/pih/warehouse/invoice/InvoiceType.groovy
@@ -15,18 +15,11 @@ import org.pih.warehouse.core.User
 class InvoiceType implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser.get()
     }
 
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser.get()
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/order/Order.groovy
+++ b/grails-app/domain/org/pih/warehouse/order/Order.groovy
@@ -21,18 +21,11 @@ import org.pih.warehouse.shipping.ShipmentStatusCode
 class Order implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser.get()
     }
 
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser.get()
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/order/OrderType.groovy
+++ b/grails-app/domain/org/pih/warehouse/order/OrderType.groovy
@@ -16,18 +16,11 @@ import org.pih.warehouse.core.User
 class OrderType implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser.get()
     }
 
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser.get()
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/picklist/Picklist.groovy
+++ b/grails-app/domain/org/pih/warehouse/picklist/Picklist.groovy
@@ -27,18 +27,11 @@ import org.pih.warehouse.requisition.Requisition
 class Picklist implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
-
+        createdBy = AuthService.currentUser.get()
     }
+
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser.get()
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/product/Product.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/Product.groovy
@@ -13,7 +13,6 @@ import org.apache.commons.collections.FactoryUtils
 import org.apache.commons.collections.list.LazyList
 import org.apache.commons.lang.NotImplementedException
 import org.codehaus.groovy.grails.commons.ApplicationHolder
-import org.hibernate.Criteria
 import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.Document
 import org.pih.warehouse.core.GlAccount
@@ -29,6 +28,7 @@ import org.pih.warehouse.inventory.InventorySnapshotEvent
 import org.pih.warehouse.inventory.TransactionCode
 import org.pih.warehouse.inventory.TransactionEntry
 import org.pih.warehouse.shipping.ShipmentItem
+
 /**
  * An product is an instance of a generic.  For instance,
  * the product might be Ibuprofen, but the product is Advil 200mg
@@ -46,21 +46,11 @@ class Product implements Comparable, Serializable {
 
 
     def beforeInsert = {
-        User.withNewSession {
-            def currentUser = AuthService.currentUser.get()
-            if (currentUser) {
-                createdBy = currentUser
-                updatedBy = currentUser
-            }
-        }
+        createdBy = AuthService.currentUser.get()
     }
+
     def beforeUpdate = {
-        User.withNewSession {
-            def currentUser = AuthService.currentUser.get()
-            if (currentUser) {
-                updatedBy = currentUser
-            }
-        }
+        updatedBy = AuthService.currentUser.get()
     }
 
     def publishPersistenceEvent = {
@@ -670,4 +660,3 @@ class Product implements Comparable, Serializable {
         ]
     }
 }
-

--- a/grails-app/domain/org/pih/warehouse/product/ProductPackage.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/ProductPackage.groovy
@@ -18,21 +18,11 @@ import org.pih.warehouse.core.User
 class ProductPackage implements Comparable<ProductPackage>, Serializable {
 
     def beforeInsert = {
-        User.withNewSession {
-            def currentUser = AuthService.currentUser.get()
-            if (currentUser) {
-                createdBy = currentUser
-                updatedBy = currentUser
-            }
-        }
+        createdBy = AuthService.currentUser.get()
     }
+
     def beforeUpdate = {
-        User.withNewSession {
-            def currentUser = AuthService.currentUser.get()
-            if (currentUser) {
-                updatedBy = currentUser
-            }
-        }
+        updatedBy = AuthService.currentUser.get()
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/product/ProductSupplierPreference.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/ProductSupplierPreference.groovy
@@ -9,11 +9,20 @@
  **/
 package org.pih.warehouse.product
 
+import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.Organization
 import org.pih.warehouse.core.PreferenceType
 import org.pih.warehouse.core.User
 
 class ProductSupplierPreference {
+
+    def beforeInsert = {
+        createdBy = AuthService.currentUser.get()
+    }
+
+    def beforeUpdate = {
+        updatedBy = AuthService.currentUser.get()
+    }
 
     String id
 

--- a/grails-app/domain/org/pih/warehouse/requisition/Requisition.groovy
+++ b/grails-app/domain/org/pih/warehouse/requisition/Requisition.groovy
@@ -22,17 +22,11 @@ import org.pih.warehouse.shipping.Shipment
 class Requisition implements Comparable<Requisition>, Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser.get()
     }
+
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser.get()
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/requisition/RequisitionItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/requisition/RequisitionItem.groovy
@@ -25,17 +25,11 @@ import org.pih.warehouse.product.ProductPackage
 class RequisitionItem implements Comparable<RequisitionItem>, Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser.get()
     }
+
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser.get()
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/shipping/Shipment.groovy
+++ b/grails-app/domain/org/pih/warehouse/shipping/Shipment.groovy
@@ -30,26 +30,20 @@ import org.pih.warehouse.requisition.Requisition
 class Shipment implements Comparable, Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
-        currentEvent = mostRecentEvent
-        currentStatus = status.code
-
+        createdBy = AuthService.currentUser.get()
     }
+
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser.get()
     }
 
-    def afterUpdate = {
+    def assignCurrentEvent = {
         currentEvent = mostRecentEvent
         currentStatus = status.code
     }
+
+    def afterInsert = assignCurrentEvent
+    def afterUpdate = assignCurrentEvent
 
     String id
     String name                    // user-defined name of the shipment
@@ -628,4 +622,3 @@ class Shipment implements Comparable, Serializable {
         return event?.eventDate
     }
 }
-


### PR DESCRIPTION
@jmiranda as discussed, I don't think the `withNewSession` closures are necessary in these domains' event handlers, and we don't use them consistently anyway.

I standardized on UnitOfMeasure's `beforeUpdate`/`beforeInsert` implementation, which matches GORM's handling of date stamps, where the insert handler does not set the updated field:

```
class Person {
   Date dateCreated
   Date lastUpdated
   def beforeInsert() {
       dateCreated = new Date()
   }
   def beforeUpdate() {
       lastUpdated = new Date()
   }
}
```

See also "[Automatic Timestamping](https://grails.github.io/grails2-doc/1.3.9/guide/single.html#5.5.1%20Events%20and%20Auto%20Timestamping)."
