### PR TITLE
OBPIH-4875 Data do not fit to columns in reports

### DIFF
--- a/grails-app/views/layouts/custom.gsp
+++ b/grails-app/views/layouts/custom.gsp
@@ -8,7 +8,7 @@
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.14.7/dist/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.3.1/dist/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4/dt-1.12.1/datatables.min.css"/>
     <!-- YUI -->
     <yui:stylesheet dir="reset-fonts-grids" file="reset-fonts-grids.css" />
 

--- a/grails-app/views/layouts/custom.gsp
+++ b/grails-app/views/layouts/custom.gsp
@@ -8,7 +8,6 @@
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.14.7/dist/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.3.1/dist/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4/dt-1.12.1/datatables.min.css"/>
     <!-- YUI -->
     <yui:stylesheet dir="reset-fonts-grids" file="reset-fonts-grids.css" />
 

--- a/web-app/css/openboxes.css
+++ b/web-app/css/openboxes.css
@@ -419,10 +419,6 @@ th.desc a {
 
 /* DIALOG */
 
-.dialog table {
-    padding: 5px 0;
-}
-
 .prop {
     padding: 5px;
 }

--- a/web-app/css/openboxes.css
+++ b/web-app/css/openboxes.css
@@ -3254,6 +3254,14 @@ table.dataTable tbody tr.even td.sorting_1 { background-color: #fff; }
 
 table.dataTable tbody tr.odd td.sorting_2 { background-color: #f7f7f7;; }
 table.dataTable tbody tr.even td.sorting_2 { background-color: #fff; }
+
+table.dataTable td,
+table.dataTable th {
+    -webkit-box-sizing: content-box;
+    -moz-box-sizing: content-box;
+    box-sizing: content-box;
+}
+
 #dataTable_processing { height: 60px; }
 
 input {


### PR DESCRIPTION
It turned out after long research that I had to add additional package of styles for datatable I found for bootstrap 4. Weird part is that anyway I have to keep old styles as well and on Mozilla it works well without any change.
As the styles provided (or rather make our custom styles working) also additional padding in one place, I had to remove this padding in styles.
