### PR TITLE
OBAM-335 UI updates to ward pull/adhoc request

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -2994,6 +2994,7 @@ react.stockMovement.error.multipleOfPackSize.label=Quantity must be multiple of 
 react.stockMovement.error.noShipmentItems.label=Cannot save shipment from PO with no items
 react.stockMovement.error.expiryWithoutLot.label=Items with an expiry date must also have a lot number.
 react.stockMovement.error.lotAndExpiryControl.label=Both lot number and expiry date are required for this item.
+react.stockMovement.error.quantityOnHand.label=This field is required for each product and needs to be a positive number
 react.stockMovement.errors.reasonCodeRequired.label=Reason code required
 react.stockMovement.errors.revisedQuantityRequired.label=Revised quantity required
 react.stockMovement.errors.sameRevisedQty.label=Revised quantity can't be the same as requested quantity
@@ -3043,6 +3044,12 @@ react.stockMovement.tooltip.maxQuantity.label=QTY sent by your administrator as 
 react.stockMovement.tooltip.quantityOnHand.label=Enter your current quantity on hand for this product
 react.stockMovement.tooltip.quantityRequested.label=Your maximum quantity for the request period minus your QOH. Edit as needed.
 react.stockMovement.tooltip.comments.label=Leave a comment for the person who will review this request.
+react.stockMovement.quantityOnHand.headerTooltip.label=Enter your current quantity on hand for this product
+react.stockMovement.demandPerRequestPeriod.headerTooltip.label=The average of your previous requests for this product for a period of [stocklist request period] days for demand/month number is 30 days
+react.stockMovement.quantityRequested.headerTooltip.label=Your demand for the request period minus your QOH. Edit as needed.
+react.stockMovement.comments.headerTooltip.label=Leave a comment for the person who will review this request.
+
+
 
 react.stockMovement.enum.AvailableItemStatus.AVAILABLE=Available
 react.stockMovement.enum.AvailableItemStatus.PICKED=Picked

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -1049,3 +1049,9 @@ div.crossed-out .table-inner-row:before {
     width: 0;
   }
 }
+
+.arrayfield-header-required::after {
+  margin-left: .25rem;
+  content: "*";
+  color: red;
+}

--- a/src/js/components/form-elements/FieldArrayComponent.jsx
+++ b/src/js/components/form-elements/FieldArrayComponent.jsx
@@ -12,7 +12,6 @@ import Translate, { translateWithDefaultMessage } from 'utils/Translate';
 
 import 'react-tippy/dist/tippy.css';
 
