### PR TITLE
OBPIH-4461 Add view for OrderItem derived status

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/order/OrderController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/order/OrderController.groovy
@@ -1094,4 +1094,20 @@ class OrderController {
         def orderSummaryList = orderService.getOrderSummaryList(params)
         render(view: "orderSummaryList", model: [orderSummaryList: orderSummaryList ?: []], params: params)
     }
+
+    // For testing order item derived status feature. orderItemSummary action gets the data from extended SQL view
+    def orderItemSummary = {
+        params.max = params.max?:10
+        params.offset = params.offset?:0
+        def orderItemSummaryList = orderService.getOrderItemSummaryList(params)
+        render(view: "orderItemSummaryList", model: [orderItemSummaryList: orderItemSummaryList ?: [], actionName: "orderItemSummary"], params: params)
+    }
+
+    // For testing order item derived status feature. orderItemDetails action gets the data from simplified SQL view
+    def orderItemDetails = {
+        params.max = params.max?:10
+        params.offset = params.offset?:0
+        def orderItemDetailsList = orderService.getOrderItemDetailsList(params)
+        render(view: "orderItemSummaryList", model: [orderItemSummaryList: orderItemDetailsList ?: []], actionName: "orderItemDetails", params: params)
+    }
 }

--- a/grails-app/domain/org/pih/warehouse/order/OrderItemDetails.groovy
+++ b/grails-app/domain/org/pih/warehouse/order/OrderItemDetails.groovy
@@ -1,0 +1,91 @@
+package org.pih.warehouse.order
+
+import org.pih.warehouse.core.UnitOfMeasure
+import org.pih.warehouse.product.Product
+
+class OrderItemDetails implements Serializable {
+    String id
+    OrderItem orderItem
+    Order order
+    String orderNumber
+    Product product
+    Integer quantity
+    String orderItemStatus
+    UnitOfMeasure quantityUom
+    BigDecimal quantityPerUom = 1
+    BigDecimal unitPrice
+
+    static mapping = {
+        id generator: 'uuid'
+        version false
+        cache usage: "read-only"
+    }
+
+    static constraints = {
+        id(nullable: true)
+        order(nullable: true)
+        orderNumber(nullable: true)
+        product(nullable: true)
+        quantity(nullable: true)
+        orderItemStatus(nullable: true)
+        quantityUom(nullable: true)
+        quantityPerUom(nullable: true)
+        unitPrice(nullable: true)
+    }
+
+    static transients = ['quantityOrdered', 'quantityShipped', 'quantityReceived', 'quantityInvoiced', 'derivedStatus']
+
+    def getQuantityOrdered() {
+        return quantity * (quantityPerUom as Integer) // * qtyPerUom for comparison with quantity shipped
+    }
+
+    def getQuantityShipped() {
+        return orderItem.shipmentItems*.quantity?.sum() ?: 0
+    }
+
+    def getQuantityReceived() {
+        return orderItem.shipmentItems*.receiptItems*.quantityReceived?.sum()?.sum() ?: 0
+    }
+
+    def getQuantityInvoiced() {
+        return orderItem.invoiceItems*.quantity?.sum() ?: 0
+    }
+
+    OrderSummaryStatus getDerivedStatus() {
+        if (quantityInvoiced >= quantityOrdered) {
+            return OrderSummaryStatus.INVOICED
+        } else if (quantityInvoiced > 0) {
+            return OrderSummaryStatus.PARTIALLY_INVOICED
+        } else if (quantityReceived >= quantityOrdered) {
+            return OrderSummaryStatus.RECEIVED
+        } else if (quantityReceived > 0) {
+            return OrderSummaryStatus.PARTIALLY_INVOICED
+        } else if (quantityShipped >= quantityOrdered) {
+            return OrderSummaryStatus.SHIPPED
+        } else if (quantityShipped > 0) {
+            return OrderSummaryStatus.PARTIALLY_SHIPPED
+        }
+
+        return order?.status?.name() as OrderSummaryStatus ?: OrderSummaryStatus.PENDING
+    }
+
+    Map toJson() {
+        return [
+            id                      : id,
+            "product.id"            : product?.id,
+            "product.productCode"   : product?.productCode,
+            "product.name"          : product?.name,
+            orderNumber             : orderNumber,
+            quantity                : quantity,
+            orderItemStatus         : orderItemStatus,
+            quantityUom             : quantityUom,
+            quantityPerUom          : quantityPerUom,
+            unitPrice               : unitPrice,
+            quantityOrdered         : quantityOrdered,
+            quantityShipped         : quantityShipped,
+            quantityReceived        : quantityReceived,
+            quantityInvoiced        : quantityInvoiced,
+            derivedStatus           : derivedStatus
+        ]
+    }
+}

