### PR TITLE
OBPIH-4677 Fix orders and items visible in PO shipment dropdown

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/api/CombinedShipmentItemApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/CombinedShipmentItemApiController.groovy
@@ -48,10 +48,7 @@ class CombinedShipmentItemApiController {
         def destination = Location.get(params.destination)
         List<Order> orders = orderService.getOrdersForCombinedShipment(vendor, destination)
         render([data: orders
-                .findAll{
-                    it.orderItems.any { item -> item.getQuantityRemainingToShip() > 0 } &&
-                    !it.orderItems.any { OrderItem item -> item.canceled}
-                }
+                .findAll{it.orderItems.any { item -> (item.getQuantityRemainingToShip() > 0) && !item.canceled }}
                 .collect {
                     [
                         id: it.id,

--- a/grails-app/services/org/pih/warehouse/order/OrderService.groovy
+++ b/grails-app/services/org/pih/warehouse/order/OrderService.groovy
@@ -139,6 +139,7 @@ class OrderService {
                 eq("origin", origin)
                 eq("destination", destination)
                 eq("orderType", OrderType.findByCode(OrderTypeCode.PURCHASE_ORDER.name()))
+                ge("status", OrderStatus.PLACED)
             }
         }
     }


### PR DESCRIPTION
It wasn't specified in the ticket, but discussed with Katarzyna, that orders which are not at least `PLACED` (e.g. `PENDING`) should not be visible in dropdown (you should not be able to ship any item of such an order). That's why `createCriteria` was also changed by me.