### PR TITLE
OBPIH-4440 Add item search to PO view page

### DIFF
--- a/grails-app/views/order/_itemDetails.gsp
+++ b/grails-app/views/order/_itemDetails.gsp
@@ -1,80 +1,122 @@
 <%@ page import="org.pih.warehouse.order.OrderItemStatusCode" %>
 <%@ page import="org.pih.warehouse.order.OrderType" %>
 <%@ page import="org.pih.warehouse.order.OrderTypeCode" %>
-<div id="tab-content" class="box">
-    <h2>
-        <warehouse:message code="order.itemDetails.label" default="Item Details"/>
-    </h2>
-    <g:if test="${orderInstance?.orderItems }">
-        <table class="table table-bordered">
-            <thead>
-            <tr class="odd">
-                <th><warehouse:message code="product.productCode.label" /></th>
-                <th><warehouse:message code="product.label" /></th>
-                <th class="center"><warehouse:message code="product.supplierCode.label"/></th>
-                <th class="center"><warehouse:message code="product.manufacturer.label"/></th>
-                <th class="center"><warehouse:message code="product.manufacturerCode.label"/></th>
-                <th class="center"><warehouse:message code="orderItem.quantity.label"/></th>
-                <th class="center"><warehouse:message code="product.uom.label"/></th>
-                <th class="center"><warehouse:message code="orderItem.recipient.label"/></th>
-                <th class="center"><warehouse:message code="orderItem.estimatedReadyDate.label"/></th>
-                <th class="center"><warehouse:message code="orderItem.actualReadyDate.label"/></th>
-                <th class="center"><warehouse:message code="orderItem.budgetCode.label"/></th>
-            </tr>
-            </thead>
-            <tbody>
-            <g:each var="orderItem" in="${orderInstance?.orderItems?.sort { a,b -> a.dateCreated <=> b.dateCreated ?: a.orderIndex <=> b.orderIndex }}" status="i">
-                <g:set var="isItemCanceled" value="${orderItem.orderItemStatusCode == OrderItemStatusCode.CANCELED}"/>
-                <g:if test="${!isItemCanceled || orderInstance?.orderType==OrderType.findByCode(OrderTypeCode.PURCHASE_ORDER.name())}">
-                    <tr class="order-item ${(i % 2) == 0 ? 'even' : 'odd'}" style="${isItemCanceled ? 'background-color: #ffcccb;' : ''}">
-                        <td>
-                            ${orderItem?.product?.productCode?:""}
-                        </td>
-                        <td class="order-item-product">
-                            <g:link controller="inventoryItem" action="showStockCard" params="['product.id':orderItem?.product?.id]">
-                                <format:product product="${orderItem?.product}"/>
-                                <g:renderHandlingIcons product="${orderItem?.product}" />
-                            </g:link>
-                        </td>
-                        <g:if test="${!isItemCanceled}">
-                            <td class="center">
-                                ${orderItem?.productSupplier?.supplierCode}
-                            </td>
-                            <td class="center">
-                                ${orderItem?.productSupplier?.manufacturerName}
-                            </td>
-                            <td class="center">
-                                ${orderItem?.productSupplier?.manufacturerCode}
-                            </td>
-                            <td class="center">
-                                ${orderItem?.quantity }
-                            </td>
-                            <td class="center">
-                                ${orderItem?.unitOfMeasure}
-                            </td>
-                            <td class="center">
-                                ${orderItem?.recipient}
-                            </td>
-                            <td class="center">
-                                <g:formatDate date="${orderItem?.estimatedReadyDate}" format="dd/MMM/yyyy"/>
-                            </td>
-                            <td class="center">
-                                <g:formatDate date="${orderItem?.actualReadyDate}" format="dd/MMM/yyyy"/>
-                            </td>
-                            <td class="center">
-                                ${orderItem?.budgetCode?.code}
-                            </td>
-                        </g:if>
-                        <g:else>
-                            <td colspan="9"></td>
-                        </g:else>
-                    </tr>
-                </g:if>
-            </g:each>
-            </tbody>
-        </table>
+<%@ page import="org.pih.warehouse.core.Constants;" %>
+
+
+<script>
+  $(document).ready(function() {
+    $("#orderItemsDetailsFilter").keyup(function(event){
+      const filterCell = 1; // product name
+      const filterValue = $("#orderItemsDetailsFilter")
+        .val()
+        .toUpperCase();
+      filterTableItemDetails(filterCell, filterValue)
+    });
+
+  });
+  function filterTableItemDetails(cellIndex, filterValue) {
+    const tableRows = $("#order-items-details tr.dataRowItemDetails");
+    // Loop through all table rows, and hide those who don't match the search query
+    $.each(tableRows, function(index, currentRow) {
+      // If filter matches text value then we display, otherwise hide
+      const txtValue = $(currentRow)
+        .find("td")
+        .eq(cellIndex)
+        .text();
+      if (txtValue.toUpperCase().indexOf(filterValue) > -1) {
+        $(currentRow).show();
+      } else {
+        $(currentRow).hide();
+      }
+    });
+  }
+</script>
+
+<div class="item-details-table">
+    <g:if test="${orderInstance.orderType != OrderType.findByCode(Constants.PUTAWAY_ORDER)}">
+        <div class="filters-container">
+            <label class="name"><warehouse:message code="inventory.filterByProduct.label"/></label>
+            <div>
+                <input type="text" id="orderItemsDetailsFilter" class="text large" placeholder="Filter by product name"/>
+            </div>
+        </div>
     </g:if>
