### PR TITLE
OBPIH-4732 Disable ability to select destination without receive stoc…

### DIFF
--- a/grails-app/taglib/org/pih/warehouse/SelectTagLib.groovy
+++ b/grails-app/taglib/org/pih/warehouse/SelectTagLib.groovy
@@ -490,7 +490,7 @@ class SelectTagLib {
 
             // use sparingly - this is expensive since it requires multiple database queries
             if (activityCode) {
-                attrs.from = attrs.from.findAll { it.supports(activityCode) || (!it.supports(activityCode) && it.supports(ActivityCode.SUBMIT_REQUEST)) }
+                attrs.from = attrs.from.findAll { it.supports(activityCode) }
             }
         }
 


### PR DESCRIPTION
…k permission

After investigating this issue, I think it turned out that in this #2871 PR the `SelectTagLib` had been changed unintenationally (even @jmiranda asked there about what we want to achieve by doing this 
`|| (!it.supports(activityCode) && it.supports(ActivityCode.SUBMIT_REQUEST))`
It caused the bug, that we could choose as destination location without receive stock permission but with `SUBMIT_REQUEST`.
I thought that maybe we used somewhere such case, where a location doesn't have passed in `<g:selectOrganization>` `activityCode`, e.g. "Receive stock", but has `SUBMIT_REQUEST` would be wanted, but I didn't find any case, and also in #2871 there is not any `<g:selectOrganization>` edited, so I assume that we didn't wanna touch `<g:selectOrganization>` in #2871 and this `||` didn't have any deeper usage there.

