### PR TITLE
OBGM-325 Remove image-builder plugin and simplify thumbnail code.

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
@@ -13,8 +13,8 @@ import com.google.zxing.BarcodeFormat
 import grails.converters.JSON
 import grails.gorm.transactions.Transactional
 import grails.validation.ValidationException
-import org.apache.commons.io.FilenameUtils
 import grails.web.context.ServletContextHolder
+import org.apache.commons.io.FilenameUtils
 import org.hibernate.Criteria
 import org.pih.warehouse.core.Document
 import org.pih.warehouse.core.Location
@@ -632,7 +632,7 @@ class ProductController {
     }
 
     def downloadDocument() {
-        log.info "viewImage: " + params
+        log.info 'downloadDocument: {}', params
         def documentInstance = Document.get(params.id)
         if (documentInstance) {
             response.setHeader "Content-disposition", "attachment;filename=\"${documentInstance.filename}\""
@@ -642,41 +642,12 @@ class ProductController {
         }
     }
 
-    /**
-     * View document
-     */
-    def viewImage() {
-        log.info "viewImage: " + params
-        def documentInstance = Document.get(params.id)
-        if (documentInstance) {
-            if (documentInstance.isImage()) {
-                documentService.scaleImage(documentInstance, response.outputStream, '300px', '300px')
-            } else {
-                // Strip out the most common mime type tree names
-                def documentType = documentInstance.contentType.minus("application/").minus("image/").minus("text/")
-                def servletContext = ServletContextHolder.servletContext
-                def imageContent = servletContext.getResource("/images/icons/${documentType}.png")
-                if (!imageContent) {
-                    imageContent = servletContext.getResource('/images/icons/silk/page.png')
-                }
-                response.contentType = 'image/png'
-                response.outputStream << imageContent.bytes
-                response.outputStream.flush()
-
-
-            }
-        } else {
-            response.sendError(404)
-        }
-    }
-
-
     def viewThumbnail() {
-        log.info "viewThumbnail: " + params
+        log.info 'viewThumbnail: {}', params
         def documentInstance = Document.get(params.id)
         if (documentInstance) {
             if (documentInstance.isImage()) {
-                documentService.scaleImage(documentInstance, response.outputStream, '100px', '100px')
+                documentService.scaleImage(documentInstance, response.outputStream, 200, 200)
             } else if (documentInstance.fileUri) {
                 def imageContent = servletContext.getResource("/images/icons/silk/link.png")
                 response.contentType = 'image/png'
@@ -1127,6 +1098,3 @@ class ProductController {
         render(view: "addDocument", model: [productInstance: productInstance, documentInstance: documentInstance])
     }
 }
-
-
-

--- a/grails-app/domain/org/pih/warehouse/product/Product.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/Product.groovy
@@ -13,7 +13,6 @@ import org.apache.commons.collections.FactoryUtils
 import org.apache.commons.collections.list.LazyList
 import org.apache.commons.lang.NotImplementedException
 import org.grails.plugins.web.taglib.ApplicationTagLib
-import org.hibernate.Criteria
 import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.Document
 import org.pih.warehouse.core.GlAccount
@@ -345,7 +344,7 @@ class Product implements Comparable, Serializable {
      *
      * @return
      */
-    Collection getImages() {
+    Collection<Document> getImages() {
         return documents?.findAll { it.contentType.startsWith("image") }
     }
 
@@ -355,7 +354,7 @@ class Product implements Comparable, Serializable {
      * @return
      */
     Document getThumbnail() {
-        return this?.images ? this.images?.sort()?.first() : null
+        return this.images?.sort({ it?.dateCreated })?.first()
     }
 
     /**
@@ -684,4 +683,3 @@ class Product implements Comparable, Serializable {
         ]
     }
 }
-

--- a/grails-app/services/org/pih/warehouse/core/DocumentService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/DocumentService.groovy
@@ -10,6 +10,8 @@
 package org.pih.warehouse.core
 
 import grails.core.GrailsApplication
+import grails.util.Holders
+import org.apache.commons.io.FilenameUtils
 import org.apache.poi.hssf.usermodel.HSSFSheet
 import org.apache.poi.hssf.usermodel.HSSFWorkbook
 import org.apache.poi.ss.usermodel.Cell
@@ -20,8 +22,6 @@ import org.apache.poi.ss.usermodel.Row
 import org.apache.poi.ss.usermodel.Sheet
 import org.apache.poi.ss.usermodel.Workbook
 import org.apache.poi.ss.util.CellRangeAddress
-import grails.util.Holders
-import org.hibernate.criterion.CriteriaSpecification
 import org.docx4j.TextUtils
 import org.docx4j.XmlUtils
 import org.docx4j.convert.out.pdf.PdfConversion
@@ -30,7 +30,6 @@ import org.docx4j.jaxb.Context
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage
 import org.docx4j.openpackaging.parts.WordprocessingML.MainDocumentPart
 import org.docx4j.openpackaging.parts.relationships.Namespaces
-import org.docx4j.wml.Body
 import org.docx4j.wml.BooleanDefaultTrue
 import org.docx4j.wml.Document
 import org.docx4j.wml.P
@@ -40,13 +39,11 @@ import org.docx4j.wml.Tbl
 import org.docx4j.wml.TblGrid
 import org.docx4j.wml.TblGridCol
 import org.docx4j.wml.TblPr
-import org.docx4j.wml.TblWidth
 import org.docx4j.wml.Tc
-import org.docx4j.wml.TcPr
 import org.docx4j.wml.Text
 import org.docx4j.wml.Tr
 import org.docx4j.wml.TrPr
-//import org.groovydev.SimpleImageBuilder
+import org.hibernate.criterion.CriteriaSpecification
 import org.pih.warehouse.api.Stocklist
 import org.pih.warehouse.order.Order
 import org.pih.warehouse.order.OrderType
@@ -57,7 +54,10 @@ import org.pih.warehouse.requisition.RequisitionItemSortByCode
 import org.pih.warehouse.shipping.ReferenceNumber
 import org.pih.warehouse.shipping.Shipment
 
+import javax.imageio.ImageIO
 import javax.xml.bind.JAXBException
+import java.awt.Image
+import java.awt.image.BufferedImage
 import java.text.DecimalFormat
 import java.text.SimpleDateFormat
 
@@ -74,48 +74,41 @@ class DocumentService {
         return grailsApplication.mainContext.getBean('org.pih.warehouse.FormatTagLib')
     }
 
-
-    File writeImage(Document document) {
-        File file
+    /**
+     * Render `document` to `outputStream` so it fits in a box of `width` x `height`.
+     *
+     * If the supplied image already fits within the box, don't change it.
+     *
+     * For best results on a hiDPI display, set `width` and `height` to 2x or 3x
+     * the desired size, then use the nailthumb jquery plugin to place the image.
+     */
+    void scaleImage(org.pih.warehouse.core.Document document, OutputStream outputStream, int width, int height) {
+        log.info "Scale image ${document.filename} width=${width} height=${height} contentType=${document.contentType}"
         try {
-            file = new File(document.filename)
-            println "Attempt to write to " + file?.absolutePath
-            FileOutputStream fos = new FileOutputStream(file)
-            fos << document?.fileContents
-            fos.close()
-        } catch (Exception e) {
-            log.error("Error occurred while writing file " + document.filename, e)
-        }
-        return file
-    }
+            final formatName = (document.extension ?: FilenameUtils.getExtension(document.filename))?.toLowerCase()
+            final original = ImageIO.read(new ByteArrayInputStream(document?.fileContents))
+            final scalingFactor = Math.min(width / (original.width as float), height / (original.height as float))
 
-
-    void scaleImage(Document document, OutputStream outputStream, String width, String height) {
-
-        log.info("Scale image " + document.filename + " width=" + width + " height=" + height + " contentType=" + document.contentType)
-        File file
-        FileInputStream fileInputStream
-        try {
-            file = writeImage(document)
-            def extension = document.extension ?: document.filename.substring(document.filename.lastIndexOf(".") + 1)
-            log.info "Scale image " + document.filename + " (" + width + ", " + height + "), format=" + extension
-            fileInputStream = new FileInputStream(file)
-//            def builder = new SimpleImageBuilder()
-//            if (builder) {
-//                def result = builder.image(stream: fileInputStream) {
-//                    fit(width: width, height: height) {
-//                        save(stream: outputStream, format: extension?.toLowerCase())
+            if (scalingFactor >= 1) {
+                log.debug "Existing dimensions suffice: width=${original.width} height=${original.height}"
+                ImageIO.write(original, formatName, outputStream)
+            } else {
+                final thumbnail = original.getScaledInstance(
+                    Math.floor(scalingFactor * original.width) as int,
+                    Math.floor(scalingFactor * original.height) as int,
+                    Image.SCALE_SMOOTH)
+                final result = new BufferedImage(
+                    thumbnail.getWidth(null),
+                    thumbnail.getHeight(null),
+                    original.type)
+                result.graphics.drawImage(thumbnail, 0, 0, null)
 //                    }
-//                }
+                log.debug "Scaled contentType=${document.contentType} to width=${result.width} height=${result.height}"
 //            } else {
-//                log.warn("Unable to scale image " + document.filename + " (" + width + ", " + height + "), format=" + extension)
-//            }
-
+                ImageIO.write(result, formatName, outputStream)
+            }
         } catch (Exception e) {
-            log.warn("Error scaling image " + document?.filename + ": " + e.message, e)
-        } finally {
-            if (fileInputStream) fileInputStream?.close()
-            if (file) file?.delete()
+            log.warn("Error scaling image ${document?.filename}: ${e.message}", e)
         }
     }
 

--- a/grails-app/views/inventory/_browseProduct.gsp
+++ b/grails-app/views/inventory/_browseProduct.gsp
@@ -4,8 +4,8 @@
 	<td>
 		<g:if test="${inventoryItem?.product?.images }">
 			<div class="nailthumb-container">
-				<g:set var="image" value="${inventoryItem?.product?.images?.sort()?.first()}"/>
-				<img src="${createLink(controller:'product', action:'renderImage', id:image.id)}" style="display:none" />
+				<g:set var="image" value="${inventoryItem?.product?.thumbnail}" />
+				<img src="${createLink(controller: 'product', action: 'viewThumbnail', id: image.id)}" style="display:none" />
 			</div>
 		</g:if>
 		<g:else>
@@ -17,8 +17,7 @@
 	<td>
 		<div class="action-menu hover">
 			<button class="action-btn">
-				<img
-					src="${resource(dir: 'images/icons/silk', file: 'bullet_arrow_down.png')}"
+				<img src="${resource(dir: 'images/icons/silk', file: 'bullet_arrow_down.png')}"
 					style="vertical-align: middle" />
 			</button>
 			<div class="actions left">
@@ -28,8 +27,8 @@
 							<td style="width: 100px;" class="center middle">
 								<g:if test="${inventoryItem?.product?.images }">
 									<div class="nailthumb-container-100">
-										<g:set var="image" value="${inventoryItem?.product?.images?.sort()?.first()}"/>
-										<img src="${createLink(controller:'product', action:'renderImage', id:image.id)}" style="display:none" />
+										<g:set var="image" value="${inventoryItem?.product?.thumbnail}" />
+										<img src="${createLink(controller: 'product', action: 'viewThumbnail', id: image.id)}" style="display:none" />
 									</div>
 								</g:if>
 								<g:else>

--- a/grails-app/views/inventory/browse.gsp
+++ b/grails-app/views/inventory/browse.gsp
@@ -96,8 +96,8 @@
 														<td>
 															<g:if test="${searchResult?.product?.images }">
 															   <div class="nailthumb-container">
-																   <g:set var="image" value="${searchResult?.product?.images?.sort()?.first()}"/>
-																   <img src="${resource(controller:'product', action:'renderImage', id:image.id)}" style="display:none" />
+																   <g:set var="image" value="${searchResult?.product?.thumbnail}" />
+																   <img src="${createLink(controller: 'product', action: 'viewThumbnail', id: image.id)}" style="display:none" />
 															   </div>
 														   </g:if>
 														   <g:else>

--- a/grails-app/views/mobile/productDetails.gsp
+++ b/grails-app/views/mobile/productDetails.gsp
@@ -24,7 +24,7 @@
 
             <picture>
                 <g:if test="${product.images}">
-                    <g:set var="image" value="${product?.images?.sort()?.first()}"/>
+                    <g:set var="image" value="${product?.thumbnail}" />
                     <img src="${createLink(controller:'product', action:'renderImage', id:image?.id)}" class="img-fluid"/>
                 </g:if>
                 <g:else>

--- a/grails-app/views/mobile/productList.gsp
+++ b/grails-app/views/mobile/productList.gsp
@@ -17,7 +17,7 @@
                         <picture>
                             <a href="${createLink(controller: 'mobile', action: 'productDetails', id: product?.id)}" class="text-decoration-none">
                                 <g:if test="${product.images}">
-                                    <g:set var="image" value="${product?.images?.sort()?.first()}"/>
+                                    <g:set var="image" value="${product?.thumbnail}" />
                                     <img src="${createLink(controller:'product', action:'renderImage', id:image?.id)}" class="img-fluid"/>
                                 </g:if>
                                 <g:else>

--- a/grails-app/views/product/_documents.gsp
+++ b/grails-app/views/product/_documents.gsp
@@ -1,3 +1,16 @@
+<style>
+/* add a thin border around document thumbnails */
+.nailthumb-document .nailthumb-image {
+    border: 1px solid lightgrey;
+    margin: 2px;
+    padding: 2px !important;
+}
+
+/* prevent nailthumb's CSS from truncating document thumbnail borders */
+.nailthumb-document .nailthumb-container {
+    overflow: visible !important;
+}
+</style>
 
 <div class="box">
     <h2>
@@ -30,10 +43,13 @@
             <g:each var="document" in="${productInstance?.documents.findAll { !it.fileUri } }" status="i">
                 <tr class="prop ${i%2?'even':'odd' }" >
                     <td>
-                        <g:link controller="product" action="downloadDocument" id="${document?.id}" params="['product.id':productInstance?.id]" target="_blank">
-                            <img src="${createLink(controller:'product', action:'viewThumbnail', id:document.id)}"
-                                 class="middle" style="padding: 2px; margin: 2px; border: 1px solid lightgrey;" />
-                        </g:link>
+                        <div class="nailthumb-document">
+                            <g:link controller="product" action="downloadDocument" id="${document?.id}"
+                                    params="['product.id': productInstance?.id]" target="_blank">
+                                <img src="${createLink(controller: 'product', action: 'viewThumbnail', id: document.id)}"
+                                     class="middle" />
+                            </g:link>
+                        </div>
                     </td>
                     <td>
                         <g:link controller="product" action="downloadDocument" id="${document?.id}" params="['product.id':productInstance?.id]" target="_blank">
@@ -74,8 +90,10 @@
                 <g:each var="document" in="${productInstance?.documents.findAll { it.fileUri } }" status="i">
                     <tr class="prop ${i%2?'even':'odd' }" >
                         <td>
-                            <img src="${createLink(controller:'product', action:'viewThumbnail', id:document.id)}"
-                                 class="middle" style="padding: 2px; margin: 2px; border: 1px solid lightgrey;" />
+                            <div class="nailthumb-document">
+                                <img src="${createLink(controller: 'product', action: 'viewThumbnail', id: document.id)}"
+                                    class="middle" />
+                            </div>
                         </td>
                         <td>
                             <a href="${document.fileUri}" target="_blank">
@@ -160,3 +178,14 @@
         </table>
     </g:uploadForm>
 </div>
+<script>
+  $(function () {
+    $('.nailthumb-document img').hide();
+    $('.nailthumb-document img').nailthumb({
+        width: 100,
+        height: 100,
+        method: 'resize',
+        replaceAnimation: null
+    });
+  });
+</script>

--- a/grails-app/views/product/_summary.gsp
+++ b/grails-app/views/product/_summary.gsp
@@ -6,8 +6,8 @@
 				<td class="middle" style="width: 1%;">
                     <g:if test="${productInstance?.images }">
                         <div class="nailthumb-product">
-                            <g:set var="image" value="${productInstance?.images?.sort()?.first()}"/>
-                            <img src="${createLink(controller:'product', action:'renderImage', id:image.id)}" style="display:none" />
+                            <g:set var="image" value="${productInstance?.thumbnail}" />
+                            <img src="${createLink(controller:'product', action:'viewThumbnail', id:image.id)}" style="display:none" />
                         </div>
                     </g:if>
                     <g:else>
@@ -124,8 +124,8 @@
     </table>
 </div>
 <script>
-    $(function() {
-        $('.nailthumb-product img').hide();
-        $('.nailthumb-product img').nailthumb({width : 40, height : 40});
-    });
+	$(function () {
+		$('.nailthumb-product img').hide();
+		$('.nailthumb-product img').nailthumb({ width: 40, height: 40, replaceAnimation: null });
+	});
 </script>

--- a/grails-app/views/product/_summaryDialog.gsp
+++ b/grails-app/views/product/_summaryDialog.gsp
@@ -6,8 +6,9 @@
 				<td class="middle" style="width: 1%;">
                     <g:if test="${productInstance?.images }">
                         <div class="nailthumb-product">
-                            <g:set var="image" value="${productInstance?.images?.sort()?.first()}"/>
-                            <img src="${createLink(controller:'product', action:'renderImage', id:image.id)}" style="display:none" />
+                            <g:set var="image" value="${productInstance?.thumbnail}" />
+                            <img src="${createLink(controller: 'product', action: 'viewThumbnail', id: image.id)}"
+                                 style="display:none" />
                         </div>
                     </g:if>
                     <g:else>

--- a/grails-app/views/requisition/printDraft.gsp
+++ b/grails-app/views/requisition/printDraft.gsp
@@ -99,8 +99,8 @@
                         <td>
 							<g:if test="${requisitionItem?.product?.images }">
 								<div class="nailthumb-container">
-									<g:set var="image" value="${requisitionItem?.product?.images?.sort()?.first()}"/>
-									<img src="${createLink(controller:'product', action:'renderImage', id:image.id)}" />
+									<g:set var="image" value="${requisitionItem?.product?.thumbnail}" />
+									<img src="${createLink(controller: 'product', action: 'viewThumbnail', id: image.id)}" />
 								</div>
 							</g:if>
 							<g:else>


### PR DESCRIPTION
This PR primarily removes a deprecated grails plugin by refactoring `scaleImage()`. It also correctly renders thumbnails on HiDPI screens, reduces inefficiencies when sending images to `nailthumb`, and makes `Product.getThumbnail()` work deterministically.