-    <g:else>
-        <div class="fade center empty"><warehouse:message code="default.noItems.label" /></div>
-    </g:else>
+    <div id="tab-content" class="box">
+        <h2>
+            <warehouse:message code="order.itemDetails.label" default="Item Details"/>
+        </h2>
+        <g:if test="${orderInstance?.orderItems }">
+            <table class="table table-bordered" id="order-items-details">
+                <thead>
+                <tr class="odd">
+                    <th><warehouse:message code="product.productCode.label" /></th>
+                    <th><warehouse:message code="product.label" /></th>
+                    <th class="center"><warehouse:message code="product.supplierCode.label"/></th>
+                    <th class="center"><warehouse:message code="product.manufacturer.label"/></th>
+                    <th class="center"><warehouse:message code="product.manufacturerCode.label"/></th>
+                    <th class="center"><warehouse:message code="orderItem.quantity.label"/></th>
+                    <th class="center"><warehouse:message code="product.uom.label"/></th>
+                    <th class="center"><warehouse:message code="orderItem.recipient.label"/></th>
+                    <th class="center"><warehouse:message code="orderItem.estimatedReadyDate.label"/></th>
+                    <th class="center"><warehouse:message code="orderItem.actualReadyDate.label"/></th>
+                    <th class="center"><warehouse:message code="orderItem.budgetCode.label"/></th>
+                </tr>
+                </thead>
+                <tbody>
+                <g:each var="orderItem" in="${orderInstance?.orderItems?.sort { a,b -> a.dateCreated <=> b.dateCreated ?: a.orderIndex <=> b.orderIndex }}" status="i">
+                    <g:set var="isItemCanceled" value="${orderItem.orderItemStatusCode == OrderItemStatusCode.CANCELED}"/>
+                    <g:if test="${!isItemCanceled || orderInstance?.orderType==OrderType.findByCode(OrderTypeCode.PURCHASE_ORDER.name())}">
+                        <tr class="order-item ${(i % 2) == 0 ? 'even' : 'odd'} dataRowItemDetails" style="${isItemCanceled ? 'background-color: #ffcccb;' : ''}">
+                            <td>
+                                ${orderItem?.product?.productCode?:""}
+                            </td>
+                            <td class="order-item-product">
+                                <g:link controller="inventoryItem" action="showStockCard" params="['product.id':orderItem?.product?.id]">
+                                    <format:product product="${orderItem?.product}"/>
+                                    <g:renderHandlingIcons product="${orderItem?.product}" />
+                                </g:link>
+                            </td>
+                            <g:if test="${!isItemCanceled}">
+                                <td class="center">
+                                    ${orderItem?.productSupplier?.supplierCode}
+                                </td>
+                                <td class="center">
+                                    ${orderItem?.productSupplier?.manufacturerName}
+                                </td>
+                                <td class="center">
+                                    ${orderItem?.productSupplier?.manufacturerCode}
+                                </td>
+                                <td class="center">
+                                    ${orderItem?.quantity }
+                                </td>
+                                <td class="center">
+                                    ${orderItem?.unitOfMeasure}
+                                </td>
+                                <td class="center">
+                                    ${orderItem?.recipient}
+                                </td>
+                                <td class="center">
+                                    <g:formatDate date="${orderItem?.estimatedReadyDate}" format="dd/MMM/yyyy"/>
+                                </td>
+                                <td class="center">
+                                    <g:formatDate date="${orderItem?.actualReadyDate}" format="dd/MMM/yyyy"/>
+                                </td>
+                                <td class="center">
+                                    ${orderItem?.budgetCode?.code}
+                                </td>
+                            </g:if>
+                            <g:else>
+                                <td colspan="9"></td>
+                            </g:else>
+                        </tr>
+                    </g:if>
+                </g:each>
+                </tbody>
+            </table>
+        </g:if>
+        <g:else>
+            <div class="fade center empty"><warehouse:message code="default.noItems.label" /></div>
+        </g:else>
+    </div>
 </div>

--- a/grails-app/views/order/_itemDetails.gsp
+++ b/grails-app/views/order/_itemDetails.gsp
@@ -11,112 +11,92 @@
       const filterValue = $("#orderItemsDetailsFilter")
         .val()
         .toUpperCase();
-      filterTableItemDetails(filterCell, filterValue)
+      const tableRows = $("#order-items-details tr.dataRowItemDetails");
+      filterTableItems(filterCell, filterValue, tableRows)
     });
-
   });
-  function filterTableItemDetails(cellIndex, filterValue) {
-    const tableRows = $("#order-items-details tr.dataRowItemDetails");
-    // Loop through all table rows, and hide those who don't match the search query
-    $.each(tableRows, function(index, currentRow) {
-      // If filter matches text value then we display, otherwise hide
-      const txtValue = $(currentRow)
-        .find("td")
-        .eq(cellIndex)
-        .text();
-      if (txtValue.toUpperCase().indexOf(filterValue) > -1) {
-        $(currentRow).show();
-      } else {
-        $(currentRow).hide();
-      }
-    });
-  }
+
 </script>
 
-<div class="item-details-table">
+
+<div id="tab-content" class="box">
+    <h2>
+        <warehouse:message code="order.itemDetails.label" default="Item Details"/>
+    </h2>
     <g:if test="${orderInstance.orderType != OrderType.findByCode(Constants.PUTAWAY_ORDER)}">
-        <div class="filters-container">
-            <label class="name"><warehouse:message code="inventory.filterByProduct.label"/></label>
-            <div>
-                <input type="text" id="orderItemsDetailsFilter" class="text large" placeholder="Filter by product name"/>
-            </div>
-        </div>
+        <input type="text" id="orderItemsDetailsFilter" class="text large" placeholder="Filter by product name"/>
     </g:if>
-    <div id="tab-content" class="box">
-        <h2>
-            <warehouse:message code="order.itemDetails.label" default="Item Details"/>
-        </h2>
-        <g:if test="${orderInstance?.orderItems }">
-            <table class="table table-bordered" id="order-items-details">
-                <thead>
-                <tr class="odd">
-                    <th><warehouse:message code="product.productCode.label" /></th>
-                    <th><warehouse:message code="product.label" /></th>
-                    <th class="center"><warehouse:message code="product.supplierCode.label"/></th>
-                    <th class="center"><warehouse:message code="product.manufacturer.label"/></th>
-                    <th class="center"><warehouse:message code="product.manufacturerCode.label"/></th>
-                    <th class="center"><warehouse:message code="orderItem.quantity.label"/></th>
-                    <th class="center"><warehouse:message code="product.uom.label"/></th>
-                    <th class="center"><warehouse:message code="orderItem.recipient.label"/></th>
-                    <th class="center"><warehouse:message code="orderItem.estimatedReadyDate.label"/></th>
-                    <th class="center"><warehouse:message code="orderItem.actualReadyDate.label"/></th>
-                    <th class="center"><warehouse:message code="orderItem.budgetCode.label"/></th>
-                </tr>
-                </thead>
-                <tbody>
-                <g:each var="orderItem" in="${orderInstance?.orderItems?.sort { a,b -> a.dateCreated <=> b.dateCreated ?: a.orderIndex <=> b.orderIndex }}" status="i">
-                    <g:set var="isItemCanceled" value="${orderItem.orderItemStatusCode == OrderItemStatusCode.CANCELED}"/>
-                    <g:if test="${!isItemCanceled || orderInstance?.orderType==OrderType.findByCode(OrderTypeCode.PURCHASE_ORDER.name())}">
-                        <tr class="order-item ${(i % 2) == 0 ? 'even' : 'odd'} dataRowItemDetails" style="${isItemCanceled ? 'background-color: #ffcccb;' : ''}">
-                            <td>
-                                ${orderItem?.product?.productCode?:""}
+    <g:if test="${orderInstance?.orderItems }">
+        <table class="table table-bordered" id="order-items-details">
+            <thead>
+            <tr class="odd">
+                <th><warehouse:message code="product.productCode.label" /></th>
+                <th><warehouse:message code="product.label" /></th>
+                <th class="center"><warehouse:message code="product.supplierCode.label"/></th>
+                <th class="center"><warehouse:message code="product.manufacturer.label"/></th>
+                <th class="center"><warehouse:message code="product.manufacturerCode.label"/></th>
+                <th class="center"><warehouse:message code="orderItem.quantity.label"/></th>
+                <th class="center"><warehouse:message code="product.uom.label"/></th>
+                <th class="center"><warehouse:message code="orderItem.recipient.label"/></th>
+                <th class="center"><warehouse:message code="orderItem.estimatedReadyDate.label"/></th>
+                <th class="center"><warehouse:message code="orderItem.actualReadyDate.label"/></th>
+                <th class="center"><warehouse:message code="orderItem.budgetCode.label"/></th>
+            </tr>
+            </thead>
+            <tbody>
+            <g:each var="orderItem" in="${orderInstance?.orderItems?.sort { a,b -> a.dateCreated <=> b.dateCreated ?: a.orderIndex <=> b.orderIndex }}" status="i">
+                <g:set var="isItemCanceled" value="${orderItem.orderItemStatusCode == OrderItemStatusCode.CANCELED}"/>
+                <g:if test="${!isItemCanceled || orderInstance?.orderType==OrderType.findByCode(OrderTypeCode.PURCHASE_ORDER.name())}">
+                    <tr class="order-item ${(i % 2) == 0 ? 'even' : 'odd'} dataRowItemDetails" style="${isItemCanceled ? 'background-color: #ffcccb;' : ''}">
+                        <td>
+                            ${orderItem?.product?.productCode?:""}
+                        </td>
+                        <td class="order-item-product">
+                            <g:link controller="inventoryItem" action="showStockCard" params="['product.id':orderItem?.product?.id]">
+                                <format:product product="${orderItem?.product}"/>
+                                <g:renderHandlingIcons product="${orderItem?.product}" />
+                            </g:link>
+                        </td>
+                        <g:if test="${!isItemCanceled}">
+                            <td class="center">
+                                ${orderItem?.productSupplier?.supplierCode}
                             </td>
