### PR TITLE
OBPIH-4921 Improve list pages/filter component not to make unnecessar…

### DIFF
--- a/src/js/MainRouter.jsx
+++ b/src/js/MainRouter.jsx
@@ -19,18 +19,17 @@ const TRANSLATION_PREFIXES = ['default', 'dashboard', 'combinedShipments', 'prod
 
 class MainRouter extends React.Component {
   componentDidMount() {
-    this.props.fetchSessionInfo().then(() => {
-      this.props.initialize({
-        languages: this.props.supportedLocales,
-        options: {
-          renderToStaticMarkup,
-          onMissingTranslation,
-        },
-      });
-      this.props.setActiveLanguage(this.props.locale);
-      this.props.fetchMenuConfig();
-      TRANSLATION_PREFIXES.forEach(prefix => this.props.fetchTranslations('', prefix));
+    this.props.fetchSessionInfo();
+    this.props.initialize({
+      languages: this.props.supportedLocales,
+      options: {
+        renderToStaticMarkup,
+        onMissingTranslation,
+      },
     });
+    this.props.setActiveLanguage(this.props.locale);
+    this.props.fetchMenuConfig();
+    TRANSLATION_PREFIXES.forEach(prefix => this.props.fetchTranslations('', prefix));
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -105,11 +105,14 @@ export function fetchUsers() {
 
 export function fetchSessionInfo() {
   const url = '/openboxes/api/getAppContext';
-  const request = apiClient.get(url);
-
-  return {
-    type: FETCH_SESSION_INFO,
-    payload: request,
+  return (dispatch) => {
+    apiClient.get(url)
+      .then((res) => {
+        dispatch({
+          type: FETCH_SESSION_INFO,
+          payload: res,
+        });
+      });
   };
 }
 

--- a/src/js/components/invoice/InvoiceListFilters.jsx
+++ b/src/js/components/invoice/InvoiceListFilters.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
+import usePrevious from 'hooks/usePrevious';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
@@ -109,21 +110,29 @@ const InvoiceListFilters = ({
   fetchTypeCodes,
 }) => {
   const [defaultValues, setDefaultValues] = useState({});
+  const prevLocation = usePrevious(currentLocation);
+  const [initiallyFetched, setInitiallyFetched] = useState(false);
 
   useEffect(() => {
-    const initialEmptyValues = Object.keys(filterFields).reduce((acc, key) => {
-      if (!acc[key]) return { ...acc, [key]: '' };
-      return acc;
-    }, {});
-    setDefaultValues({
-      ...initialEmptyValues,
-      buyerOrganization: {
-        id: currentLocation?.organization?.id,
-        value: currentLocation?.organization?.id,
-        name: currentLocation?.organization?.name,
-        label: currentLocation?.organization?.name,
-      },
-    });
+    // Avoid unnecessary re-fetches if getAppContext triggers fetching session info
+    // but currentLocation doesn't change
+    // eslint-disable-next-line max-len
+    if ((!initiallyFetched && currentLocation?.id) || (prevLocation && prevLocation.id !== currentLocation?.id)) {
+      const initialEmptyValues = Object.keys(filterFields).reduce((acc, key) => {
+        if (!acc[key]) return { ...acc, [key]: '' };
+        return acc;
+      }, {});
+      setDefaultValues({
+        ...initialEmptyValues,
+        buyerOrganization: {
+          id: currentLocation?.organization?.id,
+          value: currentLocation?.organization?.id,
+          name: currentLocation?.organization?.name,
+          label: currentLocation?.organization?.name,
+        },
+      });
+      setInitiallyFetched(true);
+    }
   }, [currentLocation]);
 
   useEffect(() => {

--- a/src/js/components/products/ProductsListTable.jsx
+++ b/src/js/components/products/ProductsListTable.jsx
@@ -24,7 +24,6 @@ const INITIAL_STATE = {
 
 const ProductsListTable = ({
   filterParams,
-  currentLocation,
   translate,
 }) => {
   // Util ref for react-table to force the fetch of data
@@ -35,7 +34,7 @@ const ProductsListTable = ({
   // If filterParams change, refetch the data with applied filters
   useEffect(() => {
     fireFetchData();
-  }, [filterParams, currentLocation]);
+  }, [filterParams]);
 
   const [loading, setLoading] = useState(false);
   const [tableData, setTableData] = useState(INITIAL_STATE);
@@ -234,5 +233,4 @@ export default connect(mapStateToProps)(ProductsListTable);
 ProductsListTable.propTypes = {
   filterParams: PropTypes.shape({}).isRequired,
   translate: PropTypes.func.isRequired,
-  currentLocation: PropTypes.shape({}).isRequired,
 };

--- a/src/js/components/purchaseOrder/PurchaseOrderListTable.jsx
+++ b/src/js/components/purchaseOrder/PurchaseOrderListTable.jsx
@@ -63,7 +63,7 @@ const PurchaseOrderListTable = ({
   const isCentralPurchasingEnabled = supportedActivities.includes('ENABLE_CENTRAL_PURCHASING');
 
   // If filterParams change, refetch the data with applied filters
-  useEffect(() => fireFetchData(), [filterParams, currentLocation]);
+  useEffect(() => fireFetchData(), [filterParams]);
 
   // If orderItems is true, download orders line items details, else download orders
   const downloadOrders = (orderItems) => {

--- a/src/js/hooks/usePrevious.js
+++ b/src/js/hooks/usePrevious.js
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from 'react';
+
+export default function usePrevious(value) {
+  const ref = useRef();
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -120,6 +120,7 @@ module.exports = {
       templates: path.resolve(SRC, 'templates'),
       store: path.resolve(SRC, 'store'),
       css: path.resolve(ROOT, 'css'),
+      hooks: path.resolve(SRC, 'hooks'),
     },
     extensions: ['.js', '.jsx'],
   },


### PR DESCRIPTION
…y fetches of data (fixes after QA)

It has not been that easy straight forward as it was supposed to be, as it was not working propely on obnav and I had hard time to reproduce the issue locally, but it turned out not to be working (not always) when freshly running the project and having clean local storage. Many problems combined - the redux persist is not always working - it does not always "remember" the values - in this case it hardly ever remembers `currentLocation` when switching between React tabs and on the other hand if it does remember, it fetches the session data including `currentLocation` again, which makes the filters run again multiple times (multiple times if initially the redux persist REMEMBERED the value, so the fetch of data on list pages could continue, because currentLocation exists), but if it gets "fresh" (the same) `currentLocation`, it makes the fetch work again, so I had to come up with some solution to be able to "recognize" if:
1. redux persist remembers the currentLocation
2. To be able to determine if we initially fetched anything (so we do not fetch two times if redux persist remembered the currentLocatoin so the fetch could continue without "waiting" for another fetch of session info (FETCH_SESSION_INFO).
3. To be able to store the previous value of currentLocation, so if it is the same as previous one, it means we don't have to fetch data again

The code, especially those if's might seem complicated, but it was the only way to prevent each of those scenarios (you can just imagine the complexity of it, if anytime you run the project again, the redux persist gave different results of either storing the session info propely or not).

I know it's not possible to fetch the session data only once when running the project if we don't have 100% React , because in the "meantime" for example our user's role might change and we should be able to refresh that data ASAP, but I think we should consider dividing the session stuff which can't change "in the meantime" without your interference (and `currentLocation` might be one of many), so we can avoid those complicated solutions in some places.
