### PR TITLE
OBDS-105 + 125: Zone and Bin: Bin Table + Bin Modal

### DIFF
--- a/src/js/components/locations-configuration/AddBinModal.jsx
+++ b/src/js/components/locations-configuration/AddBinModal.jsx
@@ -25,10 +25,10 @@ class AddBinModal extends Component {
   handleSubmit(values) {
     this.props.showSpinner();
     apiClient.post('/openboxes/api/locations/', flattenRequest({ ...values, parentLocation: { id: this.props.locationId }, locationType: { id: values.locationType.id } }))
-      .then((res) => {
+      .then(() => {
         this.props.hideSpinner();
         Alert.success(this.props.translate('react.locationsConfiguration.addBin.success.label', 'Bin location has been created successfully!'), { timeout: 3000 });
-        this.props.addBinLocation(res.data.data);
+        this.props.addBinLocation();
       })
       .catch(() => {
         this.props.hideSpinner();

--- a/src/js/components/locations-configuration/AddZoneModal.jsx
+++ b/src/js/components/locations-configuration/AddZoneModal.jsx
@@ -10,6 +10,7 @@ import ModalWrapper from 'components/form-elements/ModalWrapper';
 import apiClient, { flattenRequest } from 'utils/apiClient';
 import Translate, { translateWithDefaultMessage } from 'utils/Translate';
 
+import 'components/locations-configuration/ZoneTable.scss';
 
 class AddZoneModal extends Component {
   constructor(props) {
@@ -24,10 +25,10 @@ class AddZoneModal extends Component {
   handleSubmit(values) {
     this.props.showSpinner();
     apiClient.post('/openboxes/api/locations/', flattenRequest({ ...values, parentLocation: { id: this.props.locationId }, locationType: { id: values.locationType.id } }))
-      .then((res) => {
+      .then(() => {
         this.props.hideSpinner();
         Alert.success(this.props.translate('react.locationsConfiguration.addZone.success.label', 'Zone location has been created successfully!'), { timeout: 3000 });
-        this.props.addZoneLocation(res.data.data);
+        this.props.addZoneLocation();
       })
       .catch(() => {
         this.props.hideSpinner();

--- a/src/js/components/locations-configuration/BinTable.jsx
+++ b/src/js/components/locations-configuration/BinTable.jsx
@@ -46,7 +46,7 @@ class BinTable extends Component {
       },
       {
         Header: 'Bin Type',
-        accessor: 'locationType.locationTypeCode',
+        accessor: 'locationType.name',
         className: 'cell',
         headerClassName: 'header text-align-left',
       },
@@ -100,6 +100,7 @@ class BinTable extends Component {
     return (
       <ReactTable
         data={this.props.binData}
+        ref={this.props.refBinTable}
         columns={binColumns}
         loading={this.state.binLoading}
         pages={this.state.binPages}
@@ -113,9 +114,8 @@ class BinTable extends Component {
         pageText=""
         onFetchData={(state) => {
           const offset = state.page > 0 ? (state.page) * state.pageSize : 0;
-          apiClient.get('/openboxes/api/internalLocations/search', {
+          apiClient.get('/openboxes/api/internalLocations/search?locationTypeCode=BIN_LOCATION&locationTypeCode=INTERNAL', {
             params: {
-              locationTypeCode: 'BIN_LOCATION',
               offset: `${offset}`,
               max: `${state.pageSize}`,
               'parentLocation.id': `${this.props.currentLocationId}`,
@@ -150,6 +150,10 @@ BinTable.propTypes = {
   FIELDS: PropTypes.shape({}).isRequired,
   validate: PropTypes.func.isRequired,
   binTypes: PropTypes.shape([]).isRequired,
+  refBinTable: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]).isRequired,
 };
 
 export default connect(mapStateToProps)(BinTable);

--- a/src/js/components/locations-configuration/ZoneTable.jsx
+++ b/src/js/components/locations-configuration/ZoneTable.jsx
@@ -9,6 +9,8 @@ import ModalWrapper from 'components/form-elements/ModalWrapper';
 import apiClient from 'utils/apiClient';
 import Translate, { translateWithDefaultMessage } from 'utils/Translate';
 
+import 'components/locations-configuration/ZoneTable.scss';
+
 const INITIAL_STATE = {
   zonePages: -1,
   zoneLoading: true,
@@ -100,6 +102,7 @@ class ZoneTable extends Component {
     return (
       <ReactTable
         data={this.props.zoneData}
+        ref={this.props.refZoneTable}
         columns={zoneColumns}
         loading={this.state.zoneLoading}
         pages={this.state.zonePages}
@@ -150,6 +153,10 @@ ZoneTable.propTypes = {
   FIELDS: PropTypes.shape({}).isRequired,
   validate: PropTypes.func.isRequired,
   zoneTypes: PropTypes.shape([]).isRequired,
+  refZoneTable: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]).isRequired,
 };
 
 export default connect(mapStateToProps)(ZoneTable);

--- a/src/js/components/locations-configuration/ZoneTable.scss
+++ b/src/js/components/locations-configuration/ZoneTable.scss
@@ -81,3 +81,7 @@
   margin-top: 18px;
   gap: 3px;
 }
+
+.ReactModal__Body--open {
+  overflow-y: hidden;
+}


### PR DESCRIPTION
Approved changes from QA which include:

- fixed error when adding for example 6th location and you have set 5 per page, the 6th location makes the react-table to create another page. I also improved/fixed it in reverse way - if you have one element on n-th page and you delete it, amount of pages is decremented and it automatically goes back to previous page.
- the scroll is disabled when Add Zone/Bin modal is opened (to avoid "flying select" problem)
- added INTERNAL for Bin Types.
- the Bin Type rows show the name of the Bin Type instead of locationTypeCode like before
