### PR TITLE
OBPIH-4595 Improve validation in invalid value of active in product s…

### DIFF
--- a/grails-app/services/org/pih/warehouse/data/ProductSupplierDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSupplierDataService.groovy
@@ -35,6 +35,7 @@ class ProductSupplierDataService {
         log.info "Validate data " + command.filename
         command.data.eachWithIndex { params, index ->
 
+            def active = params.active
             def productCode = params.productCode
             def supplierName = params.supplierName
             def manufacturerName = params.manufacturerName
@@ -44,6 +45,10 @@ class ProductSupplierDataService {
             def validityStartDate = params.globalPreferenceTypeValidityStartDate
             def validityEndDate = params.globalPreferenceTypeValidityEndDate
             def contractPriceValidUntil = params.contractPriceValidUntil
+
+            if (active && (active != false && active != true)) {
+                command.errors.reject("Row ${index + 1}: Active field has to be either empty or a boolean value (true/false)")
+            }
 
             if (!params.name) {
                 command.errors.reject("Row ${index + 1}: Product Source Name is required")

--- a/grails-app/services/org/pih/warehouse/data/ProductSupplierDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSupplierDataService.groovy
@@ -46,7 +46,7 @@ class ProductSupplierDataService {
             def validityEndDate = params.globalPreferenceTypeValidityEndDate
             def contractPriceValidUntil = params.contractPriceValidUntil
 
-            if (active && (active != false && active != true)) {
+            if (active && !(active instanceof Boolean)) {
                 command.errors.reject("Row ${index + 1}: Active field has to be either empty or a boolean value (true/false)")
             }
 


### PR DESCRIPTION
…ource import

The check 
```
active &&
```
is necessary to make sure the `null` value is accepted by the validation (if active field is null, it is supposed to make the product source active (true) by default)