### PR TITLE
OBPIH-4377 Use supplier code, not vendor code, when downloading order as CSV.

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/order/OrderController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/order/OrderController.groovy
@@ -571,7 +571,7 @@ class OrderController {
             csv.printRecord(
                     warehouse.message(code: 'product.productCode.label'),
                     warehouse.message(code: 'product.name.label'),
-                    warehouse.message(code: 'product.vendorCode.label'),
+                    warehouse.message(code: 'product.supplierCode.label'),
                     warehouse.message(code: 'orderItem.quantity.label'),
                     warehouse.message(code: 'product.unitOfMeasure.label'),
                     warehouse.message(code: 'orderItem.unitPrice.label'),
@@ -591,7 +591,7 @@ class OrderController {
                 csv.printRecord(
                         orderItem?.product?.productCode,
                         orderItem?.product?.name,
-                        orderItem?.product?.vendorCode,
+                        orderItem?.productSupplier?.supplierCode,
                         CSVUtils.formatInteger(number: orderItem?.quantity),
                         CSVUtils.formatUnitOfMeasure(orderItem?.quantityUom?.code, orderItem?.quantityPerUom),
                         CSVUtils.formatCurrency(number: orderItem?.unitPrice, currencyCode: orderItem?.currencyCode, isUnitPrice: true),


### PR DESCRIPTION
This column has been wrong in two different ways over time.

Before my CSV fixes, the header was "vendor code", the value was `productSupplier?.supplierCode` - header/value mismatch
When I patched CSV, the header was "vendor code", the value was `product?.vendorCode` - header/value agreed, but wasn't what was desired
Now it's "supplier code" with a value of `productSupplier?.supplierCode` - header/value agree, and the field is what's desired (I think)