### PR TITLE
OBS-4326 Validate ProductPrice's belongsTo relationship.

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
@@ -472,20 +472,14 @@ class ProductController {
 
         if (!packageInstance) {
             packageInstance = new ProductPackage(params)
-            ProductPrice productPrice = new ProductPrice()
-            productPrice.price = parsedUnitPrice?:0
-            packageInstance.productPrice = productPrice
             productInstance.addToPackages(packageInstance)
         } else {
             packageInstance.properties = params
-            if (packageInstance.productPrice) {
-                packageInstance.productPrice.price = parsedUnitPrice?:0
-            } else if (parsedUnitPrice) {
-                ProductPrice productPrice = new ProductPrice()
-                productPrice.price = parsedUnitPrice
-                packageInstance.productPrice = productPrice
-            }
         }
+        if (parsedUnitPrice) {
+            packageInstance.createOrGetProductPrice().price = parsedUnitPrice
+        }
+
 
         if (!productInstance.hasErrors() && productInstance.save(flush: true)) {
             flash.message = "${warehouse.message(code: 'default.created.message', args: [warehouse.message(code: 'package.label', default: 'Product'), packageInstance.name])}"
@@ -1147,6 +1141,3 @@ class ProductController {
         render(view: "addDocument", model: [productInstance: productInstance, documentInstance: documentInstance])
     }
 }
-
-
-

--- a/grails-app/controllers/org/pih/warehouse/product/ProductSupplierController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductSupplierController.groovy
@@ -12,9 +12,10 @@ package org.pih.warehouse.product
 import grails.validation.ValidationException
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.PreferenceType
+import org.pih.warehouse.core.ProductPrice
+
 import java.math.RoundingMode
 import java.text.SimpleDateFormat
-import org.pih.warehouse.core.ProductPrice
 
 class ProductSupplierController {
 
@@ -110,10 +111,9 @@ class ProductSupplierController {
                 productSupplierInstance.contractPrice.price = parsedUnitPrice
                 productSupplierInstance.contractPrice.toDate = params.toDate ? dateFormat.parse(params.toDate) : null
             } else {
-                ProductPrice productPrice = new ProductPrice()
-                productPrice.price = parsedUnitPrice
-                productPrice.toDate = params.toDate ? dateFormat.parse(params.toDate) : null
-                productSupplierInstance.contractPrice = productPrice
+                ProductPrice contractPrice = productSupplierInstance.createOrGetContractPrice()
+                contractPrice.price = parsedUnitPrice
+                contractPrice.toDate = params.toDate ? dateFormat.parse(params.toDate) : null
             }
         }
 
@@ -230,10 +230,9 @@ class ProductSupplierController {
                     productSupplierInstance.contractPrice.price = parsedUnitPrice
                     productSupplierInstance.contractPrice.toDate = params.toDate ? dateFormat.parse(params.toDate) : null
                 } else {
-                    ProductPrice productPrice = new ProductPrice()
-                    productPrice.price = parsedUnitPrice
-                    productPrice.toDate = params.toDate ? dateFormat.parse(params.toDate) : null
-                    productSupplierInstance.contractPrice = productPrice
+                    ProductPrice contractPrice = productSupplierInstance.createOrGetContractPrice()
+                    contractPrice.price = parsedUnitPrice
+                    contractPrice.toDate = params.toDate ? dateFormat.parse(params.toDate) : null
                 }
             } else if (productSupplierInstance.contractPrice?.id) {
                 productSupplierInstance.contractPrice = null

--- a/grails-app/domain/org/pih/warehouse/core/ProductPrice.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/ProductPrice.groovy
@@ -53,8 +53,8 @@ class ProductPrice implements Serializable {
     static constraints = {
         type(nullable: false)
         price(nullable: false)
-        productPackage(nullable: true)
-        productSupplier(nullable: true)
+        productPackage(nullable: true, validator: { value, obj -> value || obj.productSupplier })
+        productSupplier(nullable: true, validator: { value, obj -> value || obj.productPackage })
         currency(nullable: true)
         fromDate(nullable: true)
         toDate(nullable: true)

--- a/grails-app/domain/org/pih/warehouse/product/ProductPackage.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/ProductPackage.groovy
@@ -14,7 +14,6 @@ import org.pih.warehouse.core.ProductPrice
 import org.pih.warehouse.core.UnitOfMeasure
 import org.pih.warehouse.core.User
 
-
 class ProductPackage implements Comparable<ProductPackage>, Serializable {
 
     def beforeInsert = {
@@ -71,6 +70,14 @@ class ProductPackage implements Comparable<ProductPackage>, Serializable {
 
     String toString() {
         return name
+    }
+
+    ProductPrice createOrGetProductPrice() {
+        if (!productPrice) {
+            productPrice = new ProductPrice()
+            productPrice.productPackage = this
+        }
+        return productPrice
     }
 
     /**

--- a/grails-app/domain/org/pih/warehouse/product/ProductSupplier.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/ProductSupplier.groovy
@@ -120,6 +120,14 @@ class ProductSupplier implements Serializable, Comparable<ProductSupplier> {
                         id <=> obj.id
     }
 
+    ProductPrice createOrGetContractPrice() {
+        if (!contractPrice) {
+            contractPrice = new ProductPrice()
+            contractPrice.productSupplier = this
+        }
+        return contractPrice
+    }
+
     static PROPERTIES = [
             "ID"                                  : "id",
             "Product Source Code"                 : "code",

--- a/grails-app/services/org/pih/warehouse/data/DataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/DataService.groovy
@@ -335,13 +335,8 @@ class DataService {
         productPackage.product = product
         productPackage.gtin = ""
         productPackage.uom = unitOfMeasure
-        if (!productPackage.productPrice && price) {
-            ProductPrice productPrice = new ProductPrice()
-            productPrice.price = price
-            productPrice.save()
-            productPackage.productPrice = productPrice
-        } else if (productPackage.productPrice && price) {
-            productPackage.productPrice.price = price
+        if (price) {
+            productPackage.createOrGetProductPrice().price = price
         }
         productPackage.quantity = quantity ?: 1
         productPackage = productPackage.merge()

--- a/grails-app/services/org/pih/warehouse/data/ProductSupplierDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSupplierDataService.groovy
@@ -10,10 +10,8 @@
 package org.pih.warehouse.data
 
 import groovy.sql.Sql
-import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.Organization
 import org.pih.warehouse.core.PreferenceType
-import org.pih.warehouse.core.ProductPrice
 import org.pih.warehouse.core.RatingTypeCode
 import org.pih.warehouse.core.UnitOfMeasure
 import org.pih.warehouse.importer.ImportDataCommand
@@ -186,16 +184,11 @@ class ProductSupplierDataService {
                 defaultProductPackage.product = productSupplier.product
                 defaultProductPackage.uom = unitOfMeasure
                 defaultProductPackage.quantity = quantity
-                ProductPrice productPrice = new ProductPrice()
-                productPrice.price = price
-                defaultProductPackage.productPrice = productPrice
                 productSupplier.addToProductPackages(defaultProductPackage)
-            } else if (price && !defaultProductPackage.productPrice) {
-                ProductPrice productPrice = new ProductPrice()
-                productPrice.price = price
-                defaultProductPackage.productPrice = productPrice
-            } else if (price && defaultProductPackage.productPrice) {
-                defaultProductPackage.productPrice.price = price
+            }
+
+            if (price) {
+                defaultProductPackage.createOrGetProductPrice().price = price
             }
         }
 
@@ -205,12 +198,7 @@ class ProductSupplierDataService {
         BigDecimal contractPricePrice = params.contractPricePrice ? new BigDecimal(params.contractPricePrice) : null
 
         if (contractPricePrice) {
-            if (!productSupplier.contractPrice) {
-                productSupplier.contractPrice = new ProductPrice()
-            }
-
-            productSupplier.contractPrice.price = contractPricePrice
-
+            productSupplier.createOrGetContractPrice().price = contractPricePrice
             if (contractPriceValidUntil) {
                 productSupplier.contractPrice.toDate = contractPriceValidUntil
             }

--- a/grails-app/services/org/pih/warehouse/order/OrderService.groovy
+++ b/grails-app/services/org/pih/warehouse/order/OrderService.groovy
@@ -10,7 +10,6 @@
 package org.pih.warehouse.order
 
 import grails.validation.ValidationException
-import java.math.RoundingMode
 import org.codehaus.groovy.grails.commons.ConfigurationHolder
 import org.grails.plugins.csv.CSVMapReader
 import org.hibernate.criterion.CriteriaSpecification
@@ -40,6 +39,8 @@ import org.pih.warehouse.shipping.Shipment
 import org.pih.warehouse.shipping.ShipmentException
 import org.pih.warehouse.shipping.ShipmentItem
 import util.ReportUtil
+
+import java.math.RoundingMode
 
 class OrderService {
 
@@ -550,20 +551,12 @@ class OrderService {
                 productPackage.name = "${orderItem?.quantityUom?.code}/${orderItem?.quantityPerUom as Integer}"
                 productPackage.uom = orderItem.quantityUom
                 productPackage.quantity = orderItem.quantityPerUom as Integer
-                ProductPrice productPrice = new ProductPrice()
-                productPrice.price = packagePrice
-                productPackage.productPrice = productPrice
+                productPackage.createOrGetProductPrice().price = packagePrice
                 productPackage.save()
             }
             // Otherwise update the price
             else {
-                if (productPackage.productPrice) {
-                    productPackage.productPrice.price = packagePrice
-                } else {
-                    ProductPrice productPrice = new ProductPrice()
-                    productPrice.price = packagePrice
-                    productPackage.productPrice = productPrice
-                }
+                productPackage.createOrGetProductPrice().price = packagePrice
                 productPackage.lastUpdated = new Date()
             }
             // Associate product package with order item
@@ -574,14 +567,7 @@ class OrderService {
         }
         // Otherwise we update the existing price
         else {
-            if (orderItem.productPackage.productPrice) {
-                orderItem.productPackage.productPrice.price = packagePrice
-            } else {
-                ProductPrice productPrice = new ProductPrice()
-                productPrice.price = packagePrice
-                orderItem.productPackage.productPrice = productPrice
-            }
-
+            orderItem.productPackage.createOrGetProductPrice().price = packagePrice
         }
     }
 


### PR DESCRIPTION
`ProductPrice` uses `belongsTo` in a somewhat unorthodox fashion to indicate it belongs to _either_ a `ProductSupplier` _or_ a `ProductPackage`. Thus both possible parents are `nullable: true`. This PR adds a validation on each possible parent saying it must be set if the other is null, and then updates our code to pass validation.

Note the two `createOrGet.*Price` methods:
1. I would have named them `getOrCreate.*Price` but `get.*` method names are reserved by Grails' `getByXXX` magic.
2. I have to explicitly set a back-reference in them. Normally GORM does this by itself, I'm assuming we have to do it manually because of the aforementioned nullable annotations.

See also [this PR](https://github.com/openboxes/openboxes/pull/3047) where I add cascades for ProductPrice, among other domains.