-                            <td class="order-item-product">
-                                <g:link controller="inventoryItem" action="showStockCard" params="['product.id':orderItem?.product?.id]">
-                                    <format:product product="${orderItem?.product}"/>
-                                    <g:renderHandlingIcons product="${orderItem?.product}" />
-                                </g:link>
+                            <td class="center">
+                                ${orderItem?.productSupplier?.manufacturerName}
                             </td>
-                            <g:if test="${!isItemCanceled}">
-                                <td class="center">
-                                    ${orderItem?.productSupplier?.supplierCode}
-                                </td>
-                                <td class="center">
-                                    ${orderItem?.productSupplier?.manufacturerName}
-                                </td>
-                                <td class="center">
-                                    ${orderItem?.productSupplier?.manufacturerCode}
-                                </td>
-                                <td class="center">
-                                    ${orderItem?.quantity }
-                                </td>
-                                <td class="center">
-                                    ${orderItem?.unitOfMeasure}
-                                </td>
-                                <td class="center">
-                                    ${orderItem?.recipient}
-                                </td>
-                                <td class="center">
-                                    <g:formatDate date="${orderItem?.estimatedReadyDate}" format="dd/MMM/yyyy"/>
-                                </td>
-                                <td class="center">
-                                    <g:formatDate date="${orderItem?.actualReadyDate}" format="dd/MMM/yyyy"/>
-                                </td>
-                                <td class="center">
-                                    ${orderItem?.budgetCode?.code}
-                                </td>
-                            </g:if>
-                            <g:else>
-                                <td colspan="9"></td>
-                            </g:else>
-                        </tr>
-                    </g:if>
-                </g:each>
-                </tbody>
-            </table>
-        </g:if>
-        <g:else>
-            <div class="fade center empty"><warehouse:message code="default.noItems.label" /></div>
-        </g:else>
-    </div>
+                            <td class="center">
+                                ${orderItem?.productSupplier?.manufacturerCode}
+                            </td>
+                            <td class="center">
+                                ${orderItem?.quantity }
+                            </td>
+                            <td class="center">
+                                ${orderItem?.unitOfMeasure}
+                            </td>
+                            <td class="center">
+                                ${orderItem?.recipient}
+                            </td>
+                            <td class="center">
+                                <g:formatDate date="${orderItem?.estimatedReadyDate}" format="dd/MMM/yyyy"/>
+                            </td>
+                            <td class="center">
+                                <g:formatDate date="${orderItem?.actualReadyDate}" format="dd/MMM/yyyy"/>
+                            </td>
+                            <td class="center">
+                                ${orderItem?.budgetCode?.code}
+                            </td>
+                        </g:if>
+                        <g:else>
+                            <td colspan="9"></td>
+                        </g:else>
+                    </tr>
+                </g:if>
+            </g:each>
+            </tbody>
+        </table>
+    </g:if>
+    <g:else>
+        <div class="fade center empty"><warehouse:message code="default.noItems.label" /></div>
+    </g:else>
 </div>
+

--- a/grails-app/views/order/_itemStatus.gsp
+++ b/grails-app/views/order/_itemStatus.gsp
@@ -2,6 +2,7 @@
 <%@ page import="org.pih.warehouse.order.OrderType;" %>
 <%@ page import="org.pih.warehouse.order.OrderTypeCode;" %>
 
+
 <script>
   $(document).ready(function() {
     $("#orderItemsStatusFilter").keyup(function(event){
@@ -9,153 +10,133 @@
       const filterValue = $("#orderItemsStatusFilter")
         .val()
         .toUpperCase();
-      filterTableItemStatus(filterCell, filterValue)
+      const tableRows = $("#order-items-status tr.dataRowItemStatus");
+      filterTableItems(filterCell, filterValue, tableRows)
     });
 
   });
-  function filterTableItemStatus(cellIndex, filterValue) {
-    const tableRows = $("#order-items-status tr.dataRowItemStatus");
-    // Loop through all table rows, and hide those who don't match the search query
-    $.each(tableRows, function(index, currentRow) {
-      // If filter matches text value then we display, otherwise hide
-      const txtValue = $(currentRow)
-        .find("td")
-        .eq(cellIndex)
-        .text();
-      if (txtValue.toUpperCase().indexOf(filterValue) > -1) {
-        $(currentRow).show();
-      } else {
-        $(currentRow).hide();
-      }
-    });
-  }
 </script>
 
-<div class="item-status-table">
+
+<div id="tab-content" class="box">
+    <h2>
+        <warehouse:message code="order.itemStatus.label" default="Item Status"/>
+    </h2>
     <g:if test="${orderInstance.orderType != OrderType.findByCode(Constants.PUTAWAY_ORDER)}">
-        <div class="filters-container">
-            <label class="name"><warehouse:message code="inventory.filterByProduct.label"/></label>
-            <div>
-                <input type="text" id="orderItemsStatusFilter" class="text large" placeholder="Filter by product name"/>
-            </div>
-        </div>
+        <input type="text" id="orderItemsStatusFilter" class="text large" placeholder="Filter by product name"/>
     </g:if>
