### PR TITLE
OBPIH-4327 Add missing belongsTo/cascade annotations to Product/Supplier/Location graph.

### DIFF
--- a/grails-app/domain/org/pih/warehouse/core/Location.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Location.groovy
@@ -10,7 +10,6 @@
 package org.pih.warehouse.core
 
 import org.codehaus.groovy.grails.commons.ConfigurationHolder
-import org.grails.plugins.excelimport.ExcelImportUtils
 import org.pih.warehouse.inventory.Inventory
 import org.pih.warehouse.inventory.InventorySnapshotEvent
 import org.pih.warehouse.inventory.RefreshProductAvailabilityEvent
@@ -97,6 +96,7 @@ class Location implements Comparable<Location>, java.io.Serializable {
 
     static mapping = {
         id generator: 'uuid'
+        packages cascade: "all-delete-orphan"
         cache true
     }
 

--- a/grails-app/domain/org/pih/warehouse/core/LocationRole.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/LocationRole.groovy
@@ -11,17 +11,10 @@ package org.pih.warehouse.core
 
 class LocationRole implements Serializable {
     String id
-    Location location
-    Role role
+
     static mapping = {
         id generator: 'uuid'
     }
-    static belongsTo = [user: User]
-    static constraints = {
-        user(nullable: false)
-        location(nullable: false)
-        role(nullable: false)
-    }
 
-
+    static belongsTo = [location: Location, role: Role, user: User]
 }

--- a/grails-app/domain/org/pih/warehouse/core/Organization.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Organization.groovy
@@ -16,14 +16,10 @@ import org.pih.warehouse.order.OrderTypeCode
 
 class Organization extends Party {
 
-    String id
     String code
     String name
     String description
     Location defaultLocation
-
-    Date dateCreated
-    Date lastUpdated
 
     static hasMany = [locations : Location]
 

--- a/grails-app/domain/org/pih/warehouse/core/User.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/User.groovy
@@ -9,14 +9,12 @@
  * */
 package org.pih.warehouse.core
 
+import grails.converters.JSON
 import org.codehaus.groovy.grails.commons.ConfigurationHolder as CH
 import util.StringUtil
-import grails.converters.JSON
-
 
 class User extends Person {
 
-    String id
     Boolean active = false                // default = false?
     String username            // email or username
     String password            // encrypted password

--- a/grails-app/domain/org/pih/warehouse/product/Product.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/Product.groovy
@@ -266,9 +266,10 @@ class Product implements Comparable, Serializable {
         categories joinTable: [name: 'product_category', column: 'category_id', key: 'product_id']
         attributes joinTable: [name: 'product_attribute', column: 'attribute_id', key: 'product_id']
         documents joinTable: [name: 'product_document', column: 'document_id', key: 'product_id']
+        packages cascade: "all-delete-orphan"
         productGroups joinTable: [name: 'product_group_product', column: 'product_group_id', key: 'product_id']
         synonyms cascade: 'all-delete-orphan', sort: 'name'
-        productSuppliers cascade: 'all-delete-orphan'//, sort: 'dateCreated'
+        productSuppliers cascade: 'all-delete-orphan'
         productComponents cascade: "all-delete-orphan"
         color(formula: '(select max(pc.color) from product_catalog_item pci left outer join product_catalog pc on pci.product_catalog_id = pc.id where pci.product_id = id group by pci.product_id)')
     }

--- a/grails-app/domain/org/pih/warehouse/product/ProductPackage.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/ProductPackage.groovy
@@ -51,10 +51,10 @@ class ProductPackage implements Comparable<ProductPackage>, Serializable {
     User createdBy
     User updatedBy
 
-    static belongsTo = [product: Product]
-
+    static belongsTo = [product: Product, productSupplier: ProductSupplier]
     static mapping = {
         id generator: 'uuid'
+        cascade productPrice: "all-delete-orphan"
     }
 
     static constraints = {
@@ -62,11 +62,9 @@ class ProductPackage implements Comparable<ProductPackage>, Serializable {
         description(nullable: true)
         gtin(nullable: true)
         uom(nullable: true)
-        productPrice(nullable: true)
-        quantity(nullable: false)
+        productPrice(nullable: true, unique: true)
         createdBy(nullable: true)
         updatedBy(nullable: true)
-        productSupplier(nullable: true)
     }
 
     String toString() {
@@ -76,6 +74,7 @@ class ProductPackage implements Comparable<ProductPackage>, Serializable {
     /**
      * Sort by quantity
      */
+    @Override
     int compareTo(ProductPackage other) {
         return other.quantity <=> quantity
     }

--- a/grails-app/domain/org/pih/warehouse/product/ProductSupplier.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/ProductSupplier.groovy
@@ -68,21 +68,22 @@ class ProductSupplier implements Serializable, Comparable<ProductSupplier> {
 
     static hasMany = [productPackages: ProductPackage, productSupplierPreferences: ProductSupplierPreference]
 
+    static belongsTo = [product: Product, supplier: Organization]
     static mapping = {
         description type: 'text'
+        cascade productPackages: "all-delete-orphan"
+        cascade productSupplierPreferences: "all-delete-orphan"
+        cascade contractPrice: "all-delete-orphan"
     }
 
     static constraints = {
 
         code(nullable: true)
-        name(nullable: false)
         description(nullable: true)
-        product(nullable: false)
         productCode(nullable: true)
         ndc(nullable: true, maxSize: 255)
         upc(nullable: true, maxSize: 255)
 
-        supplier(nullable: true)
         supplierCode(nullable: true, maxSize: 255)
         supplierName(nullable: true, maxSize: 255)
 
@@ -97,7 +98,7 @@ class ProductSupplier implements Serializable, Comparable<ProductSupplier> {
         ratingTypeCode(nullable: true)
         comments(nullable: true)
 
-        contractPrice(nullable: true)
+        contractPrice(nullable: true, unique: true)
     }
 
     ProductPackage getDefaultProductPackage() {

--- a/grails-app/domain/org/pih/warehouse/product/ProductSupplierPreference.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/ProductSupplierPreference.groovy
@@ -36,10 +36,10 @@ class ProductSupplierPreference {
         id generator: 'uuid'
     }
 
+    static belongsTo = ProductSupplier
+
     static constraints = {
-        productSupplier(nullable: false)
         destinationParty(nullable: true, unique: ['productSupplier'])
-        preferenceType(nullable: false)
         comments(nullable: true)
         validityStartDate(nullable: true)
         validityEndDate(nullable: true)


### PR DESCRIPTION
While debugging OBS-1076 I found a number of missing/incomplete relationships between products, suppliers, locations and friends. None of these changes fixed the bug, unfortunately, but who knows, they might prevent cascade trouble in the future.