### PR TITLE
OBPIH-4477 Data not in the right columns in reorder report

### DIFF
--- a/grails-app/services/org/pih/warehouse/forecasting/ForecastingService.groovy
+++ b/grails-app/services/org/pih/warehouse/forecasting/ForecastingService.groovy
@@ -48,7 +48,7 @@ class ForecastingService {
                 totalDemand  : totalDemand,
                 totalDays    : demandPeriod,
                 dailyDemand  : dailyDemand,
-                monthlyDemand: new BigDecimal(totalDemand / Math.floor((demandPeriod / 30))).setScale(0, RoundingMode.HALF_UP),
+                monthlyDemand: new BigDecimal(monthlyDemand).setScale(0, RoundingMode.HALF_UP),
                 onHandMonths : onHandMonths
             ]
         }

--- a/grails-app/services/org/pih/warehouse/forecasting/ForecastingService.groovy
+++ b/grails-app/services/org/pih/warehouse/forecasting/ForecastingService.groovy
@@ -16,6 +16,7 @@ import org.pih.warehouse.product.Category
 import org.pih.warehouse.product.Product
 import org.pih.warehouse.util.DateUtil
 
+import java.math.RoundingMode
 import java.sql.Timestamp
 import java.text.DateFormatSymbols
 import java.text.NumberFormat
@@ -43,12 +44,11 @@ class ForecastingService {
             def monthlyDemand = totalDemand / Math.floor((demandPeriod / 30))
             def quantityOnHand = productAvailabilityService.getQuantityOnHand(product, origin)
             def onHandMonths = monthlyDemand ? quantityOnHand / monthlyDemand : 0
-
             return [
                 totalDemand  : totalDemand,
                 totalDays    : demandPeriod,
                 dailyDemand  : dailyDemand,
-                monthlyDemand: "${NumberFormat.getIntegerInstance().format(monthlyDemand)}",
+                monthlyDemand: new BigDecimal(totalDemand / Math.floor((demandPeriod / 30))).setScale(0, RoundingMode.HALF_UP),
                 onHandMonths : onHandMonths
             ]
         }


### PR DESCRIPTION
It seemed to be a pretty easy fix, but at first I made changes to `def monthlyDemand` like this:

```
def monthlyDemand = new BigDecimal(totalDemand / Math.floor((demandPeriod / 30))).setScale(0, RoundingMode.HALF_UP)
```
and in the return in **monthlyDemand** section I just wrote: **monthlyDemand: monthlyDemand**, but in turned out that it worked well in reports, but the stock card's "On hand months" calculation was destroyed with that version, so what made it not destroying the `"On hand months"` was to copy what is in the `def monthlyDemand` inside return directly. Don't know what the reason is, because anyway it should return the same (we just don't call the method from above, but assign the value directly).
I attach two screenshots to show the difference in `"On hand months"` that I was mentioning. Anyway the changes I provided in the end shouldn't "destroy" anything now.
[https://i.imgur.com/wbkmOKT.png](url)
[https://i.imgur.com/tfGOg9R.png](url)