--- a/grails-app/domain/org/pih/warehouse/order/OrderItemSummary.groovy
+++ b/grails-app/domain/org/pih/warehouse/order/OrderItemSummary.groovy
@@ -1,0 +1,66 @@
+package org.pih.warehouse.order
+
+import org.pih.warehouse.core.UnitOfMeasure
+import org.pih.warehouse.product.Product
+import org.pih.warehouse.shipping.ShipmentItem
+
+class OrderItemSummary implements Serializable {
+    String id
+    Order order
+    String orderNumber
+    Product product
+    Integer quantity
+    String orderItemStatus
+    UnitOfMeasure quantityUom
+    BigDecimal quantityPerUom = 1
+    BigDecimal unitPrice
+
+    Integer quantityOrdered
+    Integer quantityShipped
+    Integer quantityReceived
+    Integer quantityInvoiced
+    String derivedStatus
+
+    static mapping = {
+        id generator: 'uuid'
+        version false
+        cache usage: "read-only"
+    }
+
+    static constraints = {
+        id(nullable: true)
+        order(nullable: true)
+        orderNumber(nullable: true)
+        product(nullable: true)
+        quantity(nullable: true)
+        orderItemStatus(nullable: true)
+        quantityUom(nullable: true)
+        quantityPerUom(nullable: true)
+        unitPrice(nullable: true)
+        quantityOrdered(nullable: true)
+        quantityShipped(nullable: true)
+        quantityReceived(nullable: true)
+        quantityInvoiced(nullable: true)
+        derivedStatus(nullable: true)
+    }
+
+    Map toJson() {
+        return [
+            id                      : id,
+            "product.id"            : product?.id,
+            "product.productCode"   : product?.productCode,
+            "product.name"          : product?.name,
+            orderNumber             : orderNumber,
+            quantity                : quantity,
+            orderItemStatus         : orderItemStatus,
+            quantityUom             : quantityUom,
+            quantityPerUom          : quantityPerUom,
+            unitPrice               : unitPrice,
+            quantityOrdered         : quantityOrdered,
+            quantityShipped         : quantityShipped,
+            quantityReceived        : quantityReceived,
+            quantityInvoiced        : quantityInvoiced,
+            derivedStatus           : derivedStatus
+        ]
+    }
+}

--- a/grails-app/migrations/views/changelog.xml
+++ b/grails-app/migrations/views/changelog.xml
@@ -88,4 +88,7 @@
   <changeSet id="1580848680306-29" author="awalkowiak" runOnChange="true" runAlways="true" failOnError="true">
     <sqlFile path="views/stock-movement-list-item.sql"/>
   </changeSet>
+  <changeSet id="1580848680306-30" author="awalkowiak" runOnChange="true" runAlways="true" failOnError="true">
+    <sqlFile path="views/order-item-details.sql"/>
+  </changeSet>
 </databaseChangeLog>

