### PR TITLE
OBS-1253 Fix regression in updateProductAvailability and updateInventorySnapshots

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/InventorySnapshotService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventorySnapshotService.groovy
@@ -409,7 +409,7 @@ class InventorySnapshotService {
     }
 
     void updateInventorySnapshots(Product product) {
-        if (!product || !product.id || !product.productCode) {
+        if (!product?.id) {
             return
         }
         def results = InventorySnapshot.executeUpdate(

--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -748,7 +748,7 @@ class ProductAvailabilityService {
     }
 
     void updateProductAvailability(Product product) {
-        if (!product || !product.id || !product.productCode) {
+        if (!product?.id) {
             return
         }
         def results = ProductAvailability.executeUpdate(


### PR DESCRIPTION
As part of restoring test coverage, I added guards to

- ProductAvailabilityService.updateProductAvailability()
- InventorySnapshotService.updateInventorySnapshots()

to prevent them from firing on objects that had no ID.
However, the change also made it impossible for these
methods to clear Product.productCode, which is an
optional field. I'm not sure if this change is causing
the performance problems, but I believe it is a bug.