-    <div id="tab-content" class="box">
-        <h2>
-            <warehouse:message code="order.itemStatus.label" default="Item Status"/>
-        </h2>
-        <g:if test="${orderInstance?.orderItems }">
-            <table class="table table-bordered" id="order-items-status">
-                <thead>
-                <tr class="odd">
+    <g:if test="${orderInstance?.orderItems }">
+        <table class="table table-bordered" id="order-items-status">
+            <thead>
+            <tr class="odd">
+                <g:if test="${orderInstance.orderType==OrderType.findByCode(Constants.PUTAWAY_ORDER)}">
+                    <th><warehouse:message code="orderItem.orderItemStatusCode.label" /></th>
+                </g:if>
+                <th><warehouse:message code="product.productCode.label" /></th>
+                <th><warehouse:message code="product.label" /></th>
+                <th class="center">${warehouse.message(code: 'product.unitOfMeasure.label')}</th>
+                <th class="right">${warehouse.message(code: 'orderItem.quantity.label')}</th>
+                <g:if test="${orderInstance.orderType==OrderType.findByCode(OrderTypeCode.PURCHASE_ORDER.name())}">
+                    <th class="right">${warehouse.message(code: 'order.ordered.label')}</th>
+                    <th class="right">${warehouse.message(code: 'order.shipped.label')}</th>
+                    <th class="right">${warehouse.message(code: 'order.received.label')}</th>
+                    <th class="right">${warehouse.message(code: 'invoice.invoiced.label')}</th>
+                    <th><warehouse:message code="order.unitPrice.label" /></th>
+                    <th><warehouse:message code="order.totalPrice.label" /></th>
+                </g:if>
+                <g:elseif test="${orderInstance.orderType==OrderType.findByCode(Constants.PUTAWAY_ORDER)}">
+                    <th><warehouse:message code="inventoryItem.lotNumber.label" /></th>
+                    <th><warehouse:message code="inventoryItem.expirationDate.label" /></th>
+                    <th><warehouse:message code="orderItem.originBinLocation.label" /></th>
+                    <th><warehouse:message code="orderItem.destinationBinLocation.label" /></th>
+                </g:elseif>
+            </tr>
+            </thead>
+            <tbody>
+            <g:each var="orderItem" in="${orderInstance?.listOrderItems()}" status="i">
+                <tr class="order-item ${(i % 2) == 0 ? 'even' : 'odd'} dataRowItemStatus">
                     <g:if test="${orderInstance.orderType==OrderType.findByCode(Constants.PUTAWAY_ORDER)}">
-                        <th><warehouse:message code="orderItem.orderItemStatusCode.label" /></th>
-                    </g:if>
-                    <th><warehouse:message code="product.productCode.label" /></th>
-                    <th><warehouse:message code="product.label" /></th>
-                    <th class="center">${warehouse.message(code: 'product.unitOfMeasure.label')}</th>
-                    <th class="right">${warehouse.message(code: 'orderItem.quantity.label')}</th>
-                    <g:if test="${orderInstance.orderType==OrderType.findByCode(OrderTypeCode.PURCHASE_ORDER.name())}">
-                        <th class="right">${warehouse.message(code: 'order.ordered.label')}</th>
-                        <th class="right">${warehouse.message(code: 'order.shipped.label')}</th>
-                        <th class="right">${warehouse.message(code: 'order.received.label')}</th>
-                        <th class="right">${warehouse.message(code: 'invoice.invoiced.label')}</th>
-                        <th><warehouse:message code="order.unitPrice.label" /></th>
-                        <th><warehouse:message code="order.totalPrice.label" /></th>
-                    </g:if>
-                    <g:elseif test="${orderInstance.orderType==OrderType.findByCode(Constants.PUTAWAY_ORDER)}">
-                        <th><warehouse:message code="inventoryItem.lotNumber.label" /></th>
-                        <th><warehouse:message code="inventoryItem.expirationDate.label" /></th>
-                        <th><warehouse:message code="orderItem.originBinLocation.label" /></th>
-                        <th><warehouse:message code="orderItem.destinationBinLocation.label" /></th>
-                    </g:elseif>
-                </tr>
-                </thead>
-                <tbody>
-                <g:each var="orderItem" in="${orderInstance?.listOrderItems()}" status="i">
-                    <tr class="order-item ${(i % 2) == 0 ? 'even' : 'odd'} dataRowItemStatus">
-                        <g:if test="${orderInstance.orderType==OrderType.findByCode(Constants.PUTAWAY_ORDER)}">
-                            <td>
-                                ${orderItem?.orderItemStatusCode}
-                            </td>
-                        </g:if>
                         <td>
-                            ${orderItem?.product?.productCode?:""}
+                            ${orderItem?.orderItemStatusCode}
                         </td>
+                    </g:if>
+                    <td>
+                        ${orderItem?.product?.productCode?:""}
+                    </td>
 
-                    <td class="order-item-product">
-                        <g:if test="${orderItem?.product }">
-                            <g:link controller="inventoryItem" action="showStockCard" params="['product.id':orderItem?.product?.id]">
-                                <format:product product="${orderItem?.product}"/>
-                                <g:renderHandlingIcons product="${orderItem?.product}" />
-                            </g:link>
-                        </g:if>
-                        <g:else>
-                            ${orderItem?.description }
-                        </g:else>
-                    </td>
-                    <td class="center">
-                        ${orderItem?.unitOfMeasure}
-                    </td>
-                    <td class="order-item-quantity right">
-                        ${orderItem?.quantity}
-                    </td>
-                    <g:if test="${orderInstance.orderType==OrderType.findByCode(OrderTypeCode.PURCHASE_ORDER.name())}">
-                        <td class="order-item-ordered right">
-                            ${orderInstance.isPlaced()?orderItem?.quantity:0}
-                        </td>
-                        <td class="order-item-fullfilled right">
-                            ${orderItem?.quantityShipped}
-                        </td>
-                        <td class="order-item-received right">
-                            ${orderItem?.quantityReceived}
-                        </td>
-                        <td class="right">
-                            ${orderItem?.quantityInvoicedInStandardUom}
-                        </td>
-                        <td class="">
-                            <g:formatNumber number="${orderItem?.unitPrice?:0}" />
-                            ${orderInstance?.currencyCode?:grailsApplication.config.openboxes.locale.defaultCurrencyCode}
-                        </td>
-                        <td class="">
-                            <g:formatNumber number="${orderItem?.totalPrice()?:0}" />
-                            ${orderInstance?.currencyCode?:grailsApplication.config.openboxes.locale.defaultCurrencyCode}
-                        </td>
+                <td class="order-item-product">
+                    <g:if test="${orderItem?.product }">
+                        <g:link controller="inventoryItem" action="showStockCard" params="['product.id':orderItem?.product?.id]">
+                            <format:product product="${orderItem?.product}"/>
+                            <g:renderHandlingIcons product="${orderItem?.product}" />
+                        </g:link>
                     </g:if>
