### PR TITLE
OBAM-365 Order of items is changing when jump between tabs on view in…

### DIFF
--- a/grails-app/domain/org/pih/warehouse/shipping/Shipment.groovy
+++ b/grails-app/domain/org/pih/warehouse/shipping/Shipment.groovy
@@ -272,7 +272,12 @@ class Shipment implements Comparable, Serializable {
                     a?.container?.parentContainer?.sortOrder <=> b?.container?.parentContainer?.sortOrder ?:
                             a?.container?.sortOrder <=> b?.container?.sortOrder ?:
                                     a?.requisitionItem?.orderIndex <=> b?.requisitionItem?.orderIndex ?:
-                                            a?.sortOrder <=> b?.sortOrder
+                                            a?.sortOrder <=> b?.sortOrder ?:
+                                                    a?.inventoryItem?.product?.name <=> b?.inventoryItem?.product?.name ?:
+                                                            a?.inventoryItem?.lotNumber <=> b?.inventoryItem?.lotNumber ?:
+                                                                    a?.product?.name <=> b?.product?.name ?:
+                                                                            a?.lotNumber <=> b?.lotNumber ?:
+                                                                                    b?.quantity <=> a?.quantity
             return sortOrder
         }
 


### PR DESCRIPTION
…bound return page

The problem there I think was that the container is usually null, so it didn't have any comparison inside `sortShipmentItemsBySortOrder()` method which would always work. It seemed like it actually didn't sort at all, because every property of a product which was considered in `sortShipmentItemsBySortOrder()` was null, so it was just refetching list of items randomly.
My preposition was just to add some properties to sort which would always compare, e.g. sorting by product name - it is simply taken from previous method `sortShipmentItems()` so I would read it like that - if you can compare BySortOrder - do it, but if no, then sort it by e.g. product name, so the order will stay the same no matter how many times you refetch the list of items.
