### PR TITLE
OBPIH-3983 Manager cannot delete a pending shipment

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -1130,6 +1130,7 @@ openboxes.security.rbac.rules = [
         [controller: 'invoiceApi', actions: ['removeItem'],  accessRules: [  minimumRequiredRole: RoleType.ROLE_MANAGER, supplementalRoles: [RoleType.ROLE_INVOICE] ]],
         [controller: 'stockTransfer', actions: ['eraseStockTransfer'],  accessRules: [ minimumRequiredRole: RoleType.ROLE_MANAGER ]],
         [controller: 'stockMovementItemApi', actions: ['eraseItem'],  accessRules: [ minimumRequiredRole: RoleType.ROLE_ASSISTANT ]],
+        [controller: 'stockMovement', actions: ['remove'], accessRules: [ minimumRequiredRole: RoleType.ROLE_ASSISTANT ]]
         // Other controller actions that might need explicit rules
         //[controller: 'putawayItemApi', actions: ['removingItem'], access: [RoleType.ROLE_MANAGER]],
 ]

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -1130,7 +1130,8 @@ openboxes.security.rbac.rules = [
         [controller: 'invoiceApi', actions: ['removeItem'],  accessRules: [  minimumRequiredRole: RoleType.ROLE_MANAGER, supplementalRoles: [RoleType.ROLE_INVOICE] ]],
         [controller: 'stockTransfer', actions: ['eraseStockTransfer'],  accessRules: [ minimumRequiredRole: RoleType.ROLE_MANAGER ]],
         [controller: 'stockMovementItemApi', actions: ['eraseItem'],  accessRules: [ minimumRequiredRole: RoleType.ROLE_ASSISTANT ]],
-        [controller: 'stockMovement', actions: ['remove'], accessRules: [ minimumRequiredRole: RoleType.ROLE_ASSISTANT ]]
+        [controller: 'stockMovement', actions: ['remove'], accessRules: [ minimumRequiredRole: RoleType.ROLE_ASSISTANT ]],
+        [controller: 'stockRequest', actions: ['remove'], accessRules: [minimumRequiredRole: RoleType.ROLE_ADMIN]],
         // Other controller actions that might need explicit rules
         //[controller: 'putawayItemApi', actions: ['removingItem'], access: [RoleType.ROLE_MANAGER]],
 ]

--- a/grails-app/conf/RoleFilters.groovy
+++ b/grails-app/conf/RoleFilters.groovy
@@ -28,7 +28,7 @@ class RoleFilters {
             'location'     : ['edit'],
             'shipper'      : ['create'],
             'locationGroup': ['create'],
-            'locationType' : ['create'],
+            'locationType' : ['create']
     ]
 
     def static superuserControllers = []

--- a/grails-app/conf/RoleFilters.groovy
+++ b/grails-app/conf/RoleFilters.groovy
@@ -29,7 +29,6 @@ class RoleFilters {
             'shipper'      : ['create'],
             'locationGroup': ['create'],
             'locationType' : ['create'],
-            '*'            : ['remove']
     ]
 
     def static superuserControllers = []

