### PR TITLE
OBPIH-4758 Cannot assign location permissions on a location without m…

### DIFF
--- a/grails-app/views/locationRole/_form.gsp
+++ b/grails-app/views/locationRole/_form.gsp
@@ -31,7 +31,6 @@
                             class="chzn-select-deselect"
                             name="location.id"
                             noSelection="['':'']"
-                            activityCode="${org.pih.warehouse.core.ActivityCode.MANAGE_INVENTORY}"
                             value="${locationRoleInstance?.location?.id?:session.warehouse.id}"/>
                 </td>
             </tr>


### PR DESCRIPTION
…anage inventory enabled

Fix in #3424 made a regression on this dropdown, but I assume the activityCode here was provided by mistake (maybe some copy-paste of dropdown had a place), because discussed with Katarzyna, there shouldn't be any activityCode required for assigning a location role.
It was working before, because without fix from #3424, the locations **WITHOUT** manage inventory were visible if they had submit request, but if the location didn't have submit request and manage inventory, it also wouldn't be visible.