### PR TITLE
OBPIH-4703 Make PO import not being able to assign inactive source (f…

### DIFF
--- a/grails-app/services/org/pih/warehouse/data/ProductSupplierDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSupplierDataService.groovy
@@ -302,7 +302,8 @@ class ProductSupplierDataService {
                 'manufacturerCode': manufacturerCode,
                 'supplierCode': supplierCode,
         ])
-        def productSupplier = data ? ProductSupplier.get(data.first().id) : null
+        ArrayList<ProductSupplier> productSuppliers = data?.collect{ it -> ProductSupplier.get(it?.id) }?.sort{ !it?.active }
+        def productSupplier = !!productSuppliers ? productSuppliers?.first() : null
         return productSupplier
     }
 

--- a/grails-app/services/org/pih/warehouse/data/ProductSupplierDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSupplierDataService.groovy
@@ -302,7 +302,9 @@ class ProductSupplierDataService {
                 'manufacturerCode': manufacturerCode,
                 'supplierCode': supplierCode,
         ])
+        // Sort productSuppliers by active field, so we make sure that if there is more than one and one of then could be inactive, that the active ones are "moved" to the top of list
         ArrayList<ProductSupplier> productSuppliers = data?.collect{ it -> ProductSupplier.get(it?.id) }?.sort{ !it?.active }
+        // Double negation below is equivalent to productSuppliers.size() > 0 ? productSuppliers.first() : null (empty list is treated as true, so we can't do "productSuppliers ?")
         def productSupplier = !!productSuppliers ? productSuppliers?.first() : null
         return productSupplier
     }

--- a/grails-app/services/org/pih/warehouse/order/OrderService.groovy
+++ b/grails-app/services/org/pih/warehouse/order/OrderService.groovy
@@ -679,12 +679,16 @@ class OrderService {
                                               supplier: supplier,
                                               sourceName: sourceName]
                         ProductSupplier productSupplier = productSupplierDataService.getOrCreateNew(supplierParams, false)
+                        def supplierParamFilled = supplierCode || manufacturerName || manufacturerCode
 
                         if (productSupplier) {
-                            if (!productSupplier.active) {
+                            if (!productSupplier.active && supplierParamFilled) {
                                 throw new ProductException("Product source ${productSupplier.code} for product ${productCode} is inactive")
                             }
-                            orderItem.productSupplier = productSupplier
+                            // If it matches a product source for empty params (rare case), but it's inactive, treat it as if there was not a product source
+                            if (productSupplier.active) {
+                                orderItem.productSupplier = productSupplier
+                            }
                         }
                     }
 

--- a/grails-app/services/org/pih/warehouse/order/OrderService.groovy
+++ b/grails-app/services/org/pih/warehouse/order/OrderService.groovy
@@ -679,6 +679,7 @@ class OrderService {
                                               supplier: supplier,
                                               sourceName: sourceName]
                         ProductSupplier productSupplier = productSupplierDataService.getOrCreateNew(supplierParams, false)
+                        // Check if any of search term fields for productSupplier are filled
                         def supplierParamFilled = supplierCode || manufacturerName || manufacturerCode
 
                         if (productSupplier) {


### PR DESCRIPTION
…ixes after QA)

What wasn't working or rather what I missed, that it should be done is the case where we have for example two product sources for the same product - one inactive and one active - in this case it should match the active one instead of throwing an exception if the inactive was found as `.first()`.
I made it using sort by the `active` field and then returning the first, so I'm sure that the first returned will be active if there are active and inactive in list.
In my opinion what would make the code cleaner would be to just `findAll` active ones and don't even throw the exception, because the inactive sources wouldn't be even found - I will discuss it with Katarzyna and Kelsey, so we could fix it later while releasing (it is not a big thing, but would improve code complexity).

Second case which wasn't working is the rare case where we have a product source which has empty `supplierCode`, `manufacturerName` and `manufacturerCode`.  With my previous changes it would throw an exception if that product source were inactive, because it didn't assume that maybe a user didn't want to provide a product source and that's why he left those fields empty - I discussed it with Katarzyna and if there is such case it should find for the product source, but if it's inactive, then do NOT throw an exception and treat it as there would not be a product source for this product.
It's a release thing so you could trust in me that it should be working fine now and could be merged further not to block anything.
