### PR TITLE
OBS-1176 Don't let LazyInitializationExceptions kill error pages.

### DIFF
--- a/grails-app/taglib/org/pih/warehouse/AuthTagLib.groovy
+++ b/grails-app/taglib/org/pih/warehouse/AuthTagLib.groovy
@@ -9,12 +9,18 @@
  **/
 package org.pih.warehouse
 
+import org.hibernate.LazyInitializationException
 import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.RoleType
 import org.pih.warehouse.core.User
+import org.pih.warehouse.util.ExceptionUtil
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 class AuthTagLib {
+
+    private static final transient Logger log = LoggerFactory.getLogger(AuthTagLib.class)
 
     def userService
 
@@ -110,12 +116,22 @@ class AuthTagLib {
     }
 
     def hasHighestRoleAuthenticated = { attrs, body ->
-        if (User.get(session?.user?.id)?.getHighestRole(session.warehouse).roleType == RoleType.ROLE_AUTHENTICATED)
-            out << body()
+        try {
+            if (User.get(session?.user?.id)?.getHighestRole(session?.warehouse)?.roleType == RoleType.ROLE_AUTHENTICATED) {
+                out << body()
+            }
+        } catch (LazyInitializationException e) {
+            log.error("couldn't check user roles: ${ExceptionUtil.summarize(e)}")
+        }
     }
 
     def hasHigherRoleThanAuthenticated = { attrs, body ->
-        if (User.get(session?.user?.id)?.getHighestRole(session.warehouse).roleType != RoleType.ROLE_AUTHENTICATED)
-            out << body()
+        try {
+            if (User.get(session?.user?.id)?.getHighestRole(session?.warehouse)?.roleType != RoleType.ROLE_AUTHENTICATED) {
+                out << body()
+            }
+        } catch (LazyInitializationException e) {
+            log.error("couldn't check user roles: ${ExceptionUtil.summarize(e)}")
+        }
     }
 }

--- a/grails-app/utils/org/pih/warehouse/util/ExceptionUtil.groovy
+++ b/grails-app/utils/org/pih/warehouse/util/ExceptionUtil.groovy
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2022 Partners In Health.  All rights reserved.
+ * The use and distribution terms for this software are covered by the
+ * Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+ * which can be found in the file epl-v10.html at the root of this distribution.
+ * By using this software in any fashion, you are agreeing to be bound by
+ * the terms of this license.
+ * You must not remove this notice, or any other, from this software.
+ **/
+package org.pih.warehouse.util
+
+import org.apache.commons.lang.exception.ExceptionUtils
+
+class ExceptionUtil {
+
+    /**
+     * Step through a Throwable, extracting messages and "caused by" info.
+     */
+    static String summarize(Throwable t) {
+        Set<String> messages = new LinkedHashSet<String>()
+
+        // stop when we run out of stack trace, or see the same message twice
+        while (t && messages.add(ExceptionUtils.getMessage(t))) {
+            t = ExceptionUtils.getCause(t)
+        }
+
+        return messages.join(', caused by: ')
+    }
+}


### PR DESCRIPTION
This PR adds a guard to `hasHighestRoleAuthenticated` and its close cousin `hasHigherRoleThanAuthenticated` so that, if they are called after the session is closed, they don't crash and don't leak sensitive information.

As I mentioned on Slack I'm not particularly happy with this approach, because I don't know what happened in the latest release to trigger it. Still, it can stanch the bleeding; and perhaps this PR or ticket is a better place to discuss than Slack.

Another option would be to eager-load the `roles` collection instead of doing so lazily: it certainly sees a lot of use, so perhaps there'd be a performance improvement along with crash prevention.

A third option would be to refactor the error page so as to not require these methods, and of course a fourth is to figure out the root cause of the issue. That latter one will be tough for me till Monday as I am on the road with limited internet access.