### PR TITLE
OBPIH-4336 - reason code issue

### DIFF
--- a/src/js/components/stock-movement-wizard/outbound/EditPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/EditPage.jsx
@@ -477,6 +477,7 @@ class EditItemsPage extends Component {
             editPageItems: _.map(data, item => ({
               ...item,
               quantityOnHand: item.quantityOnHand || 0,
+              reasonCode: this.props.reasonCodes.find(({ value }) => value === item.reasonCode),
               substitutionItems: _.map(item.substitutionItems, sub => ({
                 ...sub,
                 requisitionItemId: item.requisitionItemId,


### PR DESCRIPTION
fixed reasonCode format on stockMovementItems fetch

stockMovementItems returned reasonCode: 'STOCK_OUT'
when expected was reasonCode: { id: 'STOCK_OUT', name: 'Stock out', value: 'STOCK_OUT'}