-
 class FieldArrayComponent extends Component {
   constructor(props) {
     super(props);
@@ -129,7 +128,7 @@ class FieldArrayComponent extends Component {
                       hideDelay="50"
                     >
                       <div
-                        className={`mx-2 text-truncate ${config.required ? 'required' : ''}`}
+                        className={`mx-2 text-truncate ${config.required ? 'arrayfield-header-required' : ''}`}
                         style={{
                           fontSize: fieldsConfig.headerFontSize ? fieldsConfig.headerFontSize : '0.875rem',
                         }}

--- a/src/js/components/stock-movement-wizard/request/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/request/AddItemsPage.jsx
@@ -379,6 +379,7 @@ const REQUEST_FROM_WARD_STOCKLIST_FIELDS_PULL_TYPE = {
       product: {
         ...FIELDS.product,
         fieldKey: 'disabled',
+        flexWidth: '2',
         getDynamicAttr: ({
           fieldValue, debouncedProductsFetch, rowIndex, rowCount, newItem,
         }) => ({
@@ -387,8 +388,28 @@ const REQUEST_FROM_WARD_STOCKLIST_FIELDS_PULL_TYPE = {
           autoFocus: newItem && rowIndex === rowCount - 1,
         }),
       },
+      demandPerReplenishmentPeriod: {
+        type: LabelField,
+        label: 'react.stockMovement.demandPerRequestPeriod.label',
+        defaultMessage: 'Demand per Request Period',
+        flexWidth: '1.4',
+        headerAlign: 'right',
+        headerTooltip: 'react.stockMovement.demandPerRequestPeriod.headerTooltip.label',
+        headerDefaultTooltip: 'The average of your previous requests for this product for a period of [stocklist request period] days” for demand/month number is 30 days',
+        attributes: {
+          type: 'number',
+          className: 'text-right',
+        },
+      },
       quantityOnHand: {
         ...FIELDS.quantityOnHandAtRequestSite,
+        flexWidth: '1',
+        required: true,
+        headerTooltip: 'react.stockMovement.quantityOnHand.headerTooltip.label',
+        headerDefaultTooltip: 'Enter your current quantity on hand for this product',
+        attributes: {
+          type: 'number',
+        },
         getDynamicAttr: ({
           fieldValue, rowIndex, values, updateRow,
         }) => ({
@@ -401,9 +422,50 @@ const REQUEST_FROM_WARD_STOCKLIST_FIELDS_PULL_TYPE = {
           },
         }),
       },
-      demandPerReplenishmentPeriod: FIELDS.demandPerRequestPeriod,
-      quantityRequested: FIELDS.quantityRequested,
-      comments: FIELDS.comments,
+      quantityRequested: {
+        type: TextField,
+        label: 'react.stockMovement.neededQuantity.label',
+        defaultMessage: 'Needed Qty',
+        flexWidth: '0.6',
+        headerAlign: 'right',
+        headerTooltip: 'react.stockMovement.quantityRequested.headerTooltip.label',
+        headerDefaultTooltip: 'Your demand for the request period minus your QOH. Edit as needed.',
+        attributes: {
+          type: 'number',
+        },
+        getDynamicAttr: ({
+          rowIndex, values, updateRow,
+        }) => ({
+          onBlur: () => updateRow(values, rowIndex),
+        }),
+      },
+      comments: {
+        type: TextField,
+        label: 'react.stockMovement.comments.label',
+        defaultMessage: 'Comments',
+        flexWidth: '1.8',
+        headerAlign: 'left',
+        headerTooltip: 'react.stockMovement.comments.headerTooltip.label',
+        headerDefaultTooltip: 'Leave a comment for the person who will review this request.',
+        getDynamicAttr: ({
+          addRow, rowCount, rowIndex, getSortOrder,
+          updateTotalCount, updateRow, values,
+        }) => ({
+          onTabPress: rowCount === rowIndex + 1 ? () => {
+            updateTotalCount(1);
+            addRow({ sortOrder: getSortOrder() });
+          } : null,
+          arrowRight: rowCount === rowIndex + 1 ? () => {
+            updateTotalCount(1);
+            addRow({ sortOrder: getSortOrder() });
+          } : null,
+          arrowDown: rowCount === rowIndex + 1 ? () => () => {
+            updateTotalCount(1);
+            addRow({ sortOrder: getSortOrder() });
+          } : null,
+          onBlur: () => updateRow(values, rowIndex),
+        }),
+      },
       deleteButton: DELETE_BUTTON_FIELD,
     },
   },
@@ -416,6 +478,7 @@ const REQUEST_FROM_WARD_FIELDS = {
       product: {
         ...FIELDS.product,
         fieldKey: 'disabled',
+        flexWidth: '2',
         getDynamicAttr: ({
           debouncedProductsFetch, rowIndex, rowCount, updateProductData, values, newItem,
         }) => ({
@@ -424,8 +487,30 @@ const REQUEST_FROM_WARD_FIELDS = {
           autoFocus: newItem && rowIndex === rowCount - 1,
         }),
       },
+      monthlyDemand: {
+        type: LabelField,
+        label: 'react.stockMovement.demandPerMonth.label',
+        defaultMessage: 'Demand per Month',
+        headerAlign: 'right',
+        flexWidth: '1.5',
+        headerTooltip: 'react.stockMovement.demandPerRequestPeriod.headerTooltip.label',
+        headerDefaultTooltip: 'The average of your previous requests for this product for a period of [stocklist request period] days” for demand/month number is 30 days',
+        attributes: {
+          type: 'number',
+          className: 'text-right',
+        },
+      },
       quantityOnHand: {
-        ...FIELDS.quantityOnHandAtRequestSite,
+        type: TextField,
+        label: 'react.stockMovement.quantityOnHand.label',
+        defaultMessage: 'QOH',
+        flexWidth: '1',
+        required: true,
+        headerTooltip: 'react.stockMovement.quantityOnHand.headerTooltip.label',
+        headerDefaultTooltip: 'Enter your current quantity on hand for this product',
+        attributes: {
+          type: 'number',
+        },
         getDynamicAttr: ({
           fieldValue, rowIndex, values, updateRow,
         }) => ({
@@ -438,9 +523,50 @@ const REQUEST_FROM_WARD_FIELDS = {
           },
         }),
       },
-      monthlyDemand: FIELDS.monthlyDemand,
-      quantityRequested: FIELDS.quantityRequested,
-      comments: FIELDS.comments,
+      quantityRequested: {
+        type: TextField,
+        label: 'react.stockMovement.neededQuantity.label',
+        defaultMessage: 'Needed Qty',
+        flexWidth: '1',
+        headerAlign: 'right',
+        headerTooltip: 'react.stockMovement.quantityRequested.headerTooltip.label',
+        headerDefaultTooltip: 'Your demand for the request period minus your QOH. Edit as needed.',
+        attributes: {
+          type: 'number',
+        },
+        getDynamicAttr: ({
+          rowIndex, values, updateRow,
+        }) => ({
+          onBlur: () => updateRow(values, rowIndex),
+        }),
+      },
+      comments: {
+        type: TextField,
+        label: 'react.stockMovement.comments.label',
+        defaultMessage: 'Comments',
+        flexWidth: '3',
+        headerAlign: 'left',
+        headerTooltip: 'react.stockMovement.comments.headerTooltip.label',
+        headerDefaultTooltip: 'Leave a comment for the person who will review this request.',
+        getDynamicAttr: ({
+          addRow, rowCount, rowIndex, getSortOrder,
+          updateTotalCount, updateRow, values,
+        }) => ({
+          onTabPress: rowCount === rowIndex + 1 ? () => {
+            updateTotalCount(1);
+            addRow({ sortOrder: getSortOrder() });
+          } : null,
+          arrowRight: rowCount === rowIndex + 1 ? () => {
+            updateTotalCount(1);
+            addRow({ sortOrder: getSortOrder() });
+          } : null,
+          arrowDown: rowCount === rowIndex + 1 ? () => () => {
+            updateTotalCount(1);
+            addRow({ sortOrder: getSortOrder() });
+          } : null,
+          onBlur: () => updateRow(values, rowIndex),
+        }),
+      },
       deleteButton: DELETE_BUTTON_FIELD,
     },
   },
@@ -617,9 +743,9 @@ class AddItemsPage extends Component {
 
           return {
             ...val,
+            quantityOnHand: '',
             disabled: true,
             quantityRequested: qtyRequested >= 0 ? qtyRequested : 0,
-            quantityOnHand: isPullType ? quantityOnHand : undefined,
             product: {
               ...val.product,
               label: `${val.productCode} ${val.product.name}`,
@@ -715,6 +841,14 @@ class AddItemsPage extends Component {
       const dateRequested = moment(item.expirationDate, 'MM/DD/YYYY');
       if (date.diff(dateRequested) > 0) {
         errors.lineItems[key] = { expirationDate: 'react.stockMovement.error.invalidDate.label' };
+      }
+
+      if (this.state.isRequestFromWard) {
+        const isNumeric = n => !Number.isNaN(parseInt(n, 10));
+        const isPositive = n => isNumeric(n) && n >= 0;
+        if (!item.quantityOnHand || !isPositive(item.quantityOnHand)) {
+          errors.lineItems[key] = { quantityOnHand: 'react.stockMovement.error.quantityOnHand.label' };
+        }
       }
     });
     return errors;
@@ -1268,7 +1402,7 @@ class AddItemsPage extends Component {
                 lineItems: {
                   [index]: {
                     product: { $set: product },
-                    quantityOnHand: { $set: response.data.quantityOnHand || 0 },
+                    quantityOnHand: { $set: '' },
                     monthlyDemand: { $set: monthlyDemand },
                     quantityRequested: { $set: quantityRequested >= 0 ? quantityRequested : 0 },
                   },

--- a/src/js/components/stock-movement-wizard/request/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/request/AddItemsPage.jsx
@@ -844,7 +844,7 @@ class AddItemsPage extends Component {
       }
 
       if (this.state.isRequestFromWard) {
-        if (!item.quantityOnHand || !(item.quantityOnHand >= 0)) {
+        if (!item.quantityOnHand || item.quantityOnHand < 0) {
           errors.lineItems[key] = { quantityOnHand: 'react.stockMovement.error.quantityOnHand.label' };
         }
       }

--- a/src/js/components/stock-movement-wizard/request/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/request/AddItemsPage.jsx
@@ -844,9 +844,7 @@ class AddItemsPage extends Component {
       }
 
       if (this.state.isRequestFromWard) {
-        const isNumeric = n => !Number.isNaN(parseInt(n, 10));
-        const isPositive = n => isNumeric(n) && n >= 0;
-        if (!item.quantityOnHand || !isPositive(item.quantityOnHand)) {
+        if (!item.quantityOnHand || !(item.quantityOnHand >= 0)) {
           errors.lineItems[key] = { quantityOnHand: 'react.stockMovement.error.quantityOnHand.label' };
         }
       }


### PR DESCRIPTION
I spent a long time trying to figure out how to make the red asterisk for header - the same asterisk which is visible for "regular" fields with required: true. It was supposedly made and was used in many components (talking about fields, which have another nestled fields inside (ArrayField)), but it did not really work with current version, so even though it was used in many places, the asterisk didn't work.
With my changes, the red asterisk for headers are now "generic", which means they can be used anywhere (and will now finally work in places, where it was previously declared (e.g. stock-movement/combined-shipments/AddItemsPage.jsx) and many others, so I hope my changes will also improve other wizards.
