### PR TITLE
OBPIH-4914 Combined fixes of issues on list pages

### DIFF
--- a/src/js/components/Filter/FilterForm.jsx
+++ b/src/js/components/Filter/FilterForm.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { Form } from 'react-final-form';
+import { connect } from 'react-redux';
 
 import FilterVisibilityToggler from 'components/Filter/FilterVisibilityToggler';
 import Button from 'components/form-elements/Button';
@@ -23,6 +24,7 @@ const FilterForm = ({
   hidden,
   onClear,
   ignoreClearFilters,
+  currentLocation,
 }) => {
   const [amountFilled, setAmountFilled] = useState(0);
   const [filtersHidden, setFiltersHidden] = useState(hidden);
@@ -38,7 +40,7 @@ const FilterForm = ({
   // Default values can change based on currentLocation
   // or any async data defaultValues are waiting for
   useEffect(() => {
-    updateFilterParams(defaultValues);
+    updateFilterParams({ ...defaultValues });
   }, [defaultValues]);
 
   // Calculate which object's values are not empty
@@ -65,12 +67,21 @@ const FilterForm = ({
     form.reset(clearedFilterList);
   };
 
+  const formRef = useRef(null);
+
+  useEffect(() => {
+    if (formRef.current) {
+      onClearHandler(formRef.current);
+    }
+  }, [currentLocation?.id]);
+
   return (
     <div className="filter-form">
       <Form
         onSubmit={updateFilterParams}
-        initialValues={defaultValues}
+        initialValues={{ ...defaultValues }}
         render={({ values, handleSubmit, form }) => {
+          formRef.current = form;
           countFilled(values);
           return (
             <form onSubmit={handleSubmit} className="w-100 m-0">
@@ -116,7 +127,11 @@ const FilterForm = ({
   );
 };
 
-export default FilterForm;
+const mapStateToProps = state => ({
+  currentLocation: state.session.currentLocation,
+});
+
+export default connect(mapStateToProps)(FilterForm);
 
 
 FilterForm.propTypes = {
@@ -130,6 +145,9 @@ FilterForm.propTypes = {
   allowEmptySubmit: PropTypes.bool,
   hidden: PropTypes.bool,
   ignoreClearFilters: PropTypes.arrayOf(PropTypes.string),
+  currentLocation: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 FilterForm.defaultProps = {

--- a/src/js/components/invoice/InvoiceListFilters.jsx
+++ b/src/js/components/invoice/InvoiceListFilters.jsx
@@ -162,6 +162,7 @@ const InvoiceListFilters = ({
         searchFieldPlaceholder="Search by invoice number..."
         searchFieldId="invoiceNumber"
         hidden={false}
+        ignoreClearFilters={['buyerOrganization']}
       />
     </div>
   );

--- a/src/js/components/location/LocationChooser/index.jsx
+++ b/src/js/components/location/LocationChooser/index.jsx
@@ -75,8 +75,8 @@ const LocationChooser = (props) => {
   const selectLocation = (location) => {
     props.changeCurrentLocation(location).then(() => {
       props.fetchMenuConfig();
+      props.fetchSessionInfo();
     });
-    props.fetchSessionInfo();
     setIsOpen(false);
   };
 

--- a/src/js/components/products/ProductsList.jsx
+++ b/src/js/components/products/ProductsList.jsx
@@ -21,6 +21,7 @@ const ProductsList = (props) => {
   const [categories, setCategories] = useState([]);
   const [catalogs, setCatalogs] = useState([]);
   const [tags, setTags] = useState([]);
+  const [filtersInitialized, setFiltersInitialized] = useState(false);
 
   const fetchProductsCategories = async () => {
     const response = await apiClient.get('/openboxes/api/categoryOptions');
@@ -40,6 +41,12 @@ const ProductsList = (props) => {
   useEffect(() => {
     props.fetchTranslations(props.locale, 'productsList');
   }, [props.locale]);
+
+
+  const clearFilterValues = () => {
+    const { pathname } = props.history.location;
+    props.history.push({ pathname });
+  };
 
 
   const initializeDefaultFilterValues = async () => {
@@ -97,11 +104,22 @@ const ProductsList = (props) => {
     if (queryProps.catalogId || queryProps.tagId || queryProps.categoryId) {
       setDefaultFilterValues(defaultValues);
     }
+    setFiltersInitialized(true);
   };
 
   useEffect(() => {
-    initializeDefaultFilterValues();
-  }, []);
+    // Don't clear the query params while doing first filter initialization
+    // clear the filters only when changing location, but not refreshing page
+    if (filtersInitialized) {
+      clearFilterValues();
+    }
+  }, [props.currentLocation?.id]);
+
+  useEffect(() => {
+    if (props.currentLocation?.id) {
+      initializeDefaultFilterValues();
+    }
+  }, [props.currentLocation?.id]);
 
   const setFilterValues = (values) => {
     const filterAccessors = {
@@ -136,6 +154,7 @@ const ProductsList = (props) => {
 
 const mapStateToProps = state => ({
   locale: state.session.activeLanguage,
+  currentLocation: state.session.currentLocation,
 });
 
 const mapDispatchToProps = {
@@ -154,5 +173,8 @@ ProductsList.propTypes = {
     location: PropTypes.shape({
       search: PropTypes.string,
     }),
+  }).isRequired,
+  currentLocation: PropTypes.shape({
+    id: PropTypes.string.isRequired,
   }).isRequired,
 };

--- a/src/js/components/purchaseOrder/PurchaseOrderListFilters.jsx
+++ b/src/js/components/purchaseOrder/PurchaseOrderListFilters.jsx
@@ -14,6 +14,7 @@ const PurchaseOrderListFilters = ({
   filterFields,
   defaultValues,
   formProps,
+  supportedActivities,
 }) => {
   const debouncedOriginLocationsFetch = debounceLocationsFetch(
     debounceTime,
@@ -33,6 +34,8 @@ const PurchaseOrderListFilters = ({
   );
   const debouncedUsersFetch = debounceUsersFetch(debounceTime, minSearchLength);
 
+  const filtersToIgnore = supportedActivities.includes('ENABLE_CENTRAL_PURCHASING') ? ['destinationParty'] : ['destination'];
+
   return (
     <div className="d-flex flex-column list-page-filters">
       <FilterForm
@@ -44,7 +47,7 @@ const PurchaseOrderListFilters = ({
           debouncedDestinationLocationsFetch,
           debouncedUsersFetch,
         }}
-        ignoreClearFilters={['destination']}
+        ignoreClearFilters={filtersToIgnore}
         defaultValues={defaultValues}
         allowEmptySubmit
         searchFieldPlaceholder="Search by order number or name or supplier"
@@ -57,6 +60,7 @@ const PurchaseOrderListFilters = ({
 const mapStateToProps = state => ({
   debounceTime: state.session.searchConfig.debounceTime,
   minSearchLength: state.session.searchConfig.minSearchLength,
+  supportedActivities: state.session.supportedActivities,
 });
 
 export default connect(mapStateToProps)(PurchaseOrderListFilters);
@@ -68,4 +72,5 @@ PurchaseOrderListFilters.propTypes = {
   filterFields: PropTypes.shape({}).isRequired,
   defaultValues: PropTypes.shape({}).isRequired,
   formProps: PropTypes.shape({}).isRequired,
+  supportedActivities: PropTypes.arrayOf(PropTypes.string).isRequired,
 };

--- a/src/js/components/stock-movement/inbound/StockMovementInboundList.jsx
+++ b/src/js/components/stock-movement/inbound/StockMovementInboundList.jsx
@@ -16,6 +16,7 @@ import { getParamList, transformFilterParams } from 'utils/list-utils';
 const StockMovementInboundList = (props) => {
   const [filterParams, setFilterParams] = useState({});
   const [defaultFilterValues, setDefaultFilterValues] = useState({});
+  const [filtersInitialized, setFiltersInitialized] = useState(false);
 
   useEffect(() => {
     props.fetchTranslations(props.locale, 'stockMovement');
@@ -35,6 +36,17 @@ const StockMovementInboundList = (props) => {
   const fetchLocationById = async (id) => {
     const response = await apiClient(`/openboxes/api/locations/${id}`);
     return response.data?.data;
+  };
+
+  const clearFilterValues = () => {
+    const defaultValues = Object.keys(filterFields)
+      .reduce((acc, key) => ({ ...acc, [key]: '' }), { direction: 'INBOUND' });
+    const transformedParams = transformFilterParams(defaultValues, { direction: { name: 'direction' } });
+    const queryFilterParams = queryString.stringify(transformedParams);
+    const { pathname } = props.history.location;
+    if (queryFilterParams) {
+      props.history.push({ pathname, search: queryFilterParams });
+    }
   };
 
   const initializeDefaultFilterValues = async () => {
@@ -84,7 +96,16 @@ const StockMovementInboundList = (props) => {
     }
 
     setDefaultFilterValues(defaultValues);
+    setFiltersInitialized(true);
   };
+
+  useEffect(() => {
+    // Don't clear the query params while doing first filter initialization
+    // clear the filters only when changing location, but not refreshing page
+    if (filtersInitialized) {
+      clearFilterValues();
+    }
+  }, [props.currentLocation?.id]);
 
   useEffect(() => {
     // Avoid unnecessary re-fetches if getAppContext triggers fetching session info

--- a/src/js/components/stock-movement/outbound/StockMovementOutboundList.jsx
+++ b/src/js/components/stock-movement/outbound/StockMovementOutboundList.jsx
@@ -16,6 +16,7 @@ import { getParamList, transformFilterParams } from 'utils/list-utils';
 const StockMovementOutboundList = (props) => {
   const [filterParams, setFilterParams] = useState({});
   const [defaultFilterValues, setDefaultFilterValues] = useState({});
+  const [filtersInitialized, setFiltersInitialized] = useState(false);
 
   useEffect(() => {
     props.fetchTranslations(props.locale, 'stockMovement');
@@ -36,6 +37,17 @@ const StockMovementOutboundList = (props) => {
   const fetchLocationById = async (id) => {
     const response = await apiClient(`/openboxes/api/locations/${id}`);
     return response.data?.data;
+  };
+
+  const clearFilterValues = () => {
+    const defaultValues = Object.keys(filterFields)
+      .reduce((acc, key) => ({ ...acc, [key]: '' }), { direction: 'OUTBOUND' });
+    const transformedParams = transformFilterParams(defaultValues, { direction: { name: 'direction' } });
+    const queryFilterParams = queryString.stringify(transformedParams);
+    const { pathname } = props.history.location;
+    if (queryFilterParams) {
+      props.history.push({ pathname, search: queryFilterParams });
+    }
   };
 
   const initializeDefaultFilterValues = async () => {
@@ -93,7 +105,16 @@ const StockMovementOutboundList = (props) => {
     }
 
     setDefaultFilterValues(defaultValues);
+    setFiltersInitialized(true);
   };
+
+  useEffect(() => {
+    // Don't clear the query params while doing first filter initialization
+    // clear the filters only when changing location, but not refreshing page
+    if (filtersInitialized) {
+      clearFilterValues();
+    }
+  }, [props.currentLocation?.id]);
 
   useEffect(() => {
     // Avoid unnecessary re-fetches if getAppContext triggers fetching session info

--- a/src/js/reducers/sessionReducer.jsx
+++ b/src/js/reducers/sessionReducer.jsx
@@ -74,6 +74,7 @@ const initialState = {
   currencyCode: '',
   localizedHelpScoutKey: '',
   isHelpScoutEnabled: false,
+  loading: false,
 };
 
 export default function (state = initialState, action) {
@@ -110,6 +111,7 @@ export default function (state = initialState, action) {
         currencyCode: _.get(action, 'payload.data.data.currencyCode'),
         localizedHelpScoutKey: _.get(action, 'payload.data.data.localizedHelpScoutKey'),
         isHelpScoutEnabled: _.get(action, 'payload.data.data.isHelpScoutEnabled'),
+        loading: false,
       };
     case FETCH_MENU_CONFIG:
       return {
@@ -117,7 +119,7 @@ export default function (state = initialState, action) {
         menuConfig: _.get(action, 'payload.data.data.menuConfig'),
       };
     case CHANGE_CURRENT_LOCATION:
-      return { ...state, currentLocation: action.payload };
+      return { ...state, currentLocation: action.payload, loading: true };
     case CHANGE_CURRENT_LOCALE:
       return { ...state, activeLanguage: action.payload };
     case TRANSLATIONS_FETCHED:


### PR DESCRIPTION
Fixed:

- `Clear` filter button doesn't remove default, disabled values on PO and Invoice list anymore
- Filters get cleared after changing the location, but not after refreshing the page
- fix bug on PO list when switching between location with central purchasing enabled and not enabled one
- added re-fetch on stock transfer list when changing location