### PR TITLE
OBPIH-4001 Make admin, manager, assistant be able to delete pending POs

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -1124,7 +1124,7 @@ openboxes.security.rbac.rules = [
         //[controller: '*', actions: ['remove*'], access: [RoleType.ROLE_SUPERUSER]],
         //[controller: '*', actions: ['delete*'], access: [RoleType.ROLE_SUPERUSER]]
         // ... otherwise we'll need to include explicit rules for everything
-        [controller: 'order', actions: ['remove'], accessRules: [ minimumRequiredRole: RoleType.ROLE_MANAGER ]],
+        [controller: 'order', actions: ['remove'], accessRules: [ minimumRequiredRole: RoleType.ROLE_ASSISTANT ]],
         [controller: 'order', actions: ['removeOrderItem'], accessRules: [ minimumRequiredRole: RoleType.ROLE_MANAGER ]],
         [controller: 'invoice', actions: ['eraseInvoice'], accessRules: [ minimumRequiredRole: RoleType.ROLE_MANAGER ]],
         [controller: 'invoiceApi', actions: ['removeItem'],  accessRules: [  minimumRequiredRole: RoleType.ROLE_MANAGER, supplementalRoles: [RoleType.ROLE_INVOICE] ]],

--- a/grails-app/conf/RoleFilters.groovy
+++ b/grails-app/conf/RoleFilters.groovy
@@ -28,8 +28,7 @@ class RoleFilters {
             'location'     : ['edit'],
             'shipper'      : ['create'],
             'locationGroup': ['create'],
-            'locationType' : ['create'],
-            '*'            : ['remove']
+            'locationType' : ['create']
     ]
 
     def static superuserControllers = []

--- a/grails-app/views/order/_actions.gsp
+++ b/grails-app/views/order/_actions.gsp
@@ -1,4 +1,4 @@
-<%@ page import="org.pih.warehouse.core.ActivityCode" %>
+<%@ page import="org.pih.warehouse.core.RoleType; org.pih.warehouse.core.ActivityCode" %>
 <%@ page import="org.pih.warehouse.core.Constants" %>
 <%@ page import="org.pih.warehouse.core.Location" %>
 <%@ page import="org.pih.warehouse.order.OrderStatus" %>
@@ -92,9 +92,9 @@
 					</g:link>
 				</div>
 			</g:elseif>
-			<g:isSuperuser>
-				<g:if test="${orderInstance?.orderType == PURCHASE_ORDER}">
-					<g:supports activityCode="${ActivityCode.PLACE_ORDER}">
+			<g:if test="${orderInstance?.orderType == PURCHASE_ORDER}">
+				<g:supports activityCode="${ActivityCode.PLACE_ORDER}">
+					<g:isSuperuser>
 						<div class="action-menu-item">
 							<hr/>
 						</div>
@@ -118,6 +118,8 @@
 								</g:link>
 							</g:if>
 						</div>
+					</g:isSuperuser>
+					<g:isUserInRole roles="[RoleType.ROLE_SUPERUSER, RoleType.ROLE_ADMIN, RoleType.ROLE_ASSISTANT, RoleType.ROLE_MANAGER]">
 						<div class="action-menu-item">
 							<g:link controller="order" action="remove" id="${orderInstance?.id}"
 									disabled="${orderInstance?.status != OrderStatus.PENDING}"
@@ -127,20 +129,9 @@
 								&nbsp;${warehouse.message(code: 'order.deleteOrder.label')}
 							</g:link>
 						</div>
-					</g:supports>
-				</g:if>
-				<g:if test="${orderInstance?.orderType == PUTAWAY_ORDER && orderInstance?.status != OrderStatus.COMPLETED}">
-					<div class="action-menu-item">
-						<g:link controller="order" action="remove" id="${orderInstance?.id}"
-								disabled="${orderInstance?.status != OrderStatus.PENDING}"
-								disabledMessage="${g.message(code:'order.errors.delete.message')}"
-								onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');">
-							<img src="${resource(dir: 'images/icons/silk', file: 'bin.png')}" />
-							&nbsp;${warehouse.message(code: 'order.deleteOrder.label')}
-						</g:link>
-					</div>
-				</g:if>
-			</g:isSuperuser>
+					</g:isUserInRole>
+				</g:supports>
+			</g:if>
         </div>
 	</span>
 </g:if>

--- a/grails-app/views/order/_actions.gsp
+++ b/grails-app/views/order/_actions.gsp
@@ -132,6 +132,19 @@
 					</g:isUserInRole>
 				</g:supports>
 			</g:if>
+			<g:if test="${orderInstance?.orderType == PUTAWAY_ORDER && orderInstance?.status != OrderStatus.COMPLETED}">
+				<g:isSuperuser>
+					<div class="action-menu-item">
+						<g:link controller="order" action="remove" id="${orderInstance?.id}"
+								disabled="${orderInstance?.status != OrderStatus.PENDING}"
+								disabledMessage="${g.message(code:'order.errors.delete.message')}"
+								onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');">
+							<img src="${resource(dir: 'images/icons/silk', file: 'bin.png')}" />
+							&nbsp;${warehouse.message(code: 'order.deleteOrder.label')}
+						</g:link>
+					</div>
+				</g:isSuperuser>
+			</g:if>
         </div>
 	</span>
 </g:if>


### PR DESCRIPTION
The main problem to fix was that the `Delete order` button was visible only for superusers and that I had to figure out how to prevent `<g:link>` of disabling the button after making is visible not only for superusers.
Deleting now works for role at least Assistant, so for roles: Superuser, Admin, Manager, Assistant.