### PR TITLE
OBPIH-4600 Reason code field disabled when undo substitution after re…

### DIFF
--- a/src/js/components/stock-movement-wizard/outbound/EditPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/EditPage.jsx
@@ -246,8 +246,7 @@ const FIELDS = {
         getDynamicAttr: ({
           fieldValue, subfield, reasonCodes, updateRow, values, rowIndex,
         }) => {
-          const isSubstituted = values.lineItems && values.lineItems[rowIndex] &&
-            values.lineItems[rowIndex].statusCode === 'SUBSTITUTED';
+          const isSubstituted = fieldValue && fieldValue.statusCode === 'SUBSTITUTED';
           return {
             disabled: fieldValue === null || fieldValue === undefined || subfield || isSubstituted,
             options: reasonCodes,

--- a/src/js/components/stock-movement-wizard/request/EditPage.jsx
+++ b/src/js/components/stock-movement-wizard/request/EditPage.jsx
@@ -297,8 +297,7 @@ const AD_HOCK_FIELDS = {
         getDynamicAttr: ({
           fieldValue, subfield, reasonCodes, updateRow, values, rowIndex, showOnly,
         }) => {
-          const isSubstituted = values.lineItems && values.lineItems[rowIndex] &&
-            values.lineItems[rowIndex].statusCode === 'SUBSTITUTED';
+          const isSubstituted = fieldValue && fieldValue.statusCode === 'SUBSTITUTED';
           return {
             disabled: fieldValue === null ||
               fieldValue === undefined ||
@@ -597,8 +596,7 @@ const STOCKLIST_FIELDS_PUSH_TYPE = {
         getDynamicAttr: ({
           fieldValue, subfield, reasonCodes, updateRow, values, rowIndex, showOnly,
         }) => {
-          const isSubstituted = values.lineItems && values.lineItems[rowIndex] &&
-            values.lineItems[rowIndex].statusCode === 'SUBSTITUTED';
+          const isSubstituted = fieldValue && fieldValue.statusCode === 'SUBSTITUTED';
           return {
             disabled: fieldValue === null ||
               fieldValue === undefined ||
@@ -897,8 +895,7 @@ const STOCKLIST_FIELDS_PULL_TYPE = {
         getDynamicAttr: ({
           fieldValue, subfield, reasonCodes, updateRow, values, rowIndex, showOnly,
         }) => {
-          const isSubstituted = values.lineItems && values.lineItems[rowIndex] &&
-            values.lineItems[rowIndex].statusCode === 'SUBSTITUTED';
+          const isSubstituted = fieldValue && fieldValue.statusCode === 'SUBSTITUTED';
           return {
             disabled: fieldValue === null ||
               fieldValue === undefined ||


### PR DESCRIPTION
…turn to sm after save and exit

After long investigation I think the problem there was that `const isSubstituted` was considering `lineItems` instead of `editPageItems` which are taken to the table. After substituting, the item has `statusCode` === 'SUBSTITUTED', but when making the reproduction steps from the ticket, and undoing the item, this item in `lineItems`' array had still `statusCode` 'SUBSTITUTED' (it should have 'APPROVED') and it seemed like only editPageItems refetch after the undoing. 
Assuming that in above fields we don't use `lineItems` anywhere and we do use `editPageItems`, I think it should be the proper fix.