### PR TITLE
Revert "OBPIH-4746 Fix creating picklist and shipment items after revising"

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/api/StockMovementApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/StockMovementApiController.groovy
@@ -157,13 +157,7 @@ class StockMovementApiController {
     def reviseItems = {
         StockMovement stockMovement = stockMovementService.getStockMovement(params.id)
         bindStockMovement(stockMovement, request.JSON)
-        // First revise the items
         stockMovementService.reviseItems(stockMovement)
-        // Then create missing picklist items and shipment items (previously this part was done in the stockMovementService.reviseItems,
-        // but since the stockMovementService is transactional there were issues with not properly refreshed product availability
-        // (old values were pulled and validation was failing)
-        stockMovementService.createMissingPicklistItems(stockMovement)
-        stockMovementService.createMissingShipmentItems(stockMovement)
         render status: 200
     }
 

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -1917,6 +1917,9 @@ class StockMovementService {
         if (requisition.hasErrors() || !requisition.save(flush: true)) {
             throw new ValidationException("Invalid requisition", requisition.errors)
         }
+
+        createMissingPicklistItems(stockMovement)
+        createMissingShipmentItems(stockMovement)
     }
 
     void substituteItem(StockMovementItem stockMovementItem) {


### PR DESCRIPTION


This reverts commit aed8b65aab942c17f4f1ed5bbdffde2869d08cc7.

I'm wondering if pulling the following two calls

- stockMovementService.createMissingPicklistItems()
- stockMovementService.createMissingShipmentItems()

out of stockMovementService.updateRequisitionBasedStockMovementItems()'s
transactional context and into StockMovementApiController.reviseItems()
might have unanticipated performance implications? A total guess! But
perhaps worth a PR