### PR TITLE
OBPIH-4704 Fix dashboard moving when switching sections

### DIFF
--- a/src/js/components/Layout/HeaderStyles.scss
+++ b/src/js/components/Layout/HeaderStyles.scss
@@ -185,9 +185,7 @@
 }
 
 @media (max-width: 1440px) {
-  .nav-item {
-    a {
-      padding: 0 8px !important;
-    }
+  .nav-item > a {
+    padding: 0 8px !important;
   }
 }

--- a/src/js/components/dashboard/Dashboard.scss
+++ b/src/js/components/dashboard/Dashboard.scss
@@ -131,8 +131,6 @@
 
 .configs-left-nav {
   position: sticky;
-  // height of the header (single line)
-  top: 108px;
   background-color: #ededed;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
I also realized and fixed on the fly that on resolutions below 1440 menu items inside dropdowns had wrong padding on the left and right side (it was changed from 16 to 8, but it should only change for the main buttons, so for sections: Dashboard, Inventory etc, but not items (`<a>`) inside dropdown).
As for reporting section columns it was decided between Katarzyna and me that we would keep it as it is for now, as the fix would not be that straight forward.