### PR TITLE
OBPIH-4451 Fixes after QA

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/api/LocationApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/LocationApiController.groovy
@@ -53,12 +53,12 @@ class LocationApiController extends BaseDomainApiController {
         def fields = params.fields ? params.fields.split(",") : null
         def locations = new HashSet()
         def isRequestor = userService.isUserRequestor(currentUser)
-        def inRoleBrowser = userService.isUserInRole(currentUser, RoleType.ROLE_BROWSER)
+        def inRoleBrowser = userService.hasRoleBrowserGlobally(currentUser)
         def requestorInAnyLocation = userService.hasRoleRequestorInAnyLocations(currentUser)
-        def inRoleAssistant = userService.isUserInRole(currentUser, RoleType.ROLE_ASSISTANT)
-        def inRoleManager = userService.isUserInRole(currentUser, RoleType.ROLE_MANAGER)
-        def inRoleAdmin = userService.isUserInRole(currentUser, RoleType.ROLE_ADMIN)
-        def inRoleSuperuser = userService.isUserInRole(currentUser, RoleType.ROLE_SUPERUSER)
+        def inRoleAssistant = userService.hasRoleAssistantGlobally(currentUser)
+        def inRoleManager = userService.isManagerGlobally(currentUser)
+        def inRoleAdmin = userService.isUserAdminGlobally(currentUser)
+        def inRoleSuperuser = userService.isSuperuserGlobally(currentUser)
 
         def requiredRoles = RoleType.listRoleTypesForLocationChooser()
 

--- a/grails-app/services/org/pih/warehouse/core/LocationService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/LocationService.groovy
@@ -250,12 +250,12 @@ class LocationService {
         def locations = new HashSet()
         def nullHigh = new NullComparator(true)
         def isRequestor = userService.isUserRequestor(user)
-        def inRoleBrowser = userService.isUserInRole(user, RoleType.ROLE_BROWSER)
+        def inRoleBrowser = userService.hasRoleBrowserGlobally(user)
         def requestorInAnyLocation = userService.hasRoleRequestorInAnyLocations(user)
-        def inRoleAssistant = userService.isUserInRole(user, RoleType.ROLE_ASSISTANT)
-        def inRoleManager = userService.isUserInRole(user, RoleType.ROLE_MANAGER)
-        def inRoleAdmin = userService.isUserInRole(user, RoleType.ROLE_ADMIN)
-        def inRoleSuperuser = userService.isUserInRole(user, RoleType.ROLE_SUPERUSER)
+        def inRoleAssistant = userService.hasRoleAssistantGlobally(user)
+        def inRoleManager = userService.isManagerGlobally(user)
+        def inRoleAdmin = userService.isUserAdminGlobally(user)
+        def inRoleSuperuser = userService.isSuperuserGlobally(user)
 
         def requiredRoles = RoleType.listRoleTypesForLocationChooser()
 

--- a/grails-app/services/org/pih/warehouse/core/UserService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/UserService.groovy
@@ -149,6 +149,46 @@ class UserService {
         return false
     }
 
+    Boolean hasRoleAssistantGlobally(User u) {
+        if (u) {
+            def assistantRole = RoleType.ROLE_ASSISTANT
+            return u.roles.any { role -> role.roleType == assistantRole}
+        }
+        return false
+    }
+
+    Boolean hasRoleBrowserGlobally(User u) {
+        if (u) {
+            def browserRole = RoleType.ROLE_BROWSER
+            return u.roles.any { role -> role.roleType == browserRole}
+        }
+        return false
+    }
+
+    Boolean isManagerGlobally(User u) {
+        if (u) {
+            def managerRole = RoleType.ROLE_MANAGER
+            return u.roles.any { role -> role.roleType == managerRole}
+        }
+        return false
+    }
+
+    Boolean isUserAdminGlobally(User u) {
+        if (u) {
+            def adminRole = RoleType.ROLE_ADMIN
+            return u.roles.any { role -> role.roleType == adminRole}
+        }
+        return false
+    }
+
+    Boolean isSuperuserGlobally(User u) {
+        if (u) {
+            def superuserRole = RoleType.ROLE_SUPERUSER
+            return u.roles.any { role -> role.roleType == superuserRole}
+        }
+        return false
+    }
+
     Boolean hasHighestRole(User u, String locationId, RoleType roleType) {
         if (u) {
             def user = User.get(u.id)


### PR DESCRIPTION
The problem was that the methods `inRoleBrowser` etc were checking if a user has a permission in any or current location instead of checking if the user has those permissions globally. It is my fault that I haven't realized that, because:
1. it was working well while logging in (because you weren't logged in anywhere and the methods were giving false, and the locations were hidden then, which was good)
2. the "React" method (`getLocations` instead of `getLoginLocations` like it is anywhere else (GSP and logging in)) seemed to be working fine after logging in 
3. The problem turned out on GSP pages - the GSP pages were using the same stuff as while logging in, but inside any GSP page we were logged in to a location, so the methods `inRoleBrowser`, `isUserAdmin` etc were giving some weird stuff.

The fix was to create those methods to check if the user has those permissions globally instead of checking the permission in particular location. It seems to be working fine now in any case (logging in, react and gsp). Even though it should be refactored sometime as discussed, because it might provide to some mistakes in the future.