### PR TITLE
OBS-1269 RequisitionItem.undoChanges() should remove dangling references from ShipmentItem

### DIFF
--- a/grails-app/domain/org/pih/warehouse/requisition/RequisitionItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/requisition/RequisitionItem.groovy
@@ -21,6 +21,7 @@ import org.pih.warehouse.product.Category
 import org.pih.warehouse.product.Product
 import org.pih.warehouse.product.ProductGroup
 import org.pih.warehouse.product.ProductPackage
+import org.pih.warehouse.shipping.ShipmentItem
 
 class RequisitionItem implements Comparable<RequisitionItem>, Serializable {
 
@@ -217,6 +218,15 @@ class RequisitionItem implements Comparable<RequisitionItem>, Serializable {
             quantityCanceled = 0
             cancelComments = null
             cancelReasonCode = null
+
+            // remove any dangling references from ShipmentItem, OBS-1269
+            requisitionItems.each {
+                it.shipmentItems.each { ShipmentItem si ->
+                    if (si.requisitionItem) {
+                        si.requisitionItem = null
+                    }
+                }
+            }
 
             if (substitutionItem) {
                 removeFromRequisitionItems(substitutionItem)
@@ -680,7 +690,7 @@ class RequisitionItem implements Comparable<RequisitionItem>, Serializable {
         }
     }
 
-    def getShipmentItems() {
+    Collection<ShipmentItem> getShipmentItems() {
         return requisition?.shipment?.shipmentItems?.findAll { it.requisitionItem?.id == id }?.flatten()
     }
 


### PR DESCRIPTION
This PR prevents the error reported in OBS-1269 where certain undo commands will crash on a requisition that has already been shipped. The cause is a foreign key constraint violation. This patch removes the requisitionItem(s) that the undo command will delete from any ShipmentItem object that points to them.

Since `ShipmentItem.requisitionItem` is explicitly nullable, this might be all we need? But I'm a little suspicious -- can this patch leave ShipmentItem objects in an inconsistent state? Is more recovery/undo logic needed here?