--- a/grails-app/conf/UrlMappings.groovy
+++ b/grails-app/conf/UrlMappings.groovy
@@ -28,8 +28,6 @@ class UrlMappings {
 
         "/stockRequest/$action/$id**?" {
             controller = "stockMovement"
-            isStockRequest = true
-            expectedSourceType = RequisitionSourceType.ELECTRONIC
         }
 
         "/$controller/$action?/$id?" {

--- a/grails-app/conf/UrlMappings.groovy
+++ b/grails-app/conf/UrlMappings.groovy
@@ -1,6 +1,7 @@
 import grails.validation.ValidationException
 import org.apache.http.auth.AuthenticationException
 import org.hibernate.ObjectNotFoundException
+import org.pih.warehouse.requisition.RequisitionSourceType
 
 /**
  * Copyright (c) 2012 Partners In Health.  All rights reserved.
@@ -23,6 +24,12 @@ class UrlMappings {
 
         "/stockMovement/$action/$id**?" {
             controller = "stockMovement"
+        }
+
+        "/stockRequest/$action/$id**?" {
+            controller = "stockMovement"
+            isStockRequest = true
+            expectedSourceType = RequisitionSourceType.ELECTRONIC
         }
 
         "/$controller/$action?/$id?" {

--- a/grails-app/controllers/org/pih/warehouse/inventory/StockMovementController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/inventory/StockMovementController.groovy
@@ -307,6 +307,14 @@ class StockMovementController {
     def remove = {
         Location currentLocation = Location.get(session.warehouse.id)
         StockMovement stockMovement = stockMovementService.getStockMovement(params.id)
+        boolean isRequestedUrlForStockRequest = params.isStockRequest ?: false
+
+        // Check if URL is /stockRequest and if the stockMovement we are trying to delete is a request
+        // OR check if url is /stockMovement and the stockMovement we are trying to delete is not request to prevent user from trying to delete request using /stockMovement URL
+        if ((params.expectedSourceType == RequisitionSourceType.ELECTRONIC && (!isRequestedUrlForStockRequest || !stockMovement.isElectronicType())) ||
+            params.expectedSourceType != RequisitionSourceType.ELECTRONIC && !isRequestedUrlForStockRequest && stockMovement.isElectronicType()) {
+                throw new IllegalAccessException("You are trying to do something malicious, please stop")
+        }
         if (stockMovement.isDeleteOrRollbackAuthorized(currentLocation)) {
             if (stockMovement?.shipment?.currentStatus == ShipmentStatusCode.PENDING || !stockMovement?.shipment?.currentStatus) {
                 try {

--- a/grails-app/controllers/org/pih/warehouse/inventory/StockMovementController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/inventory/StockMovementController.groovy
@@ -306,7 +306,6 @@ class StockMovementController {
 
     def remove = {
         Location currentLocation = Location.get(session.warehouse.id)
-        boolean isCentralPurchasingEnabled = currentLocation?.supports(ActivityCode.ENABLE_CENTRAL_PURCHASING)
         StockMovement stockMovement = stockMovementService.getStockMovement(params.id)
         if (stockMovement.isDeleteOrRollbackAuthorized(currentLocation)) {
             if (stockMovement?.shipment?.currentStatus == ShipmentStatusCode.PENDING || !stockMovement?.shipment?.currentStatus) {
@@ -332,10 +331,6 @@ class StockMovementController {
         params.direction = (currentLocation == stockMovement.origin) ? StockMovementDirection.OUTBOUND :
                 (currentLocation == stockMovement.destination) ? StockMovementDirection.INBOUND : "ALL"
 
-        if (isCentralPurchasingEnabled) {
-            redirect(controller: 'order', action: "list", params: [orderTypeCode: OrderTypeCode.PURCHASE_ORDER])
-            return
-        }
         redirect(action: "list", params:params)
     }
 

--- a/grails-app/views/stockMovement/_actions.gsp
+++ b/grails-app/views/stockMovement/_actions.gsp
@@ -52,23 +52,23 @@
                             </g:link>
                         </g:isUserAdmin>
                     </g:if>
-                    <g:elseif test="${stockMovement?.isElectronicType()}">
-                        <g:isUserAdmin>
-                            <g:link controller="stockRequest" action="remove" id="${stockMovement?.id}"
-                                    onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');">
-                                <img src="${resource(dir: 'images/icons/silk', file: 'delete.png')}" />
-                                &nbsp;${warehouse.message(code: 'default.delete.label', args:[warehouse.message(code:'stockMovement.label')])}
-                            </g:link>
-                        </g:isUserAdmin>
+                    <g:elseif test="${stockMovement?.electronicType}">
+                        <g:link controller="stockRequest" action="remove" id="${stockMovement?.id}"
+                                onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');"
+                                disabledMessage="You do not have minimum required role to delete stock request"
+                        >
+                            <img src="${resource(dir: 'images/icons/silk', file: 'delete.png')}" />
+                            &nbsp;${warehouse.message(code: 'default.delete.label', args:[warehouse.message(code:'stockMovement.label')])}
+                        </g:link>
                     </g:elseif>
                     <g:else>
-                        <g:isUserInRole roles="[RoleType.ROLE_SUPERUSER, RoleType.ROLE_ADMIN, RoleType.ROLE_MANAGER, RoleType.ROLE_ASSISTANT]">
-                            <g:link controller="stockMovement" action="remove" id="${stockMovement?.id}"
-                                    onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');">
-                                <img src="${resource(dir: 'images/icons/silk', file: 'delete.png')}" />
-                                &nbsp;${warehouse.message(code: 'default.delete.label', args:[warehouse.message(code:'stockMovement.label')])}
-                            </g:link>
-                        </g:isUserInRole>
+                        <g:link controller="stockMovement" action="remove" id="${stockMovement?.id}"
+                                onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');"
+                                disabledMessage="You do not have minimum required role to delete stock movement"
+                        >
+                            <img src="${resource(dir: 'images/icons/silk', file: 'delete.png')}" />
+                            &nbsp;${warehouse.message(code: 'default.delete.label', args:[warehouse.message(code:'stockMovement.label')])}
+                        </g:link>
                     </g:else>
                 </div>
             </g:if>

--- a/grails-app/views/stockMovement/_actions.gsp
+++ b/grails-app/views/stockMovement/_actions.gsp
@@ -52,9 +52,9 @@
                             </g:link>
                         </g:isUserAdmin>
                     </g:if>
-                    <g:elseif test="${stockMovement?.requisition?.sourceType == RequisitionSourceType.ELECTRONIC }">
+                    <g:elseif test="${stockMovement?.isElectronicType()}">
                         <g:isUserAdmin>
-                            <g:link controller="stockMovement" action="remove" id="${stockMovement?.id}"
+                            <g:link controller="stockRequest" action="remove" id="${stockMovement?.id}"
                                     onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');">
                                 <img src="${resource(dir: 'images/icons/silk', file: 'delete.png')}" />
                                 &nbsp;${warehouse.message(code: 'default.delete.label', args:[warehouse.message(code:'stockMovement.label')])}

--- a/grails-app/views/stockMovement/_actions.gsp
+++ b/grails-app/views/stockMovement/_actions.gsp
@@ -1,5 +1,6 @@
-<%@ page import="org.pih.warehouse.shipping.ShipmentStatusCode" %>
+<%@ page import="org.pih.warehouse.requisition.RequisitionSourceType; org.pih.warehouse.shipping.ShipmentStatusCode" %>
 <%@ page import="org.pih.warehouse.api.StockMovementDirection" %>
+<%@ page import="org.pih.warehouse.core.RoleType" %>
 <g:if test="${stockMovement?.id }">
     <span id="stockmovement-action-menu" class="action-menu">
         <button class="action-btn ">
@@ -39,27 +40,38 @@
                     </g:link>
                 </g:else>
             </div>
-            <g:isUserAdmin>
-                <g:if test="${(stockMovement?.isPending() || !stockMovement?.shipment?.currentStatus) && (isSameOrigin || !stockMovement?.origin?.isDepot())}">
-                    <hr/>
-                    <div class="action-menu-item">
-                        <g:if test="${stockMovement?.order}">
+            <g:if test="${(stockMovement?.isPending() || !stockMovement?.shipment?.currentStatus) && (isSameOrigin || !stockMovement?.origin?.isDepot())}">
+                <hr/>
+                <div class="action-menu-item">
+                    <g:if test="${stockMovement?.order}">
+                        <g:isUserAdmin>
                             <g:link class="button" controller="stockTransfer" action="remove" id="${stockMovement?.id}" params="[orderId: stockMovement?.order?.id]"
                                     onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');">
                                 <img src="${resource(dir: 'images/icons/silk', file: 'delete.png')}" />
                                 &nbsp;${warehouse.message(code: 'default.delete.label', args:[warehouse.message(code:'stockMovement.label')])}
                             </g:link>
-                        </g:if>
-                        <g:else>
+                        </g:isUserAdmin>
+                    </g:if>
+                    <g:elseif test="${stockMovement?.requisition?.sourceType == RequisitionSourceType.ELECTRONIC }">
+                        <g:isUserAdmin>
                             <g:link controller="stockMovement" action="remove" id="${stockMovement?.id}"
                                     onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');">
                                 <img src="${resource(dir: 'images/icons/silk', file: 'delete.png')}" />
                                 &nbsp;${warehouse.message(code: 'default.delete.label', args:[warehouse.message(code:'stockMovement.label')])}
                             </g:link>
-                        </g:else>
-                    </div>
-                </g:if>
-            </g:isUserAdmin>
+                        </g:isUserAdmin>
+                    </g:elseif>
+                    <g:else>
+                        <g:isUserInRole roles="[RoleType.ROLE_SUPERUSER, RoleType.ROLE_ADMIN, RoleType.ROLE_MANAGER, RoleType.ROLE_ASSISTANT]">
+                            <g:link controller="stockMovement" action="remove" id="${stockMovement?.id}"
+                                    onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');">
+                                <img src="${resource(dir: 'images/icons/silk', file: 'delete.png')}" />
+                                &nbsp;${warehouse.message(code: 'default.delete.label', args:[warehouse.message(code:'stockMovement.label')])}
+                            </g:link>
+                        </g:isUserInRole>
+                    </g:else>
+                </div>
+            </g:if>
         </div>
     </span>
 </g:if>

--- a/grails-app/views/stockMovement/show.gsp
+++ b/grails-app/views/stockMovement/show.gsp
@@ -110,23 +110,23 @@
                             </g:link>
                         </g:isUserAdmin>
                     </g:if>
-                    <g:elseif test="${stockMovement?.isElectronicType()}">
-                        <g:isUserAdmin>
-                            <g:link controller="stockRequest" action="remove" id="${stockMovement.id}" params="[show:true]" class="button"
-                                    onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');">
-                                <img src="${resource(dir: 'images/icons/silk', file: 'delete.png')}" />&nbsp;
-                                <warehouse:message code="default.button.delete.label" />
-                            </g:link>
-                        </g:isUserAdmin>
+                    <g:elseif test="${stockMovement?.electronicType}">
+                        <g:link controller="stockRequest" action="remove" id="${stockMovement.id}" params="[show:true]" class="button"
+                                onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');"
+                                disabledMessage="You do not have minimum required role to delete stock request"
+                        >
+                            <img src="${resource(dir: 'images/icons/silk', file: 'delete.png')}" />&nbsp;
+                            <warehouse:message code="default.button.delete.label" />
+                        </g:link>
                     </g:elseif>
                     <g:else>
-                        <g:isUserInRole roles="[RoleType.ROLE_SUPERUSER, RoleType.ROLE_ADMIN, RoleType.ROLE_MANAGER, RoleType.ROLE_ASSISTANT]">
-                            <g:link controller="stockMovement" action="remove" id="${stockMovement.id}" params="[show:true]" class="button"
-                                    onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');">
-                                <img src="${resource(dir: 'images/icons/silk', file: 'delete.png')}" />&nbsp;
-                                <warehouse:message code="default.button.delete.label" />
-                            </g:link>
-                        </g:isUserInRole>
+                        <g:link controller="stockMovement" action="remove" id="${stockMovement.id}" params="[show:true]" class="button"
+                                onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');"
+                                disabledMessage="You do not have minimum required role to delete stock movement"
+                        >
+                            <img src="${resource(dir: 'images/icons/silk', file: 'delete.png')}" />&nbsp;
+                            <warehouse:message code="default.button.delete.label" />
+                        </g:link>
                     </g:else>
                 </g:if>
 

--- a/grails-app/views/stockMovement/show.gsp
+++ b/grails-app/views/stockMovement/show.gsp
@@ -1,4 +1,6 @@
 <%@ page import="org.pih.warehouse.requisition.RequisitionStatus; org.pih.warehouse.shipping.ShipmentStatusCode" %>
+<%@ page import="org.pih.warehouse.core.RoleType" %>
+<%@ page import="org.pih.warehouse.requisition.RequisitionSourceType" %>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -97,23 +99,37 @@
                         <warehouse:message code="default.button.rollback.label" />
                     </g:link>
                 </g:elseif>
+            </g:isUserAdmin>
                 <g:if test="${(stockMovement?.isPending() || !stockMovement?.shipment?.currentStatus) && (isSameOrigin || !stockMovement?.origin?.isDepot())}">
                     <g:if test="${stockMovement?.order}">
-                        <g:link class="button" controller="stockTransfer" action="remove" id="${stockMovement?.id}" params="[orderId: stockMovement?.order?.id]"
-                                onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');">
-                            <img src="${resource(dir: 'images/icons/silk', file: 'delete.png')}" />
-                            &nbsp;<warehouse:message code="default.button.delete.label" />
-                        </g:link>
+                        <g:isUserAdmin>
+                            <g:link class="button" controller="stockTransfer" action="remove" id="${stockMovement?.id}" params="[orderId: stockMovement?.order?.id]"
+                                    onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');">
+                                <img src="${resource(dir: 'images/icons/silk', file: 'delete.png')}" />
+                                &nbsp;<warehouse:message code="default.button.delete.label" />
+                            </g:link>
+                        </g:isUserAdmin>
                     </g:if>
+                    <g:elseif test="${stockMovement?.requisition?.sourceType == RequisitionSourceType.ELECTRONIC }">
+                        <g:isUserAdmin>
+                            <g:link controller="stockMovement" action="remove" id="${stockMovement.id}" params="[show:true]" class="button"
+                                    onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');">
+                                <img src="${resource(dir: 'images/icons/silk', file: 'delete.png')}" />&nbsp;
+                                <warehouse:message code="default.button.delete.label" />
+                            </g:link>
+                        </g:isUserAdmin>
+                    </g:elseif>
                     <g:else>
-                        <g:link controller="stockMovement" action="remove" id="${stockMovement.id}" params="[show:true]" class="button"
-                                onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');">
-                            <img src="${resource(dir: 'images/icons/silk', file: 'delete.png')}" />&nbsp;
-                            <warehouse:message code="default.button.delete.label" />
-                        </g:link>
+                        <g:isUserInRole roles="[RoleType.ROLE_SUPERUSER, RoleType.ROLE_ADMIN, RoleType.ROLE_MANAGER, RoleType.ROLE_ASSISTANT]">
+                            <g:link controller="stockMovement" action="remove" id="${stockMovement.id}" params="[show:true]" class="button"
+                                    onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');">
+                                <img src="${resource(dir: 'images/icons/silk', file: 'delete.png')}" />&nbsp;
+                                <warehouse:message code="default.button.delete.label" />
+                            </g:link>
+                        </g:isUserInRole>
                     </g:else>
                 </g:if>
-            </g:isUserAdmin>
+
             <g:isSuperuser>
                 <a href="javascript:void(0);" class="button btn-show-dialog"
                     data-height="600" data-width="1000"

--- a/grails-app/views/stockMovement/show.gsp
+++ b/grails-app/views/stockMovement/show.gsp
@@ -110,9 +110,9 @@
                             </g:link>
                         </g:isUserAdmin>
                     </g:if>
-                    <g:elseif test="${stockMovement?.requisition?.sourceType == RequisitionSourceType.ELECTRONIC }">
+                    <g:elseif test="${stockMovement?.isElectronicType()}">
                         <g:isUserAdmin>
-                            <g:link controller="stockMovement" action="remove" id="${stockMovement.id}" params="[show:true]" class="button"
+                            <g:link controller="stockRequest" action="remove" id="${stockMovement.id}" params="[show:true]" class="button"
                                     onclick="return confirm('${warehouse.message(code: 'default.button.delete.confirm.message', default: 'Are you sure?')}');">
                                 <img src="${resource(dir: 'images/icons/silk', file: 'delete.png')}" />&nbsp;
                                 <warehouse:message code="default.button.delete.label" />

--- a/src/groovy/org/pih/warehouse/api/StockMovement.groovy
+++ b/src/groovy/org/pih/warehouse/api/StockMovement.groovy
@@ -8,6 +8,8 @@ import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.Person
+import org.pih.warehouse.core.Role
+import org.pih.warehouse.core.User
 import org.pih.warehouse.inventory.StockMovementStatusCode
 import org.pih.warehouse.order.Order
 import org.pih.warehouse.order.OrderItemStatusCode
@@ -21,6 +23,8 @@ import org.pih.warehouse.shipping.Shipment
 import org.pih.warehouse.shipping.ShipmentItem
 import org.pih.warehouse.shipping.ShipmentStatusCode
 import org.pih.warehouse.shipping.ShipmentType
+import org.pih.warehouse.auth.AuthService
+import util.ConfigHelper
 
 
 @Validateable
@@ -218,6 +222,17 @@ class StockMovement {
         boolean isDestination = destination?.id == currentLocation.id
         boolean canOriginManageInventory = origin?.supports(ActivityCode.MANAGE_INVENTORY)
         boolean isCentralPurchasingEnabled = currentLocation?.supports(ActivityCode.ENABLE_CENTRAL_PURCHASING)
+
+        // stock request /stockRequest/remove/:id
+        if (this.isElectronicType()) {
+            User user = AuthService.currentUser.get()
+            def rules = ConfigurationHolder.config.openboxes.security.rbac.rules
+            def accessRule = ConfigHelper.findAccessRule("stockRequest", "remove", rules)
+            def userRoles = user.getEffectiveRoles(currentLocation)
+            if (!userRoles.any { Role role -> role.roleType == accessRule?.accessRules?.minimumRequiredRole }) {
+                throw new IllegalAccessException("User must be in role Admin to delete stock request")
+            }
+        }
 
         return ((canOriginManageInventory && isOrigin) || (!canOriginManageInventory && isDestination) || (isCentralPurchasingEnabled && isFromOrder))
     }

--- a/src/groovy/org/pih/warehouse/api/StockMovement.groovy
+++ b/src/groovy/org/pih/warehouse/api/StockMovement.groovy
@@ -80,6 +80,10 @@ class StockMovement {
     Shipment shipment
     List documents
 
+    static transients = [
+            "electronicType"
+    ]
+
     static constraints = {
         id(nullable: true)
         name(nullable: true)
@@ -111,7 +115,6 @@ class StockMovement {
         requestType(nullable: true)
         sourceType(nullable: true)
     }
-
 
     Map toJson() {
         return [
@@ -224,13 +227,12 @@ class StockMovement {
         boolean isCentralPurchasingEnabled = currentLocation?.supports(ActivityCode.ENABLE_CENTRAL_PURCHASING)
 
         // stock request /stockRequest/remove/:id
-        if (this.isElectronicType()) {
+        if (electronicType) {
             User user = AuthService.currentUser.get()
-            def rules = ConfigurationHolder.config.openboxes.security.rbac.rules
-            def accessRule = ConfigHelper.findAccessRule("stockRequest", "remove", rules)
+            def accessRule = ConfigHelper.findAccessRule("stockRequest", "remove")
             def userRoles = user.getEffectiveRoles(currentLocation)
             if (!userRoles.any { Role role -> role.roleType == accessRule?.accessRules?.minimumRequiredRole }) {
-                throw new IllegalAccessException("User must be in role Admin to delete stock request")
+                throw new IllegalAccessException("You don't have minimum required role to perform this action")
             }
         }
 

--- a/src/groovy/util/ConfigHelper.groovy
+++ b/src/groovy/util/ConfigHelper.groovy
@@ -34,12 +34,38 @@ class ConfigHelper {
         def rules = ConfigurationHolder.config.openboxes.security.rbac.rules
 
         // If there is more than one rule specified for the same controller and action, determine which Role is "higher" by sortOrder of RoleType enum, and return the "higher" one
-        ArrayList rule = rules.findAll {
-            (it.controller == controllerName && it.actions.contains(actionName)) ||
-                    (it.controller == controllerName && it.actions.contains("*")) ||
-                    (it.controller == "*" && it.actions.contains("*"))
+
+        ArrayList rule = []
+
+        // First try to find a rule specified for the controllerName and actionName
+        rule = rules.findAll {
+            (it.controller == controllerName && it.actions.contains(actionName))
         }.sort { it?.accessRules?.minimumRequiredRole?.sortOrder }
-        return rule?.size() > 0 ? rule?.first() : null
+
+        if (rule.size() > 0) {
+            return rule.first()
+        }
+
+        // If didn't find anything then try to find a rule for controllerName and action *
+        rule = rules.findAll {
+            (it.controller == controllerName && it.actions.contains("*"))
+        }.sort { it?.accessRules?.minimumRequiredRole?.sortOrder }
+
+        if (rule.size() > 0) {
+            return rule.first()
+        }
+
+        // In the end try to find generic rule (controller="*" and action="*")
+        rule = rules.findAll {
+            (it.controller == "*" && it.actions.contains("*"))
+        }.sort { it?.accessRules?.minimumRequiredRole?.sortOrder }
+
+        if (rule.size() > 0) {
+            return rule.first()
+        }
+
+        // If not a single rule found, return null
+        return null
     }
 
 }

--- a/src/groovy/util/ConfigHelper.groovy
+++ b/src/groovy/util/ConfigHelper.groovy
@@ -8,6 +8,7 @@
  * You must not remove this notice, or any other, from this software.
  **/
 package util
+import org.codehaus.groovy.grails.commons.ConfigurationHolder
 
 // See http://jira.codehaus.org/browse/GRAILS-6515
 class ConfigHelper {
@@ -27,6 +28,18 @@ class ConfigHelper {
             return value
         }
 
+    }
+
+    static findAccessRule(String controllerName, String actionName, Object rules) {
+        ArrayList rule = rules.findAll {
+            (it.controller == controllerName && it.actions.contains(actionName)) ||
+                    (it.controller == controllerName && it.actions.contains("*")) ||
+                    (it.controller == "*" && it.actions.contains("*"))
+        }
+        if (rule?.size() > 1) {
+            throw new Exception("There can't be more than one rule specified for this controller and action!")
+        }
+        return rule?.size() > 0 ? rule.first() : null
     }
 
 }

--- a/src/groovy/util/ConfigHelper.groovy
+++ b/src/groovy/util/ConfigHelper.groovy
@@ -30,16 +30,16 @@ class ConfigHelper {
 
     }
 
-    static findAccessRule(String controllerName, String actionName, Object rules) {
+    static findAccessRule(String controllerName, String actionName) {
+        def rules = ConfigurationHolder.config.openboxes.security.rbac.rules
+
+        // If there is more than one rule specified for the same controller and action, determine which Role is "higher" by sortOrder of RoleType enum, and return the "higher" one
         ArrayList rule = rules.findAll {
             (it.controller == controllerName && it.actions.contains(actionName)) ||
                     (it.controller == controllerName && it.actions.contains("*")) ||
                     (it.controller == "*" && it.actions.contains("*"))
-        }
-        if (rule?.size() > 1) {
-            throw new Exception("There can't be more than one rule specified for this controller and action!")
-        }
-        return rule?.size() > 0 ? rule.first() : null
+        }.sort { it?.accessRules?.minimumRequiredRole?.sortOrder }
+        return rule?.size() > 0 ? rule?.first() : null
     }
 
 }

