### PR TITLE
OBS-1269 Remove dangling references when calling StockMovementService.reviseItems()

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/api/StockMovementApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/StockMovementApiController.groovy
@@ -386,7 +386,7 @@ class StockMovementApiController {
 
         // Bind all line items
         if (lineItems) {
-            log.info "lineItems: " + lineItems
+            log.info "binding lineItems: ${lineItems}"
             bindLineItems(stockMovement, lineItems)
         }
 

--- a/grails-app/domain/org/pih/warehouse/requisition/RequisitionItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/requisition/RequisitionItem.groovy
@@ -21,8 +21,12 @@ import org.pih.warehouse.product.Category
 import org.pih.warehouse.product.Product
 import org.pih.warehouse.product.ProductGroup
 import org.pih.warehouse.product.ProductPackage
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 class RequisitionItem implements Comparable<RequisitionItem>, Serializable {
+
+    private static final transient Logger log = LoggerFactory.getLogger(RequisitionItem)
 
     def beforeInsert = {
         def currentUser = AuthService.currentUser.get()

--- a/grails-app/domain/org/pih/warehouse/requisition/RequisitionItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/requisition/RequisitionItem.groovy
@@ -271,7 +271,7 @@ class RequisitionItem implements Comparable<RequisitionItem>, Serializable {
      */
     def changeQuantity(Integer newQuantity, ProductPackage newProductPackage, String reasonCode, String comments) {
 
-        println "Change quantity: " + newQuantity + " " + reasonCode + " " + comments
+        log.info "Change quantity: ${newQuantity} ${reasonCode} ${comments}"
         // And then create a new requisition item for the remaining quantity (if not 0)
         if (newQuantity == 0) {
             cancelQuantity(reasonCode, comments)

--- a/grails-app/domain/org/pih/warehouse/requisition/RequisitionItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/requisition/RequisitionItem.groovy
@@ -225,7 +225,7 @@ class RequisitionItem implements Comparable<RequisitionItem>, Serializable {
             if (substitutionItem) {
                 removeFromRequisitionItems(substitutionItem)
                 requisition.removeFromRequisitionItems(substitutionItem)
-                modificationItem.disableRefresh = Boolean.TRUE
+                substitutionItem.disableRefresh = Boolean.TRUE
                 substitutionItem.delete()
             }
 

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -1889,7 +1889,7 @@ class StockMovementService {
                 }
 
                 if (!requisitionItem) {
-                    throw new IllegalArgumentException("Could not find requisition item for stock movement item with ID ${stockMovementItem.id}")
+                    throw new IllegalArgumentException("Could not find stock movement item with ID ${stockMovementItem.id}")
                 }
 
                 log.info 'Removing previous changes, picklists and shipments, if present'

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -1881,7 +1881,6 @@ class StockMovementService {
 
     void reviseItems(StockMovement stockMovement) {
         Requisition requisition = Requisition.get(stockMovement.id)
-        def revisedItems = []
 
         if (stockMovement.lineItems) {
             stockMovement.lineItems.each { StockMovementItem stockMovementItem ->
@@ -1890,20 +1889,14 @@ class StockMovementService {
                 }
 
                 if (!requisitionItem) {
-                    throw new IllegalArgumentException("Could not find stock movement item with ID ${stockMovementItem.id}")
+                    throw new IllegalArgumentException("Could not find requisition item for stock movement item with ID ${stockMovementItem.id}")
                 }
 
-                if (requisitionItem.shipmentItems || requisitionItem.picklistItems) {
-                    removeShipmentAndPicklistItemsForModifiedRequisitionItem(requisitionItem)
-                }
+                log.info 'Removing previous changes, picklists and shipments, if present'
+                removeShipmentAndPicklistItemsForModifiedRequisitionItem(requisitionItem)
+                requisitionItem.undoChanges()
 
-                log.info "Item revised " + requisitionItem.id
-
-                // Cannot cancel quantity if it has already been canceled
-                if (requisitionItem.quantityCanceled) {
-                    requisitionItem.undoChanges()
-                }
-
+                log.info "Revising quantity for ${requisitionItem.id}"
                 requisitionItem.changeQuantity(
                         stockMovementItem?.quantityRevised?.intValueExact(),
                         stockMovementItem.reasonCode,


### PR DESCRIPTION
Hi @jmiranda, I was able to reproduce OBS-1269 by moving back and forth a few times between Edit, Pick and Ship and editing the quantity field _without_ ever clicking the big red Undo button. More details are on the ticket.

The one-line summary of this change is that it basically presses the undo button for you if you don't press it yourself before editing the quantity.

In more detail, `reviseItems()`, as written, has guards around `removeShipmentAndPicklistItemsForModifiedRequisitionItem()` and `RequisitionItem::undoChanges()` which strikes me as both unnecessary and, at least in the case described in OBS-1269, incorrect. (Contrast the `revertItem()` implementation which calls them indiscriminately.)

In fact, nowhere else in this file do I see guards around either of these methods, while both of them have sufficient logic internally to prevent doing the wrong thing if they are called when there is in fact nothing to undo (I tested this assumption by making a separate build that called each method twice while testing this patch).

I was able to go back and forth cheerfully between states while making any number of edits with this patch in place. Is there anything else you'd like me to look into to make sure I didn't break something elsewhere?