-                    <g:elseif test="${orderInstance.orderType==OrderType.findByCode(Constants.PUTAWAY_ORDER)}">
-                        <td>
-                            ${orderItem?.inventoryItem?.lotNumber}
-                        </td>
-                        <td>
-                            <g:formatDate date="${orderItem?.inventoryItem?.expirationDate}" format="MM/dd/yyyy"/>
-                        </td>
-                        <td>
-                            ${orderItem?.originBinLocation}
-                        </td>
-                        <td>
-                            ${orderItem?.destinationBinLocation}
-                        </td>
-                    </g:elseif>
-                </tr>
-            </g:each>
-            </tbody>
-            <g:if test="${orderInstance.orderType==OrderType.findByCode(OrderTypeCode.PURCHASE_ORDER.name())}">
-                <tfoot>
-                <tr class="">
-                    <th colspan="9" class="right">
-                    </th>
-                    <th colspan="1" class="left">
-                        <g:formatNumber number="${orderInstance?.totalPrice()?:0.0 }"/>
+                    <g:else>
+                        ${orderItem?.description }
+                    </g:else>
+                </td>
+                <td class="center">
+                    ${orderItem?.unitOfMeasure}
+                </td>
+                <td class="order-item-quantity right">
+                    ${orderItem?.quantity}
+                </td>
+                <g:if test="${orderInstance.orderType==OrderType.findByCode(OrderTypeCode.PURCHASE_ORDER.name())}">
+                    <td class="order-item-ordered right">
+                        ${orderInstance.isPlaced()?orderItem?.quantity:0}
+                    </td>
+                    <td class="order-item-fullfilled right">
+                        ${orderItem?.quantityShipped}
+                    </td>
+                    <td class="order-item-received right">
+                        ${orderItem?.quantityReceived}
+                    </td>
+                    <td class="right">
+                        ${orderItem?.quantityInvoicedInStandardUom}
+                    </td>
+                    <td class="">
+                        <g:formatNumber number="${orderItem?.unitPrice?:0}" />
                         ${orderInstance?.currencyCode?:grailsApplication.config.openboxes.locale.defaultCurrencyCode}
-                    </th>
-                </tr>
-                </tfoot>
-            </g:if>
-
-            </table>
+                    </td>
+                    <td class="">
+                        <g:formatNumber number="${orderItem?.totalPrice()?:0}" />
+                        ${orderInstance?.currencyCode?:grailsApplication.config.openboxes.locale.defaultCurrencyCode}
+                    </td>
+                </g:if>
+                <g:elseif test="${orderInstance.orderType==OrderType.findByCode(Constants.PUTAWAY_ORDER)}">
+                    <td>
+                        ${orderItem?.inventoryItem?.lotNumber}
+                    </td>
+                    <td>
+                        <g:formatDate date="${orderItem?.inventoryItem?.expirationDate}" format="MM/dd/yyyy"/>
+                    </td>
+                    <td>
+                        ${orderItem?.originBinLocation}
+                    </td>
+                    <td>
+                        ${orderItem?.destinationBinLocation}
+                    </td>
+                </g:elseif>
+            </tr>
+        </g:each>
+        </tbody>
+        <g:if test="${orderInstance.orderType==OrderType.findByCode(OrderTypeCode.PURCHASE_ORDER.name())}">
+            <tfoot>
+            <tr class="">
+                <th colspan="9" class="right">
+                </th>
+                <th colspan="1" class="left">
+                    <g:formatNumber number="${orderInstance?.totalPrice()?:0.0 }"/>
+                    ${orderInstance?.currencyCode?:grailsApplication.config.openboxes.locale.defaultCurrencyCode}
+                </th>
+            </tr>
+            </tfoot>
         </g:if>
-        <g:else>
-            <div class="fade center empty"><warehouse:message code="default.noItems.label" /></div>
-        </g:else>
-    </div>
+
+        </table>
+    </g:if>
+    <g:else>
+        <div class="fade center empty"><warehouse:message code="default.noItems.label" /></div>
+    </g:else>
 </div>
+

--- a/grails-app/views/order/_itemStatus.gsp
+++ b/grails-app/views/order/_itemStatus.gsp
@@ -1,48 +1,87 @@
 <%@ page import="org.pih.warehouse.core.Constants;" %>
 <%@ page import="org.pih.warehouse.order.OrderType;" %>
 <%@ page import="org.pih.warehouse.order.OrderTypeCode;" %>
-<div id="tab-content" class="box">
-    <h2>
-        <warehouse:message code="order.itemStatus.label" default="Item Status"/>
-    </h2>
-    <g:if test="${orderInstance?.orderItems }">
-        <table class="table table-bordered">
-            <thead>
-            <tr class="odd">
-                <g:if test="${orderInstance.orderType==OrderType.findByCode(Constants.PUTAWAY_ORDER)}">
-                    <th><warehouse:message code="orderItem.orderItemStatusCode.label" /></th>
-                </g:if>
-                <th><warehouse:message code="product.productCode.label" /></th>
-                <th><warehouse:message code="product.label" /></th>
-                <th class="center">${warehouse.message(code: 'product.unitOfMeasure.label')}</th>
-                <th class="right">${warehouse.message(code: 'orderItem.quantity.label')}</th>
-                <g:if test="${orderInstance.orderType==OrderType.findByCode(OrderTypeCode.PURCHASE_ORDER.name())}">
-                    <th class="right">${warehouse.message(code: 'order.ordered.label')}</th>
-                    <th class="right">${warehouse.message(code: 'order.shipped.label')}</th>
-                    <th class="right">${warehouse.message(code: 'order.received.label')}</th>
-                    <th class="right">${warehouse.message(code: 'invoice.invoiced.label')}</th>
-                    <th><warehouse:message code="order.unitPrice.label" /></th>
-                    <th><warehouse:message code="order.totalPrice.label" /></th>
-                </g:if>
-                <g:elseif test="${orderInstance.orderType==OrderType.findByCode(Constants.PUTAWAY_ORDER)}">
-                    <th><warehouse:message code="inventoryItem.lotNumber.label" /></th>
-                    <th><warehouse:message code="inventoryItem.expirationDate.label" /></th>
-                    <th><warehouse:message code="orderItem.originBinLocation.label" /></th>
-                    <th><warehouse:message code="orderItem.destinationBinLocation.label" /></th>
-                </g:elseif>
-            </tr>
-            </thead>
-            <tbody>
-            <g:each var="orderItem" in="${orderInstance?.listOrderItems()}" status="i">
-                <tr class="order-item ${(i % 2) == 0 ? 'even' : 'odd'}">
+
+<script>
+  $(document).ready(function() {
+    $("#orderItemsStatusFilter").keyup(function(event){
+      const filterCell = 1; // product name
+      const filterValue = $("#orderItemsStatusFilter")
+        .val()
+        .toUpperCase();
+      filterTableItemStatus(filterCell, filterValue)
+    });
+
+  });
+  function filterTableItemStatus(cellIndex, filterValue) {
+    const tableRows = $("#order-items-status tr.dataRowItemStatus");
+    // Loop through all table rows, and hide those who don't match the search query
+    $.each(tableRows, function(index, currentRow) {
+      // If filter matches text value then we display, otherwise hide
+      const txtValue = $(currentRow)
+        .find("td")
+        .eq(cellIndex)
+        .text();
+      if (txtValue.toUpperCase().indexOf(filterValue) > -1) {
+        $(currentRow).show();
+      } else {
+        $(currentRow).hide();
+      }
+    });
+  }
+</script>
+
+<div class="item-status-table">
+    <g:if test="${orderInstance.orderType != OrderType.findByCode(Constants.PUTAWAY_ORDER)}">
+        <div class="filters-container">
+            <label class="name"><warehouse:message code="inventory.filterByProduct.label"/></label>
+            <div>
+                <input type="text" id="orderItemsStatusFilter" class="text large" placeholder="Filter by product name"/>
+            </div>
+        </div>
+    </g:if>
+    <div id="tab-content" class="box">
+        <h2>
+            <warehouse:message code="order.itemStatus.label" default="Item Status"/>
+        </h2>
+        <g:if test="${orderInstance?.orderItems }">
+            <table class="table table-bordered" id="order-items-status">
+                <thead>
+                <tr class="odd">
                     <g:if test="${orderInstance.orderType==OrderType.findByCode(Constants.PUTAWAY_ORDER)}">