--- a/test/unit/org/pih/warehouse/utils/ConfigHelperTests.groovy
+++ b/test/unit/org/pih/warehouse/utils/ConfigHelperTests.groovy
@@ -15,11 +15,13 @@ class ConfigHelperTests extends GrailsUnitTestCase {
                 security {
                     rbac { 
                         rules = [
-                            [controller: '*', actions: ['remove'], accessRules: [ minimumRequiredRole: RoleType.ROLE_SUPERUSER ]],
+                            [controller: '*', actions: ['*'], accessRules: [ minimumRequiredRole: org.pih.warehouse.core.RoleType.ROLE_SUPERUSER ]],
+                            [controller: "order", actions: ['show'], accessRules: [ minimumRequiredRole: org.pih.warehouse.core.RoleType.ROLE_SUPERUSER ]],
+                            [controller: 'order', actions: ['*'], accessRules: [ minimumRequiredRole: org.pih.warehouse.core.RoleType.ROLE_SUPERUSER ]],
+                            [controller: '*', actions: ['remove'], accessRules: [ minimumRequiredRole: org.pih.warehouse.core.RoleType.ROLE_SUPERUSER ]],
                             [controller : "stockRequest", actions : ["remove"], accessRules: [ minimumRequiredRole: org.pih.warehouse.core.RoleType.ROLE_MANAGER ]],
                             [controller : "stockRequest", actions : ["remove"], accessRules: [ minimumRequiredRole: org.pih.warehouse.core.RoleType.ROLE_ADMIN ]],
                             [controller: 'stockRequest', actions: ['removeItem'], accessRules: [ minimumRequiredRole: org.pih.warehouse.core.RoleType.ROLE_BROWSER ]],
-                            [controller: 'order', actions: ['*'], accessRules: [ minimumRequiredRole: org.pih.warehouse.core.RoleType.ROLE_SUPERUSER ]],
                         ]
                     }    
                 }    
@@ -48,13 +50,21 @@ class ConfigHelperTests extends GrailsUnitTestCase {
     }
 
     @Test
-    void findAccessRule_shouldReturnNullIfNotExistingRule() {
-        assertNull ConfigHelper.findAccessRule("stockMovement", "show")
+    void findAccessRule_shouldReturnGenericRuleIfNotExistingForControllerButGenericExists() {
+        def expectedResult = [controller: '*', actions: ['*'], accessRules: [ minimumRequiredRole: RoleType.ROLE_SUPERUSER ]]
+        assertEquals expectedResult, ConfigHelper.findAccessRule("inventoryItem", "create")
     }
 
     @Test
     void findAccessRule_shouldReturnCorrectRuleIfControllerHasAsteriskAsActions() {
         def expectedResult = [controller: 'order', actions: ['*'], accessRules: [ minimumRequiredRole: RoleType.ROLE_SUPERUSER ]]
         assertEquals expectedResult, ConfigHelper.findAccessRule("order", "remove")
+    }
+
+    @Test
+    void findAccessRule_shouldReturnMoreSpecifiedRuleIfAdditionalExisitingRuleForControllerButActionIsAsterisk() {
+        def expectedResult = [controller: 'order', actions: ['show'], accessRules: [minimumRequiredRole: RoleType.ROLE_SUPERUSER ]]
+        assertEquals expectedResult, ConfigHelper.findAccessRule("order", "show")
+
     }
 }

--- a/test/unit/org/pih/warehouse/utils/ConfigHelperTests.groovy
+++ b/test/unit/org/pih/warehouse/utils/ConfigHelperTests.groovy
@@ -1,0 +1,67 @@
+package org.pih.warehouse.utils
+
+import grails.test.GrailsUnitTestCase
+import org.junit.Test
+import org.pih.warehouse.core.RoleType
+import util.ConfigHelper
+
+class ConfigHelperTests extends GrailsUnitTestCase {
+    @Test
+    void findAccessRule_shouldReturnCorrectRule() {
+        def rules = [
+            [controller: 'order', actions: ['remove'], accessRules: [ minimumRequiredRole: RoleType.ROLE_MANAGER ]],
+            [controller: 'order', actions: ['removeOrderItem'], accessRules: [ minimumRequiredRole: RoleType.ROLE_MANAGER ]],
+            [controller: 'stockMovement', actions: ['remove'], accessRules: [ minimumRequiredRole: RoleType.ROLE_ASSISTANT ]],
+            [controller: 'stockRequest', actions: ['remove'], accessRules: [minimumRequiredRole: RoleType.ROLE_ADMIN]]
+        ]
+        def expectedResult = [controller: 'stockRequest', actions: ['remove'], accessRules: [minimumRequiredRole: RoleType.ROLE_ADMIN]]
+        assertEquals expectedResult, ConfigHelper.findAccessRule("stockRequest", "remove", rules)
+    }
+
+    @Test
+    void findAccessRule_shouldReturnExceptionWhenTwoRulesForTheSameControllerAndAction() {
+        def rules = [
+                [controller: '*', actions: ['remove'], accessRules: [ minimumRequiredRole: RoleType.ROLE_SUPERUSER ]],
+                [controller: 'order', actions: ['removeOrderItem'], accessRules: [ minimumRequiredRole: RoleType.ROLE_MANAGER ]],
+                [controller: 'stockRequest', actions: ['remove'], accessRules: [minimumRequiredRole: RoleType.ROLE_ADMIN]],
+                [controller: 'stockRequest', actions: ['remove'], accessRules: [minimumRequiredRole: RoleType.ROLE_MANAGER]]
+        ]
+        def message = shouldFail(Exception) {
+            ConfigHelper.findAccessRule("stockRequest", "remove", rules)
+        }
+        assertTrue message == "There can't be more than one rule specified for this controller and action!"
+    }
+
+    @Test
+    void findAccessRule_shouldReturnCorrectRuleWhenTwoActionsContainingTheSameStringFirstScenario() {
+        def rules = [
+                [controller: '*', actions: ['remove'], accessRules: [ minimumRequiredRole: RoleType.ROLE_SUPERUSER ]],
+                [controller: 'order', actions: ['removeOrderItem'], accessRules: [ minimumRequiredRole: RoleType.ROLE_MANAGER ]],
+                [controller: 'stockRequest', actions: ['remove'], accessRules: [minimumRequiredRole: RoleType.ROLE_ADMIN]],
+                [controller: 'stockRequest', actions: ['removeItem'], accessRules: [minimumRequiredRole: RoleType.ROLE_MANAGER]]
+        ]
+        def expectedResult = [controller: 'stockRequest', actions: ['remove'], accessRules: [minimumRequiredRole: RoleType.ROLE_ADMIN]]
+        assertEquals expectedResult, ConfigHelper.findAccessRule("stockRequest", "remove", rules)
+    }
+
+    @Test
+    void findAccessRule_shouldReturnCorrectRuleWhenTwoActionsContainingTheSameStringSecondScenario() {
+        def rules = [
+                [controller: '*', actions: ['remove'], accessRules: [ minimumRequiredRole: RoleType.ROLE_SUPERUSER ]],
+                [controller: 'order', actions: ['removeOrderItem'], accessRules: [ minimumRequiredRole: RoleType.ROLE_MANAGER ]],
+                [controller: 'stockRequest', actions: ['remove'], accessRules: [minimumRequiredRole: RoleType.ROLE_ADMIN]],
+                [controller: 'stockRequest', actions: ['removeItem'], accessRules: [minimumRequiredRole: RoleType.ROLE_MANAGER]]
+        ]
+        def expectedResult = [controller: 'stockRequest', actions: ['removeItem'], accessRules: [minimumRequiredRole: RoleType.ROLE_MANAGER]]
+        assertEquals expectedResult, ConfigHelper.findAccessRule("stockRequest", "removeItem", rules)
+    }
+
+    @Test
+    void findAccessRule_shouldReturnNullIfNotExistingRule() {
+        def rules = [
+                [controller: '*', actions: ['remove'], accessRules: [ minimumRequiredRole: RoleType.ROLE_SUPERUSER ]],
+                [controller: 'order', actions: ['removeOrderItem'], accessRules: [ minimumRequiredRole: RoleType.ROLE_MANAGER ]],
+        ]
+        assertNull ConfigHelper.findAccessRule("stockRequest", "remove", rules)
+    }
+}


### PR DESCRIPTION
What needs to be discussed and I am not sure how to do it is how to distinguish outbound sm (Create outbound movement) from stock request (Create Stock Request) on the backend side, because it uses the same `def remove` and in the rules for now I followed what was supposed to be done for regular shipments so:
```
[controller: 'stockMovement', actions: ['remove'], accessRules: [ minimumRequiredRole: RoleType.ROLE_ASSISTANT ]]
```
but the problem is that we don't want to change the behavior in requests, so it should still remain `> Admin`.
I've hidden **Delete** button on the frontend side checking if `requsition.sourceType == ELECTRONIC:`
```
stockMovement?.requisition?.sourceType == RequisitionSourceType.ELECTRONIC
```
, so if you are not `> Admin` you won't be able to see the button to delete, but I assume we would like to protect it also on the backend side for some circumstances (for example we change a user's role from Admin to Manager while he is on the request's view page and he does see the button (because he rendered it when he had Admin), but he shouldn't be already able to delete). I know it's not high probable to happen, so we need to discuss whether there is some way to distinguish outbound sm and requests in the security rules.
My only idea was to make some additional check in `def remove` in `StockMovementController` to check 
```
if (stockMovement?.requisition?.sourceType == RequisitionSourceType.ELECTRONIC)
```
 (if it's a request) and if so, then check the user role, but isn't it an ugly idea?

As for the redirect stuff - it was discussed with Katarzyna, that it is rather not expected to be redirected to orders' list page when the location has enabled purchasing, so I fixed it on the fly.

cc @awalkowiak @jmiranda 