### PR TITLE
OBPIH-3776 Add download orders option

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -1510,6 +1510,7 @@ order.destination.label=Destination
 order.destination.validator.organization.required=Destination organization is required
 order.destinationParty.label=Purchasing Organization
 order.downloadOrderLineDetails.label=Download order line details
+order.downloadOrders=Download orders
 order.editDetails.label=Edit order
 order.editItems.label=Edit line items
 order.enterOrderDetails.label=Enter order

--- a/grails-app/views/order/_filters.gsp
+++ b/grails-app/views/order/_filters.gsp
@@ -133,10 +133,27 @@
                 <button type="submit" class="button icon search" name="search" value="true">
                     <warehouse:message code="default.search.label"/>
                 </button>
-                <button name="format" value="csv" class="button">
-                    <img src="${resource(dir: 'images/icons/silk', file: 'page_excel.png')}" />&nbsp;
-                    <warehouse:message code="order.downloadOrderLineDetails.label" default="Download order line details"/>
-                </button>
+                <span class="action-menu" style="margin-left: 15px">
+                    <button class="action-btn button">
+                        <img src="${createLinkTo(dir:'images/icons/silk',file:'page_white_excel.png')}" />&nbsp;
+                    ${warehouse.message(code: 'default.button.download.label')}
+                        <img src="${resource(dir: 'images/icons/silk', file: 'bullet_arrow_down.png')}" />
+                    </button>
+                    <div class="actions">
+                        <div class="action-menu-item download-subbuttons">
+                            <button name="format" value="csv">
+                                <img src="${resource(dir: 'images/icons/silk', file: 'page_white_excel.png')}" />
+                                <warehouse:message code="order.downloadOrderLineDetails.label" default="Download order line details"/>
+                            </button>
+                        </div>
+                        <div class="action-menu-item download-subbuttons">
+                            <button name="downloadOrders" value="csv">
+                                <img src="${resource(dir: 'images/icons/silk', file: 'page_white_excel.png')}" />
+                                <warehouse:message code="order.downloadOrders" default="Download orders"/>
+                            </button>
+                        </div>
+                    </div>
+                </span>
                 <g:link controller="order" action="list" class="button icon reload">
                     <warehouse:message code="default.button.cancel.label"/>
                 </g:link>

--- a/web-app/css/openboxes.css
+++ b/web-app/css/openboxes.css
@@ -1054,6 +1054,23 @@ button.action-btn, button.previous, button.next {
     padding: 5px;
     text-decoration: none;
 }
+.actions .download-subbuttons button {
+    all: unset;
+    display: block;
+    padding: 5px;
+    font-weight: normal;
+    color: #666;
+    font-size: 0.9em;
+    font: 11px "lucida grande", verdana, arial, helvetica, sans-serif;
+    line-height: 12px;
+    text-align: left;
+}
+
+.actions .download-subbuttons:hover {
+    display: block;
+    background-color: lightgrey;
+    text-decoration: none;
+}
 
 /* Flow Header */
 .currentState { font-weight: bold; background-color: #eee; color: blue; }


### PR DESCRIPTION
I was struggling with finding a way how to propely round the `order.total `and `order.totalNormalized` so it looks in the .csv as in the table of list orders - I hope that rounding it to 2 decimal places as in the table was a good approach. 
I was also thinking whether I should download all orders (obviously with applied filter, but what I mean is that if there are 4 pages, the 4 pages are downloaded at one time) or only those visible at the moment (10 rows) in the table should be downloaded, but I kept the approach of already done report which is "Download order line details" where all rows are downloaded. 