--- a/grails-app/migrations/views/order-item-details.sql
+++ b/grails-app/migrations/views/order-item-details.sql
@@ -1,0 +1,16 @@
+CREATE OR REPLACE VIEW order_item_details AS (
+    SELECT
+        o_i.id AS id,
+        o_i.id AS order_item_id,
+        o.id AS order_id,
+        o.order_number AS order_number,
+        o_i.product_id AS product_id,
+        o_i.quantity AS quantity,
+        o_i.order_item_status_code AS order_item_status,
+        quantity_uom_id,
+        quantity_per_uom,
+        unit_price
+    FROM order_item o_i
+        JOIN `order` o ON o.id = o_i.order_id
+    WHERE o.order_type_id = 'PURCHASE_ORDER' AND o_i.order_item_status_code != 'CANCELLED'
+);

--- a/grails-app/services/org/pih/warehouse/order/OrderService.groovy
+++ b/grails-app/services/org/pih/warehouse/order/OrderService.groovy
@@ -963,6 +963,25 @@ class OrderService {
         }
     }
 
+    def getOrderItemSummaryList(Map params) {
+        return OrderItemSummary.createCriteria().list(params) {
+            if (params.orderNumber) {
+                ilike("orderNumber", "%${params.orderNumber}%")
+            }
+            if (params.derivedStatus) {
+                'in'("derivedStatus", params.derivedStatus)
+            }
+        }
+    }
+
+    def getOrderItemDetailsList(Map params) {
+        return OrderItemDetails.createCriteria().list(params) {
+            if (params.orderNumber) {
+                ilike("orderNumber", "%${params.orderNumber}%")
+            }
+        }
+    }
+
     List<OrderItem> getOrderItemsForPriceHistory(Organization supplierOrganization, Product productInstance, String query) {
         def terms = "%" + query + "%"
         def orderItems = OrderItem.createCriteria().list() {

--- a/grails-app/views/order/_orderItemSummaryFilters.gsp
+++ b/grails-app/views/order/_orderItemSummaryFilters.gsp
@@ -1,0 +1,34 @@
+<%@ page import="org.pih.warehouse.core.ActivityCode; org.pih.warehouse.order.OrderTypeCode" %>
+<div class="box">
+    <h2><warehouse:message code="default.filters.label"/></h2>
+    <g:form id="listForm" action="${actionName}" method="GET">
+        <g:hiddenField name="max" value="${params.max ?: 10}"/>
+        <div class="filter-list">
+            <div class="filter-list-item">
+                <label>${warehouse.message(code: 'default.orderNumber.label', default: "Order Number")}</label>
+                <g:textField class="text" id="orderNumber" name="orderNumber" value="${params.orderNumber}" style="width:100%" placeholder="Search by order number"/>
+
+            </div>
+            <div class="filter-list-item">
+                <label>${warehouse.message(code: 'order.derivedStatus.label', default: "Derived Status")}</label>
+                <g:select id="derivedStatus"
+                          name="derivedStatus"
+                          from="${org.pih.warehouse.order.OrderSummaryStatus.derivedStatuses()}"
+                          class="select2"
+                          optionValue="${{ format.metadata(obj: it) }}"
+                          value="${params.derivedStatus}"
+                          noSelection="['': '']"
+                          multiple="true"
+                />
+            </div>
+            <div class="filter-list-item buttons center">
+                <button type="submit" class="button icon search" name="search" value="true">
+                    <warehouse:message code="default.search.label"/>
+                </button>
+                <g:link controller="order" action="${actionName}" class="button icon reload">
+                    <warehouse:message code="default.button.cancel.label"/>
+                </g:link>
+            </div>
+        </div>
+    </g:form>
+</div>

--- a/grails-app/views/order/orderItemSummaryList.gsp
+++ b/grails-app/views/order/orderItemSummaryList.gsp
@@ -1,0 +1,92 @@
+<%@ page import="org.pih.warehouse.order.OrderItemStatusCode; org.pih.warehouse.order.OrderTypeCode" %>
+<html>
+	<head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <meta name="layout" content="custom" />
+		<g:set var="entityName" value="${warehouse.message(code: 'orderItemSummary.label', default: 'Order Item Summary')}" />
+        <title><warehouse:message code="default.list.label" args="[entityName]" /></title>
+   	</head>
+	<body>
+		<div class="body">
+			<div class="yui-gf">
+				<div class="yui-u first">
+					<g:render template="orderItemSummaryFilters" model="[actionName: actionName]"/>
+				</div>
+				<div class="yui-u">
+
+					<div class="box">
+						<h2>
+							<warehouse:message code="default.list.label" args="[entityName]" />
+						</h2>
+						<table>
+							<thead>
+								<tr>
+									<th>${warehouse.message(code: 'default.orderItemId.label', default: "Order Item ID")}</th>
+									<th>${warehouse.message(code: 'default.orderNumber.label', default: "Order Number")}</th>
+									<th>${warehouse.message(code: 'default.productCode.label', default: "Product Code")}</th>
+									<th>${warehouse.message(code: 'default.orderStatus.label', default: "Order Item Status")}</th>
+									<th>${warehouse.message(code: 'default.quantityOrdered.label', default: "Quantity Ordered")}</th>
+									<th>${warehouse.message(code: 'default.quantityShipped.label', default: "Quantity Shipped")}</th>
+									<th>${warehouse.message(code: 'default.quantityReceived.label', default: "Quantity Received")}</th>
+									<th>${warehouse.message(code: 'default.quantityInvoiced.label', default: "Quantity Invoiced")}</th>
+									<th>${warehouse.message(code: 'default.derivedStatus.label', default: "Derived Status")}</th>
+								</tr>
+							</thead>
+							<tbody>
+								<g:unless test="${orderItemSummaryList}">
+									<tr class="prop">
+										<td colspan="15">
+											<div class="empty fade center">
+												<warehouse:message code="orders.none.message"/>
+											</div>
+										</td>
+									</tr>
+								</g:unless>
+
+								<g:each var="orderItemSummary" in="${orderItemSummaryList}" status="i">
+
+									<tr class="${(i % 2) == 0 ? 'even' : 'odd'}">
+										<td class="middle">
+											${orderItemSummary.id}
+										</td>
+										<td class="middle">
+											<g:link controller="order" action="show" id="${orderItemSummary?.order?.id}">
+												${orderItemSummary.orderNumber}
+											</g:link>
+										</td>
+										<td class="middle">
+											${orderItemSummary.product.productCode}
+										</td>
+										<td class="middle">
+											${orderItemSummary.orderItemStatus}
+										</td>
+										<td class="middle">
+											${orderItemSummary.quantityOrdered}
+										</td>
+										<td class="middle">
+											${orderItemSummary.quantityShipped}
+										</td>
+										<td class="middle">
+											${orderItemSummary.quantityReceived}
+										</td>
+										<td class="middle">
+											${orderItemSummary.quantityInvoiced}
+										</td>
+										<td class="middle">
+											${orderItemSummary.derivedStatus}
+										</td>
+									</tr>
+								</g:each>
+							</tbody>
+						</table>
+						<div class="paginateButtons">
+							<g:set var="pageParams" value="${pageScope.variables['params']}"/>
+							<g:paginate total="${orderItemSummaryList?.totalCount?:0}" params="${params}"/>
+						</div>
+					</div>
+				</div>
+
+			</div>
+		</div>
+    </body>
+</html>


### PR DESCRIPTION
I added two views. First one order_item_summary "extended" with more JOINs, based on the already existing views related to the Order derived status (inside the order-summary-view.sql). The other one order_item_details is a bit simplified. There is option to check tables with results from both views on the '(...)/openboxes/order/orderItemSummaryList' and on the '(...)/openboxes/order/orderItemDetailsList'. The key difference between those two is that we won't be able do an extensive filtering on the simplified one, where on the list from the order_item_summary view we can basically filter on every field we have there. After performance testing/comparison we can decide which option we want to be there and the other one will be removed.