### PR TITLE
OBPIH-4433 Shipment type does not save for inbound/outboud returns

### DIFF
--- a/src/groovy/org/pih/warehouse/api/StockTransfer.groovy
+++ b/src/groovy/org/pih/warehouse/api/StockTransfer.groovy
@@ -118,7 +118,7 @@ class StockTransfer {
                 type                : type?.code,
                 dateShipped         : dateShipped?.format("MM/dd/yyyy") ?: "",
                 expectedDeliveryDate: expectedDeliveryDate?.format("MM/dd/yyyy") ?: "",
-                shipmentType        : shipmentType?.id ?: "",
+                shipmentType        : shipmentType ?: "",
                 trackingNumber      : trackingNumber ?: "",
                 driverName          : driverName ?: "",
                 comments            : comments ?: "",

--- a/src/js/components/returns/inbound/SendInboundReturn.jsx
+++ b/src/js/components/returns/inbound/SendInboundReturn.jsx
@@ -19,6 +19,7 @@ import TextField from 'components/form-elements/TextField';
 import apiClient, { flattenRequest, parseResponse } from 'utils/apiClient';
 import { renderFormField } from 'utils/form-utils';
 import Translate, { translateWithDefaultMessage } from 'utils/Translate';
+import splitTranslation from 'utils/translation-utils';
 
 import 'react-confirm-alert/src/react-confirm-alert.css';
 
@@ -199,13 +200,12 @@ class SendMovementPage extends Component {
 
   fetchShipmentTypes() {
     const url = '/openboxes/api/generic/shipmentType';
-
     return apiClient.get(url)
       .then((response) => {
         const shipmentTypes = _.map(response.data.data, (type) => {
           const [en, fr] = _.split(type.name, '|fr:');
           return {
-            value: type.id,
+            ...type,
             label: this.props.locale === 'fr' && fr ? fr : en,
           };
         });
@@ -226,7 +226,13 @@ class SendMovementPage extends Component {
         const inboundReturn = parseResponse(resp.data.data);
         this.setState({
           values: {
-            inboundReturn,
+            inboundReturn: {
+              ...inboundReturn,
+              shipmentType: {
+                ...inboundReturn.shipmentType,
+                label: splitTranslation(inboundReturn.shipmentType.name, this.props.locale),
+              },
+            },
           },
         }, () => this.fetchShipmentTypes());
       })
@@ -261,7 +267,6 @@ class SendMovementPage extends Component {
         ...values,
       };
       const url = `/openboxes/api/stockTransfers/${this.props.match.params.inboundReturnId}/sendShipment`;
-
       this.saveValues(payload)
         .then(() => {
           apiClient.post(url, flattenRequest(payload))

--- a/src/js/components/returns/outbound/SendOutboundReturn.jsx
+++ b/src/js/components/returns/outbound/SendOutboundReturn.jsx
@@ -19,6 +19,7 @@ import TextField from 'components/form-elements/TextField';
 import apiClient, { flattenRequest, parseResponse } from 'utils/apiClient';
 import { renderFormField } from 'utils/form-utils';
 import Translate, { translateWithDefaultMessage } from 'utils/Translate';
+import splitTranslation from 'utils/translation-utils';
 
 import 'react-confirm-alert/src/react-confirm-alert.css';
 
@@ -220,8 +221,8 @@ class SendMovementPage extends Component {
         const shipmentTypes = _.map(response.data.data, (type) => {
           const [en, fr] = _.split(type.name, '|fr:');
           return {
-            id: type.id,
-            name: this.props.locale === 'fr' && fr ? fr : en,
+            ...type,
+            label: this.props.locale === 'fr' && fr ? fr : en,
           };
         });
 
@@ -245,6 +246,10 @@ class SendMovementPage extends Component {
             outboundReturn: {
               ...outboundReturn,
               picklistItems,
+              shipmentType: {
+                ...outboundReturn.shipmentType,
+                label: splitTranslation(outboundReturn.shipmentType.name, this.props.locale),
+              },
             },
           },
         }, () => this.fetchShipmentTypes());


### PR DESCRIPTION
Additionally, even though it was not the case of the ticket I fixed another issue which would appear, that is save&exit stuff - without that additional fix you would be able to Send shipment and the shipmentType would be correctly added, but when save&exiting it still wouldn't work - what I mean by that is when e.g. you chose shipmentType "Sea" and saved, on view page it would be "Sea" as expected, but if you tried to edit the return and wouldn't change the shipmentType (it would appear as "Sea") and submited the shipment, it would again be Default.
