### PR TITLE
OBPIH-5004 Fix saving and canceling multiple receipt items

### DIFF
--- a/src/groovy/org/pih/warehouse/api/PartialReceiptItem.groovy
+++ b/src/groovy/org/pih/warehouse/api/PartialReceiptItem.groovy
@@ -55,7 +55,7 @@ class PartialReceiptItem {
     }
 
     Set<ReceiptItem> getReceiptItemsByStatus(ReceiptStatusCode[] receiptStatusCodes) {
-        def receiptItems = ReceiptItem.findAllByShipmentItem(shipmentItem)
+        def receiptItems = shipmentItem?.receiptItems ?: []
         return receiptItems.findAll { ReceiptItem receiptItem ->
             shipmentItem?.product == receiptItem?.product && receiptItem?.receipt?.receiptStatusCode in receiptStatusCodes
         }


### PR DESCRIPTION
@jmiranda this line was throwing `collection [...] not processed by flush()` after doing `shipmentItem.addToReceiptItems(receiptItem)` when there was a multi-line cancel case.