-                        <td>
-                            ${orderItem?.orderItemStatusCode}
-                        </td>
+                        <th><warehouse:message code="orderItem.orderItemStatusCode.label" /></th>
                     </g:if>
-                    <td>
-                        ${orderItem?.product?.productCode?:""}
-                    </td>
+                    <th><warehouse:message code="product.productCode.label" /></th>
+                    <th><warehouse:message code="product.label" /></th>
+                    <th class="center">${warehouse.message(code: 'product.unitOfMeasure.label')}</th>
+                    <th class="right">${warehouse.message(code: 'orderItem.quantity.label')}</th>
+                    <g:if test="${orderInstance.orderType==OrderType.findByCode(OrderTypeCode.PURCHASE_ORDER.name())}">
+                        <th class="right">${warehouse.message(code: 'order.ordered.label')}</th>
+                        <th class="right">${warehouse.message(code: 'order.shipped.label')}</th>
+                        <th class="right">${warehouse.message(code: 'order.received.label')}</th>
+                        <th class="right">${warehouse.message(code: 'invoice.invoiced.label')}</th>
+                        <th><warehouse:message code="order.unitPrice.label" /></th>
+                        <th><warehouse:message code="order.totalPrice.label" /></th>
+                    </g:if>
+                    <g:elseif test="${orderInstance.orderType==OrderType.findByCode(Constants.PUTAWAY_ORDER)}">
+                        <th><warehouse:message code="inventoryItem.lotNumber.label" /></th>
+                        <th><warehouse:message code="inventoryItem.expirationDate.label" /></th>
+                        <th><warehouse:message code="orderItem.originBinLocation.label" /></th>
+                        <th><warehouse:message code="orderItem.destinationBinLocation.label" /></th>
+                    </g:elseif>
+                </tr>
+                </thead>
+                <tbody>
+                <g:each var="orderItem" in="${orderInstance?.listOrderItems()}" status="i">
+                    <tr class="order-item ${(i % 2) == 0 ? 'even' : 'odd'} dataRowItemStatus">
+                        <g:if test="${orderInstance.orderType==OrderType.findByCode(Constants.PUTAWAY_ORDER)}">
+                            <td>
+                                ${orderItem?.orderItemStatusCode}
+                            </td>
+                        </g:if>
+                        <td>
+                            ${orderItem?.product?.productCode?:""}
+                        </td>
 
                     <td class="order-item-product">
                         <g:if test="${orderItem?.product }">
@@ -113,9 +152,10 @@
                 </tfoot>
             </g:if>
 
-        </table>
-    </g:if>
-    <g:else>
-        <div class="fade center empty"><warehouse:message code="default.noItems.label" /></div>
-    </g:else>
+            </table>
+        </g:if>
+        <g:else>
+            <div class="fade center empty"><warehouse:message code="default.noItems.label" /></div>
+        </g:else>
+    </div>
 </div>

--- a/grails-app/views/order/_orderSummary.gsp
+++ b/grails-app/views/order/_orderSummary.gsp
@@ -1,142 +1,192 @@
 <%@ page import="org.pih.warehouse.order.OrderItemStatusCode;" %>
 <%@ page import="org.pih.warehouse.order.OrderType;" %>
 <%@ page import="org.pih.warehouse.order.OrderTypeCode;" %>
-<div class="box">
-    <h2>
-        <warehouse:message code="default.summary.label"/>
-    </h2>
-    <g:if test="${orderInstance?.orderItems}">
-        <g:set var="status" value="${0}"/>
-        <g:set var="columnsNumber" value="5"/>
-        <table class="order-items">
-            <thead>
-            <tr>
-                <th class="bottom">
-                    <warehouse:message code="product.productCode.label"/>
-                </th>
-                <th class="bottom">
-                    <warehouse:message code="product.name.label"/>
-                </th>
-                <g:if test="${orderInstance.orderItems.any { it.productSupplier?.supplierCode } }">
-                    <g:set var="columnsNumber" value="${columnsNumber.toInteger() + 1}"/>
-                    <th class="center">
-                        <warehouse:message code="product.supplierCode.label"/>
-                    </th>
-                </g:if>
-                <g:if test="${orderInstance.orderItems.any { it.productSupplier?.manufacturerName } }">
-                    <g:set var="columnsNumber" value="${columnsNumber.toInteger() + 1}"/>
-                    <th class="center">
-                        <warehouse:message code="product.manufacturer.label"/>
-                    </th>
-                </g:if>
-                <g:if test="${orderInstance.orderItems.any { it.productSupplier?.manufacturerCode } }">
-                    <g:set var="columnsNumber" value="${columnsNumber.toInteger() + 1}"/>
-                    <th class="center">
-                        <warehouse:message code="product.manufacturerCode.label"/>
-                    </th>
-                </g:if>
-                <th class="center bottom">
-                    <warehouse:message code="orderItem.quantity.label" default="Quantity"/>
-                </th>
-                <th class="center bottom">
-                    <warehouse:message code="product.uom.label" default="UOM"/>
-                </th>
-                <th class="right bottom">
-                    <warehouse:message code="orderItem.unitPrice.label" default="Unit price"/>
-                </th>
-                <th class="right bottom">
-                    <warehouse:message code="orderItem.totalPrice.label" default="Total amount"/>
-                </th>
+<%@ page import="org.pih.warehouse.core.Constants;" %>
 
