### PR TITLE
OBPIH-4404 Improvements after QA

### DIFF
--- a/src/js/components/stock-movement-wizard/combined-shipments/SendMovementPage.jsx
+++ b/src/js/components/stock-movement-wizard/combined-shipments/SendMovementPage.jsx
@@ -553,7 +553,7 @@ class SendMovementPage extends Component {
         'You are not able to send shipment from a location other than origin. Change your current location.',
       ));
       this.props.hideSpinner();
-    } else if (values.shipmentType.id === _.find(this.state.shipmentTypes, shipmentType => shipmentType.label === 'Default').value) {
+    } else if (values.shipmentType.id === _.find(this.state.shipmentTypes, shipmentType => shipmentType.label === 'Default').id) {
       Alert.error(this.props.translate(
         'react.stockMovement.alert.populateShipmentType.label',
         'Please populate shipment type before continuing',

--- a/src/js/components/stock-movement-wizard/inbound/SendMovementPage.jsx
+++ b/src/js/components/stock-movement-wizard/inbound/SendMovementPage.jsx
@@ -546,7 +546,7 @@ class SendMovementPage extends Component {
         'You are not able to send shipment from a location other than origin. Change your current location.',
       ));
       this.props.hideSpinner();
-    } else if (values.shipmentType.id === _.find(this.state.shipmentTypes, shipmentType => shipmentType.label === 'Default').value) {
+    } else if (values.shipmentType.id === _.find(this.state.shipmentTypes, shipmentType => shipmentType.label === 'Default').id) {
       Alert.error(this.props.translate(
         'react.stockMovement.alert.populateShipmentType.label',
         'Please populate shipment type before continuing',

--- a/src/js/components/stock-movement-wizard/outbound/SendMovementPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/SendMovementPage.jsx
@@ -599,7 +599,7 @@ class SendMovementPage extends Component {
         'You are not able to send shipment from a location other than origin. Change your current location.',
       ));
       this.props.hideSpinner();
-    } else if (values.shipmentType.id === _.find(this.state.shipmentTypes, shipmentType => shipmentType.label === 'Default').value) {
+    } else if (values.shipmentType.id === _.find(this.state.shipmentTypes, shipmentType => shipmentType.label === 'Default').id) {
       Alert.error(this.props.translate(
         'react.stockMovement.alert.populateShipmentType.label',
         'Please populate shipment type before continuing',


### PR DESCRIPTION
The problem there was not actually a fault of mine while dealing with the task, but with the validation - as a default, the `shipmentType` as a value being sent to validation was simply a string "5".
When changing to any other option, the `shipmentType` becomes an object (which is good) with id, name etc.
Why did the validation work if you tried to send shipment without changing the shipment type?
In this line:  
```
else if (values.shipmentType.id === _.find(this.state.shipmentTypes, shipmentType => shipmentType.label === 'Default').value)
```
it was unexpectedly true, because:
1. `values.shipmentType.id` is `undefined` (because values.shipmentType is a string "5", not an object)
2. `shipmentTypes` fetched from api don't have property `.value` so it was also `undefined`, so `undefined` === `undefined`.

To make this not work, you can just try to switch `shipmentType` from Default to any other and then again to Default, and the validation wouldn't work, because THEN it would find `values.shipmentType.id` propely as "5" but the second part would still be `undefined`, as `shipmentTypes` from api don't have property `.value` - "5" !== undefined.

My changes "destroyed" the validation, because the `shipmentType` immediately became the object with id, name etc which anyway would happen if you changed the `shipmentType`, so in a nutshell the problem was with the initialValue of shipmentType.
