### PR TITLE
OBPIH-4451 Issue with user permissions in location chooser

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/api/LocationApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/LocationApiController.groovy
@@ -15,6 +15,7 @@ import org.codehaus.groovy.grails.web.json.JSONObject
 import org.hibernate.Criteria
 import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.Location
+import org.pih.warehouse.core.LocationRole
 import org.pih.warehouse.core.LocationType
 import org.pih.warehouse.core.RoleType
 import org.pih.warehouse.core.User
@@ -50,10 +51,23 @@ class LocationApiController extends BaseDomainApiController {
         boolean isSuperuser = userService.isSuperuser(session?.user)
         String direction = params?.direction
         def fields = params.fields ? params.fields.split(",") : null
-        def locations
+        def locations = new HashSet()
         def isRequestor = userService.isUserRequestor(currentUser)
         def inRoleBrowser = userService.isUserInRole(currentUser, RoleType.ROLE_BROWSER)
         def requestorInAnyLocation = userService.hasRoleRequestorInAnyLocations(currentUser)
+        def inRoleAssistant = userService.isUserInRole(currentUser, RoleType.ROLE_ASSISTANT)
+        def inRoleManager = userService.isUserInRole(currentUser, RoleType.ROLE_MANAGER)
+        def inRoleAdmin = userService.isUserInRole(currentUser, RoleType.ROLE_ADMIN)
+        def inRoleSuperuser = userService.isUserInRole(currentUser, RoleType.ROLE_SUPERUSER)
+
+        def requiredRoles = [
+                RoleType.ROLE_ASSISTANT,
+                RoleType.ROLE_MANAGER,
+                RoleType.ROLE_ADMIN,
+                RoleType.ROLE_SUPERUSER,
+                RoleType.ROLE_BROWSER
+        ]
+
 
         if (params.locationChooser && isRequestor && !currentUser.locationRoles && !inRoleBrowser) {
             locations = locationService.getLocations(null, null)
@@ -61,13 +75,23 @@ class LocationApiController extends BaseDomainApiController {
         } else if (params.locationChooser && requestorInAnyLocation && inRoleBrowser) {
             locations = locationService.getRequestorLocations(currentUser)
             locations += locationService.getLocations(fields, params, isSuperuser, direction, currentLocation, currentUser)
-        } else if (params.locationChooser && requestorInAnyLocation) {
-            locations = locationService.getRequestorLocations(currentUser)
         } else {
-            locations = locationService.getLocations(fields, params, isSuperuser, direction, currentLocation, currentUser)
+            if (params.locationChooser && requestorInAnyLocation) {
+                locations += locationService.getRequestorLocations(currentUser)
+            }
+            // If a user doesn't have at least one of the requiredRoles by default, get locations where the user HAS any of those roles
+            if (params.locationChooser && !inRoleBrowser && !inRoleAssistant && !inRoleManager && !inRoleAdmin && !inRoleSuperuser) {
+                currentUser.locationRoles.each { LocationRole locationRole ->
+                    if (requiredRoles.contains(locationRole.role.roleType)) {
+                        locations += locationRole.location
+                    }
+                }
+            } else {
+                locations += locationService.getLocations(fields, params, isSuperuser, direction, currentLocation, currentUser)
+            }
         }
         render ([data:locations] as JSON)
-     }
+    }
 
 
     def productSummary = {

--- a/grails-app/controllers/org/pih/warehouse/api/LocationApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/LocationApiController.groovy
@@ -60,13 +60,7 @@ class LocationApiController extends BaseDomainApiController {
         def inRoleAdmin = userService.isUserInRole(currentUser, RoleType.ROLE_ADMIN)
         def inRoleSuperuser = userService.isUserInRole(currentUser, RoleType.ROLE_SUPERUSER)
 
-        def requiredRoles = [
-                RoleType.ROLE_ASSISTANT,
-                RoleType.ROLE_MANAGER,
-                RoleType.ROLE_ADMIN,
-                RoleType.ROLE_SUPERUSER,
-                RoleType.ROLE_BROWSER
-        ]
+        def requiredRoles = RoleType.listRoleTypesForLocationChooser()
 
 
         if (params.locationChooser && isRequestor && !currentUser.locationRoles && !inRoleBrowser) {

--- a/grails-app/services/org/pih/warehouse/core/LocationService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/LocationService.groovy
@@ -257,13 +257,7 @@ class LocationService {
         def inRoleAdmin = userService.isUserInRole(user, RoleType.ROLE_ADMIN)
         def inRoleSuperuser = userService.isUserInRole(user, RoleType.ROLE_SUPERUSER)
 
-        def requiredRoles = [
-                RoleType.ROLE_ASSISTANT,
-                RoleType.ROLE_MANAGER,
-                RoleType.ROLE_ADMIN,
-                RoleType.ROLE_SUPERUSER,
-                RoleType.ROLE_BROWSER
-        ]
+        def requiredRoles = RoleType.listRoleTypesForLocationChooser()
 
         if (isRequestor && !user.locationRoles && !inRoleBrowser) {
             locations = getLocations(null, null)

--- a/grails-app/services/org/pih/warehouse/core/LocationService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/LocationService.groovy
@@ -247,11 +247,23 @@ class LocationService {
     Map getLoginLocationsMap(User user, Location currentLocation) {
         log.info "Get login locations for user ${user} and location ${currentLocation})"
         def locationMap = [:]
-        def locations
+        def locations = new HashSet()
         def nullHigh = new NullComparator(true)
         def isRequestor = userService.isUserRequestor(user)
         def inRoleBrowser = userService.isUserInRole(user, RoleType.ROLE_BROWSER)
         def requestorInAnyLocation = userService.hasRoleRequestorInAnyLocations(user)
+        def inRoleAssistant = userService.isUserInRole(user, RoleType.ROLE_ASSISTANT)
+        def inRoleManager = userService.isUserInRole(user, RoleType.ROLE_MANAGER)
+        def inRoleAdmin = userService.isUserInRole(user, RoleType.ROLE_ADMIN)
+        def inRoleSuperuser = userService.isUserInRole(user, RoleType.ROLE_SUPERUSER)
+
+        def requiredRoles = [
+                RoleType.ROLE_ASSISTANT,
+                RoleType.ROLE_MANAGER,
+                RoleType.ROLE_ADMIN,
+                RoleType.ROLE_SUPERUSER,
+                RoleType.ROLE_BROWSER
+        ]
 
         if (isRequestor && !user.locationRoles && !inRoleBrowser) {
             locations = getLocations(null, null)
@@ -259,11 +271,22 @@ class LocationService {
         } else if (requestorInAnyLocation && inRoleBrowser) {
             locations = getRequestorLocations(user)
             locations += getLoginLocations(currentLocation)
-        } else if (requestorInAnyLocation) {
-            locations = getRequestorLocations(user)
         } else {
-            locations = getLoginLocations(currentLocation)
+            if (requestorInAnyLocation) {
+                locations += getRequestorLocations(user)
+            }
+            // If a user doesn't have at least one of the requiredRoles by default, get locations where the user HAS any of those roles
+            if (!inRoleBrowser && !inRoleAssistant && !inRoleManager && !inRoleAdmin && !inRoleSuperuser) {
+                user.locationRoles.each { LocationRole locationRole ->
+                    if (requiredRoles.contains(locationRole.role.roleType)) {
+                        locations += locationRole.location
+                    }
+                }
+            } else {
+                locations += getLoginLocations(currentLocation)
+            }
         }
+
         if (locations) {
             locations = locations.collect { Location location ->
                 [

--- a/src/groovy/org/pih/warehouse/core/RoleType.groovy
+++ b/src/groovy/org/pih/warehouse/core/RoleType.groovy
@@ -178,4 +178,14 @@ enum RoleType {
                 ROLE_REQUESTOR,
         ]
     }
+
+    static listRoleTypesForLocationChooser() {
+        return [
+                ROLE_ASSISTANT,
+                ROLE_MANAGER,
+                ROLE_ADMIN,
+                ROLE_SUPERUSER,
+                ROLE_BROWSER
+        ]
+    }
 }


### PR DESCRIPTION
There are a lot of combinations of user/location permissions both user default permissions and location-based. I tested a bunch of them and it seemed to be working fine - if a user doesn't have any default permissions and doesn't have any location-based permissions, none locations are visible and if a user doesn't have any default permissions which were pointed out in the ticket, but has that permission in any location - that location is visible.
Worth pointing out is the fact that I had to be switching between develop branch and release branch to be able to edit a user, because while trying to edit the user on release branch I was getting an ugly error: 
```
"Exception Message: No enum constant org.pih.warehouse.core.RoleType.ROLE_PRODUCT_MANAGER "
```
It is probably due to the fact, that it was implemented on develop and wasn't implemented on release, but I have it in my database and it gives the error.

You might ask why I removed `else if (params.locationChooser && requestorInAnyLocation)` and have put it inside else - it's because if I had a requestor role in a location and had additionaly some other permissions to any other locations, it wouldn't show those locations, because the if would stop at that else if and wouldn't go further where the other locations would be loaded, so my thought was to put in inside else to make sure, that that case is covered.