-            </tr>
-            </thead>
+<style>
+    .filters-container {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        align-items: center;
+        margin: 10px 0;
+    }
+</style>
 
-            <tbody>
+<script>
+  $(document).ready(function() {
+    $("#orderItemsFilter").keyup(function(event){
+      const filterCell = 1; // product name
+      const filterValue = $("#orderItemsFilter")
+        .val()
+        .toUpperCase();
+      filterTable(filterCell, filterValue)
+    });
+  });
+  function filterTable(cellIndex, filterValue) {
+    const tableRows = $("#order-items tr.dataRow");
+    // Loop through all table rows, and hide those who don't match the search query
+    $.each(tableRows, function(index, currentRow) {
+      // If filter matches text value then we display, otherwise hide
+      const txtValue = $(currentRow)
+        .find("td")
+        .eq(cellIndex)
+        .text();
+      if (txtValue.toUpperCase().indexOf(filterValue) > -1) {
+        $(currentRow).show();
+      } else {
+        $(currentRow).hide();
+      }
+    });
+  }
+</script>
 
-            <g:each var="orderItem" in="${orderInstance?.orderItems?.sort { a,b -> a.dateCreated <=> b.dateCreated ?: a.orderIndex <=> b.orderIndex }}" status="i">
-                <g:set var="isItemCanceled" value="${orderItem.orderItemStatusCode == OrderItemStatusCode.CANCELED}"/>
-                <g:if test="${!isItemCanceled || orderInstance?.orderType==OrderType.findByCode(OrderTypeCode.PURCHASE_ORDER.name())}">
-                    <tr class="order-item ${(i % 2) == 0 ? 'even' : 'odd'}" style="${isItemCanceled ? 'background-color: #ffcccb;' : ''}">
-                        <td style="color: ${orderItem?.product?.color}">
-                            ${orderItem?.product?.productCode}
-                        </td>
-                        <td>
-                            <g:link controller="inventoryItem" action="showStockCard"
-                                    style="color: ${orderItem?.product?.color}"  params="['product.id':orderItem?.product?.id]">
-                                <format:product product="${orderItem?.product}"/>
-                                <g:renderHandlingIcons product="${orderItem?.product}" />
-                            </g:link>
-                        </td>
-                        <g:if test="${!isItemCanceled}">
-                            <g:if test="${orderInstance.orderItems.any { it.productSupplier?.supplierCode } }">
-                                <td class="center">
-                                    ${orderItem?.productSupplier?.supplierCode}
-                                </td>
-                            </g:if>
-                            <g:if test="${orderInstance.orderItems.any { it.productSupplier?.manufacturerName } }">
-                                <td class="center">
-                                    ${orderItem?.productSupplier?.manufacturerName}
-                                </td>
-                            </g:if>
-                            <g:if test="${orderInstance.orderItems.any { it.productSupplier?.manufacturerCode } }">
-                                <td class="center">
-                                    ${orderItem?.productSupplier?.manufacturerCode}
-                                </td>
-                            </g:if>
-                            <td class="center">
-                                ${orderItem?.quantity }
-                            </td>
-                            <td class="center">
-                                ${orderItem?.unitOfMeasure}
-                            </td>
-                            <td class="right">
-                                <g:formatNumber number="${orderItem?.unitPrice}" />
-                                ${orderInstance?.currencyCode?:grailsApplication.config.openboxes.locale.defaultCurrencyCode}
-                            </td>
-                            <td class="right">
-                                <g:formatNumber number="${orderItem?.totalPrice()}"/>
-                                ${orderInstance?.currencyCode?:grailsApplication.config.openboxes.locale.defaultCurrencyCode}
-                            </td>
-                        </g:if>
-                        <g:else>
-                            <td colspan="${columnsNumber}"></td>
-                        </g:else>
-                    </tr>
-                </g:if>
-            </g:each>
-            </tbody>
-            <tfoot>
-            <tr>
-                <th colspan="${columnsNumber}" class="right">
-                    <warehouse:message code="default.subtotal.label" default="Subtotal"/>
-                </th>
-                <th class="right">
-                    <g:formatNumber number="${orderInstance?.subtotal}"/>
-                    ${orderInstance?.currencyCode?:grailsApplication.config.openboxes.locale.defaultCurrencyCode}
-                </th>
-            </tr>
-            <tr>
-                <th colspan="${columnsNumber}" class="right">
-                    <warehouse:message code="default.adjustments.label" default="Adjustments"/>
-                </th>
-                <th class="right">
-                    <g:formatNumber number="${orderInstance?.totalAdjustments}"/>
-                    ${orderInstance?.currencyCode?:grailsApplication.config.openboxes.locale.defaultCurrencyCode}
-                </th>
-            </tr>
-            <tr>
-                <th colspan="${columnsNumber}" class="right">
-                    <warehouse:message code="default.total.label"/>
-                </th>
-                <th class="right">
-                    <g:formatNumber number="${orderInstance?.total}"/>
-                    ${orderInstance?.currencyCode?:grailsApplication.config.openboxes.locale.defaultCurrencyCode}
-                </th>
-            </tr>
-            </tfoot>
-        </table>
+<div class="summary-table">
+    <g:if test="${orderInstance.orderType != OrderType.findByCode(Constants.PUTAWAY_ORDER)}">
+        <div class="filters-container">
+            <label class="name"><warehouse:message code="inventory.filterByProduct.label"/></label>
+            <div>
+                <input type="text" id="orderItemsFilter" class="text large" placeholder="Filter by product name"/>
+            </div>
+        </div>
     </g:if>
