### PR TITLE
OBPIH-4872 Fix fade class opacity styling bug

### DIFF
--- a/grails-app/domain/org/pih/warehouse/inventory/OutboundStockMovementListItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/OutboundStockMovementListItem.groovy
@@ -137,9 +137,9 @@ class OutboundStockMovementListItem implements Serializable {
                         name: stocklist?.name
                 ],
                 order                : [
-                        id                  : shipment?.returnOrder?.id,
-                        name                : shipment?.returnOrder?.name,
-                        orderNumber         : shipment?.returnOrder?.orderNumber
+                        id                  : order?.id,
+                        name                : order?.name,
+                        orderNumber         : order?.orderNumber
                 ],
                 replenishmentType   : stocklist?.replenishmentTypeCode?.name(),
                 dateRequested       : dateRequested?.format("MM/dd/yyyy"),
@@ -168,7 +168,7 @@ class OutboundStockMovementListItem implements Serializable {
     }
 
     Boolean isFromReturnOrder() {
-        return shipment?.isFromReturnOrder
+        return order?.isReturnOrder
     }
 
     Boolean isPending() {

--- a/src/js/components/stock-movement-wizard/request/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/request/AddItemsPage.jsx
@@ -13,7 +13,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import Alert from 'react-s-alert';
 
-import { fetchUsers, hideSpinner, showSpinner, updateBreadcrumbs } from 'actions';
+import { fetchUsers, hideSpinner, showSpinner } from 'actions';
 import ArrayField from 'components/form-elements/ArrayField';
 import ButtonField from 'components/form-elements/ButtonField';
 import LabelField from 'components/form-elements/LabelField';
@@ -1393,13 +1393,18 @@ class AddItemsPage extends Component {
     if (this.state.values.statusCode === 'CREATED') {
       return apiClient.post(url, payload)
         .then(() => {
+          const translatedSubmitMessage = this.props.translate(
+            'react.stockMovement.request.submitMessage.label',
+            'Thank you for submitting your request. You can check the status of your request using stock movement number',
+          );
+          let redirectToURL = '';
           if (!this.props.supportedActivities.includes('MANAGE_INVENTORY') && this.props.supportedActivities.includes('SUBMIT_REQUEST')) {
-            Alert.success(`${this.props.translate('react.stockMovement.request.submitMessage.label', 'Thank you for submitting your request. You can check the status of your request using stock movement number')} ${movementNumber}`);
-            this.props.history.push('/openboxes/');
-            this.props.updateBreadcrumbs([]);
+            redirectToURL = '/openboxes/';
           } else {
-            window.location = `/openboxes/stockMovement/list?direction=INBOUND&movementNumber=${movementNumber}&submitted=true`;
+            redirectToURL = '/openboxes/stockMovement/list?direction=INBOUND';
           }
+          Alert.success(`${translatedSubmitMessage} ${movementNumber}`);
+          this.props.history.push(redirectToURL);
         });
     }
     return Promise.resolve();
@@ -1641,7 +1646,6 @@ const mapDispatchToProps = {
   showSpinner,
   hideSpinner,
   fetchUsers,
-  updateBreadcrumbs,
 };
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(AddItemsPage));
@@ -1678,5 +1682,4 @@ AddItemsPage.propTypes = {
   history: PropTypes.shape({
     push: PropTypes.func,
   }).isRequired,
-  updateBreadcrumbs: PropTypes.func.isRequired,
 };

--- a/web-app/css/openboxes.css
+++ b/web-app/css/openboxes.css
@@ -1263,6 +1263,9 @@ a:hover {
 .fade {
     color: #aaa;
 }
+.fade:not(.show) {
+    opacity: 1;
+}
 .empty {
     line-height: 100px;
     color: #aaa;


### PR DESCRIPTION
After upgrading `bootstrap` version - elements with class `.fade` additionally have `opacity: 0` applied to them.
The reason for that is that new version of bootstrap has additional styling for class `.fade` where:
```
.fade:not(.show) {
    opacity: 0;
}
```
so instead of adding in every instance where we use class `.fade` additional class `.show` I just overwritten the styling for `.fade:not(.show)`