### PR TITLE
OBPIH-4766 Don't implicitly close response when generating Excel files.

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/product/ProductAttributeValueController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductAttributeValueController.groovy
@@ -34,5 +34,6 @@ class ProductAttributeValueController {
         response.contentType = "application/vnd.ms-excel"
         response.setHeader("Content-disposition", "attachment; filename=\"${filename}.xls\"")
         documentService.generateExcel(response.outputStream, data)
+        response.outputStream.flush()
     }
 }

--- a/grails-app/services/org/pih/warehouse/core/DocumentService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/DocumentService.groovy
@@ -9,7 +9,6 @@
  **/
 package org.pih.warehouse.core
 
-
 import org.apache.poi.hssf.usermodel.HSSFSheet
 import org.apache.poi.hssf.usermodel.HSSFWorkbook
 import org.apache.poi.ss.usermodel.Cell
@@ -21,17 +20,14 @@ import org.apache.poi.ss.usermodel.Sheet
 import org.apache.poi.ss.usermodel.Workbook
 import org.apache.poi.ss.util.CellRangeAddress
 import org.codehaus.groovy.grails.commons.ApplicationHolder
-import org.hibernate.criterion.CriteriaSpecification
 import org.docx4j.TextUtils
 import org.docx4j.XmlUtils
 import org.docx4j.convert.out.pdf.PdfConversion
 import org.docx4j.convert.out.pdf.viaXSLFO.Conversion
 import org.docx4j.jaxb.Context
-import org.docx4j.openpackaging.io.SaveToZipFile
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage
 import org.docx4j.openpackaging.parts.WordprocessingML.MainDocumentPart
 import org.docx4j.openpackaging.parts.relationships.Namespaces
-import org.docx4j.wml.Body
 import org.docx4j.wml.BooleanDefaultTrue
 import org.docx4j.wml.Document
 import org.docx4j.wml.P
@@ -41,13 +37,12 @@ import org.docx4j.wml.Tbl
 import org.docx4j.wml.TblGrid
 import org.docx4j.wml.TblGridCol
 import org.docx4j.wml.TblPr
-import org.docx4j.wml.TblWidth
 import org.docx4j.wml.Tc
-import org.docx4j.wml.TcPr
 import org.docx4j.wml.Text
 import org.docx4j.wml.Tr
 import org.docx4j.wml.TrPr
 import org.groovydev.SimpleImageBuilder
+import org.hibernate.criterion.CriteriaSpecification
 import org.pih.warehouse.api.Stocklist
 import org.pih.warehouse.order.Order
 import org.pih.warehouse.order.OrderType
@@ -61,7 +56,6 @@ import org.pih.warehouse.shipping.Shipment
 import javax.xml.bind.JAXBException
 import java.text.DecimalFormat
 import java.text.SimpleDateFormat
-
 
 class DocumentService {
 
@@ -395,7 +389,6 @@ class DocumentService {
                 createExcelRow(sheet, index + 1, dataRow)
             }
             workbook.write(outputStream)
-            outputStream.close()
         } catch (IOException e) {
             log.error("IO exception while generating excel file")
         }


### PR DESCRIPTION
DocumentService.generateExcel() closes the response provided to it, but 3 out of 4 callers attempt to flush the response after it returns, which won’t work. For clarity, I removed the close() call from generateExcel() and added a flush() call to the 1 caller that didn't already do so. Resolves OBENBOXES-OBNAV-Q25.