-    <g:else>
-        <div class="fade center empty"><warehouse:message code="default.noItems.label" /></div>
-    </g:else>
+    <div class="box">
+        <h2>
+            <warehouse:message code="default.summary.label"/>
+        </h2>
+        <g:if test="${orderInstance?.orderItems}">
+            <g:set var="status" value="${0}"/>
+            <g:set var="columnsNumber" value="5"/>
+            <table class="order-items" id="order-items">
+                <thead>
+                <tr>
+                    <th class="bottom">
+                        <warehouse:message code="product.productCode.label"/>
+                    </th>
+                    <th class="bottom">
+                        <warehouse:message code="product.name.label"/>
+                    </th>
+                    <g:if test="${orderInstance.orderItems.any { it.productSupplier?.supplierCode } }">
+                        <g:set var="columnsNumber" value="${columnsNumber.toInteger() + 1}"/>
+                        <th class="center">
+                            <warehouse:message code="product.supplierCode.label"/>
+                        </th>
+                    </g:if>
+                    <g:if test="${orderInstance.orderItems.any { it.productSupplier?.manufacturerName } }">
+                        <g:set var="columnsNumber" value="${columnsNumber.toInteger() + 1}"/>
+                        <th class="center">
+                            <warehouse:message code="product.manufacturer.label"/>
+                        </th>
+                    </g:if>
+                    <g:if test="${orderInstance.orderItems.any { it.productSupplier?.manufacturerCode } }">
+                        <g:set var="columnsNumber" value="${columnsNumber.toInteger() + 1}"/>
+                        <th class="center">
+                            <warehouse:message code="product.manufacturerCode.label"/>
+                        </th>
+                    </g:if>
+                    <th class="center bottom">
+                        <warehouse:message code="orderItem.quantity.label" default="Quantity"/>
+                    </th>
+                    <th class="center bottom">
+                        <warehouse:message code="product.uom.label" default="UOM"/>
+                    </th>
+                    <th class="right bottom">
+                        <warehouse:message code="orderItem.unitPrice.label" default="Unit price"/>
+                    </th>
+                    <th class="right bottom">
+                        <warehouse:message code="orderItem.totalPrice.label" default="Total amount"/>
+                    </th>
+
+                </tr>
+                </thead>
+
+                <tbody>
+
+                <g:each var="orderItem" in="${orderInstance?.orderItems?.sort { a,b -> a.dateCreated <=> b.dateCreated ?: a.orderIndex <=> b.orderIndex }}" status="i">
+                    <g:set var="isItemCanceled" value="${orderItem.orderItemStatusCode == OrderItemStatusCode.CANCELED}"/>
+                    <g:if test="${!isItemCanceled || orderInstance?.orderType==OrderType.findByCode(OrderTypeCode.PURCHASE_ORDER.name())}">
+                        <tr class="order-item ${(i % 2) == 0 ? 'even' : 'odd'} dataRow" style="${isItemCanceled ? 'background-color: #ffcccb;' : ''}">
+                            <td style="color: ${orderItem?.product?.color}">
+                                ${orderItem?.product?.productCode}
+                            </td>
+                            <td>
+                                <g:link controller="inventoryItem" action="showStockCard"
+                                        style="color: ${orderItem?.product?.color}"  params="['product.id':orderItem?.product?.id]">
+                                    <format:product product="${orderItem?.product}"/>
+                                    <g:renderHandlingIcons product="${orderItem?.product}" />
+                                </g:link>
+                            </td>
+                            <g:if test="${!isItemCanceled}">
+                                <g:if test="${orderInstance.orderItems.any { it.productSupplier?.supplierCode } }">
+                                    <td class="center">
+                                        ${orderItem?.productSupplier?.supplierCode}
+                                    </td>
+                                </g:if>
+                                <g:if test="${orderInstance.orderItems.any { it.productSupplier?.manufacturerName } }">
+                                    <td class="center">
+                                        ${orderItem?.productSupplier?.manufacturerName}
+                                    </td>
+                                </g:if>
+                                <g:if test="${orderInstance.orderItems.any { it.productSupplier?.manufacturerCode } }">
+                                    <td class="center">
+                                        ${orderItem?.productSupplier?.manufacturerCode}
+                                    </td>
+                                </g:if>
+                                <td class="center">
+                                    ${orderItem?.quantity }
+                                </td>
+                                <td class="center">
+                                    ${orderItem?.unitOfMeasure}
+                                </td>
+                                <td class="right">
+                                    <g:formatNumber number="${orderItem?.unitPrice}" />
+                                    ${orderInstance?.currencyCode?:grailsApplication.config.openboxes.locale.defaultCurrencyCode}
+                                </td>
+                                <td class="right">
+                                    <g:formatNumber number="${orderItem?.totalPrice()}"/>
+                                    ${orderInstance?.currencyCode?:grailsApplication.config.openboxes.locale.defaultCurrencyCode}
+                                </td>
+                            </g:if>
+                            <g:else>
+                                <td colspan="${columnsNumber}"></td>
+                            </g:else>
+                        </tr>
+                    </g:if>
+                </g:each>
+                </tbody>
+                <tfoot>
+                <tr>
+                    <th colspan="${columnsNumber}" class="right">
+                        <warehouse:message code="default.subtotal.label" default="Subtotal"/>
+                    </th>
+                    <th class="right">
+                        <g:formatNumber number="${orderInstance?.subtotal}"/>
+                        ${orderInstance?.currencyCode?:grailsApplication.config.openboxes.locale.defaultCurrencyCode}
+                    </th>
+                </tr>
+                <tr>
+                    <th colspan="${columnsNumber}" class="right">
+                        <warehouse:message code="default.adjustments.label" default="Adjustments"/>
+                    </th>
+                    <th class="right">
+                        <g:formatNumber number="${orderInstance?.totalAdjustments}"/>
+                        ${orderInstance?.currencyCode?:grailsApplication.config.openboxes.locale.defaultCurrencyCode}
+                    </th>
+                </tr>
+                <tr>
+                    <th colspan="${columnsNumber}" class="right">
+                        <warehouse:message code="default.total.label"/>
+                    </th>
+                    <th class="right">
+                        <g:formatNumber number="${orderInstance?.total}"/>
+                        ${orderInstance?.currencyCode?:grailsApplication.config.openboxes.locale.defaultCurrencyCode}
+                    </th>
+                </tr>
+                </tfoot>
+            </table>
+        </g:if>
+        <g:else>
+            <div class="fade center empty"><warehouse:message code="default.noItems.label" /></div>
+        </g:else>
+    </div>
 </div>

--- a/grails-app/views/order/show.gsp
+++ b/grails-app/views/order/show.gsp
@@ -280,6 +280,22 @@
                     selected: ${params.tab ? params.tab : 0}
                 });
             });
+
+            function filterTableItems(cellIndex, filterValue, tableRows) {
+              // Loop through all table rows, and hide those who don't match the search query
+              $.each(tableRows, function(index, currentRow) {
+                // If filter matches text value then we display, otherwise hide
+                const txtValue = $(currentRow)
+                  .find("td")
+                  .eq(cellIndex)
+                  .text();
+                if (txtValue.toUpperCase().indexOf(filterValue) > -1) {
+                  $(currentRow).show();
+                } else {
+                  $(currentRow).hide();
+                }
+              });
+            }
         </script>
     </body>
 </html>


### PR DESCRIPTION
After many different approaches, the dynamic filtering (hiding a row) worked the best here. I managed to recreate what was done probably in Stock History section. At the moment the filtering is done by product name which Kelsey admitted on one of the previous standups. The changes may seem weird (it might look like I changed the whole file) on Git, due to indents because of one additional <div> for everything, but the part I edited was just adding the <script> section and one if at the beginning of the first div.
The "if" was added to determine whether it is a putaway order or a PO order, because I assume it was not supposed to be done for putaways and as there is one view for both cases, it would work also for putaways if I hadn't added the "if".