### PR TITLE
OBGM-366 Fix Interceptor session bugs by refactoring AuthService (also fixes OBPIH-4325).

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/InitializationInterceptor.groovy
+++ b/grails-app/controllers/org/pih/warehouse/InitializationInterceptor.groovy
@@ -11,8 +11,8 @@ package org.pih.warehouse
 import org.pih.warehouse.core.User
 
 class InitializationInterceptor {
-    def locationService
-    def productService
+
+    int order = HIGHEST_PRECEDENCE
 
     public InitializationInterceptor() {
         matchAll()

--- a/grails-app/controllers/org/pih/warehouse/LoggingInterceptor.groovy
+++ b/grails-app/controllers/org/pih/warehouse/LoggingInterceptor.groovy
@@ -21,11 +21,8 @@ class LoggingInterceptor {
 
     boolean before() {
         try {
-            def sessionId = session?.id
-            def userId = session?.user?.username
-            def serverUrl = Holders.grailsApplication.config.grails.serverURL
             MDC.put('sessionId', session?.id ?: "No session ID")
-            MDC.put('username', userId ?: "No user")
+            MDC.put('username', session?.user?.username ?: "No user")
             MDC.put('location', session?.warehouse?.name ?: "No location")
             MDC.put('locale', session?.user?.locale?.toString() ?: "No locale")
             MDC.put('ipAddress', request?.remoteAddr ?: "No IP address")

--- a/grails-app/controllers/org/pih/warehouse/RoleInterceptor.groovy
+++ b/grails-app/controllers/org/pih/warehouse/RoleInterceptor.groovy
@@ -13,7 +13,10 @@ import org.pih.warehouse.core.RoleType
  * */
 class RoleInterceptor {
     def userService
-    def dependsOn = [SecurityInterceptor]
+
+    // this interceptor depends on SecurityInterceptor
+    int order = LOWEST_PRECEDENCE
+
     def static changeActions = ['delete', 'create', 'add', 'process', 'save',
                                 'update', 'importData', 'receive', 'showRecordInventory', 'withdraw', 'cancel', 'change', 'toggle', 'exportAsCsv']
     def static changeControllers = ['createProductFromTemplate']

--- a/grails-app/controllers/org/pih/warehouse/SecurityInterceptor.groovy
+++ b/grails-app/controllers/org/pih/warehouse/SecurityInterceptor.groovy
@@ -9,10 +9,6 @@ package org.pih.warehouse
  * You must not remove this notice, or any other, from this software.
  **/
 
-import org.pih.warehouse.auth.AuthService
-import org.pih.warehouse.core.Location
-import org.pih.warehouse.core.User
-
 class SecurityInterceptor {
 
     static ArrayList controllersWithAuthUserNotRequired = ['test', 'errors']
@@ -29,25 +25,14 @@ class SecurityInterceptor {
 
     void afterView() {
         // Clear out current user after rendering the view
-        AuthService.currentUser.set(null)
-        AuthService.currentLocation.set(null)
+        authService.currentUser = null
+        authService.currentLocation = null
     }
     boolean before() {
 
-        // Set the current user (if there's on in the session)
-        if (session.user) {
-            if (!AuthService.currentUser) {
-                AuthService.currentUser = new ThreadLocal<User>()
-            }
-            AuthService.currentUser.set(User.get(session.user.id))
-        }
-
-        if (session.warehouse) {
-            if (!AuthService.currentLocation) {
-                AuthService.currentLocation = new ThreadLocal<Location>()
-            }
-            AuthService.currentLocation.set(Location.get(session.warehouse.id))
-        }
+        // set user/warehouse, if present, or clear them if not
+        authService.currentUser = session.user ?: null
+        authService.currentLocation = session.warehouse ?: null
 
         // This allows requests for the health monitoring endpoint to pass through without a user
         if (controllerName.equals("api") && actionName.equals("status")) {

--- a/grails-app/controllers/org/pih/warehouse/UtilInterceptor.groovy
+++ b/grails-app/controllers/org/pih/warehouse/UtilInterceptor.groovy
@@ -16,6 +16,9 @@ package org.pih.warehouse
  */
 class UtilInterceptor {
 
+    // run this as early as we can to measure other interceptors' perf. impact
+    int order = HIGHEST_PRECEDENCE
+
     UtilInterceptor() {
         matchAll().except(uri: '/static/**')
     }

--- a/grails-app/domain/org/pih/warehouse/core/BudgetCode.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/BudgetCode.groovy
@@ -14,18 +14,11 @@ import org.pih.warehouse.auth.AuthService
 class BudgetCode implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser
     }
 
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/core/GlAccount.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/GlAccount.groovy
@@ -14,19 +14,13 @@ import org.pih.warehouse.auth.AuthService
 class GlAccount implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser
     }
 
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser
     }
+
     String id
     String code
     String name

--- a/grails-app/domain/org/pih/warehouse/core/GlAccountType.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/GlAccountType.groovy
@@ -14,18 +14,11 @@ import org.pih.warehouse.auth.AuthService
 class GlAccountType implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser
     }
 
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/core/PreferenceType.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/PreferenceType.groovy
@@ -14,18 +14,11 @@ import org.pih.warehouse.auth.AuthService
 class PreferenceType implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser
     }
 
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/core/ProductPrice.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/ProductPrice.groovy
@@ -16,17 +16,11 @@ import org.pih.warehouse.product.ProductSupplier
 class ProductPrice implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser
     }
+
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/core/Synonym.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Synonym.groovy
@@ -18,21 +18,11 @@ import org.pih.warehouse.product.Product
 class Synonym implements Serializable {
 
     def beforeInsert = {
-        User.withNewSession {
-            def currentUser = AuthService.currentUser.get()
-            if (currentUser) {
-                createdBy = currentUser
-                updatedBy = currentUser
-            }
-        }
+        createdBy = AuthService.currentUser
     }
+
     def beforeUpdate = {
-        User.withNewSession {
-            def currentUser = AuthService.currentUser.get()
-            if (currentUser) {
-                updatedBy = currentUser
-            }
-        }
+        updatedBy = AuthService.currentUser
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/core/Tag.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Tag.groovy
@@ -16,21 +16,11 @@ import org.pih.warehouse.product.Product
 class Tag implements Serializable {
 
     def beforeInsert = {
-        User.withNewSession {
-            def currentUser = AuthService.currentUser.get()
-            if (currentUser) {
-                createdBy = currentUser
-                updatedBy = currentUser
-            }
-        }
+        createdBy = AuthService.currentUser
     }
+
     def beforeUpdate = {
-        User.withNewSession {
-            def currentUser = AuthService.currentUser.get()
-            if (currentUser) {
-                updatedBy = currentUser
-            }
-        }
+        updatedBy = AuthService.currentUser
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/core/UnitOfMeasure.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/UnitOfMeasure.groovy
@@ -14,10 +14,11 @@ import org.pih.warehouse.auth.AuthService
 class UnitOfMeasure implements Serializable {
 
     def beforeInsert = {
-        createdBy = AuthService.currentUser.get()
+        createdBy = AuthService.currentUser
     }
+
     def beforeUpdate = {
-        updatedBy = AuthService.currentUser.get()
+        updatedBy = AuthService.currentUser
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/core/UnitOfMeasureClass.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/UnitOfMeasureClass.groovy
@@ -15,10 +15,11 @@ import org.pih.warehouse.auth.AuthService
 class UnitOfMeasureClass implements Serializable {
 
     def beforeInsert = {
-        createdBy = AuthService.currentUser.get()
+        createdBy = AuthService.currentUser
     }
+
     def beforeUpdate = {
-        updatedBy = AuthService.currentUser.get()
+        updatedBy = AuthService.currentUser
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/inventory/Transaction.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/Transaction.groovy
@@ -38,17 +38,11 @@ import grails.util.Holders
 class Transaction implements Comparable, Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser
     }
+
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser
     }
 
     def publishSaveEvent = {

--- a/grails-app/domain/org/pih/warehouse/invoice/Invoice.groovy
+++ b/grails-app/domain/org/pih/warehouse/invoice/Invoice.groovy
@@ -25,18 +25,11 @@ import org.pih.warehouse.shipping.Shipment
 class Invoice implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser
     }
 
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/invoice/InvoiceItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/invoice/InvoiceItem.groovy
@@ -25,18 +25,11 @@ import org.pih.warehouse.shipping.ShipmentItem
 class InvoiceItem implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser
     }
 
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/invoice/InvoiceType.groovy
+++ b/grails-app/domain/org/pih/warehouse/invoice/InvoiceType.groovy
@@ -15,18 +15,11 @@ import org.pih.warehouse.core.User
 class InvoiceType implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser
     }
 
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/order/Order.groovy
+++ b/grails-app/domain/org/pih/warehouse/order/Order.groovy
@@ -22,18 +22,11 @@ import org.pih.warehouse.shipping.ShipmentStatusCode
 class Order implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser
     }
 
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/order/OrderType.groovy
+++ b/grails-app/domain/org/pih/warehouse/order/OrderType.groovy
@@ -16,18 +16,11 @@ import org.pih.warehouse.core.User
 class OrderType implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser
     }
 
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/picklist/Picklist.groovy
+++ b/grails-app/domain/org/pih/warehouse/picklist/Picklist.groovy
@@ -31,18 +31,11 @@ import org.pih.warehouse.requisition.Requisition
 class Picklist implements Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
-
+        createdBy = AuthService.currentUser
     }
+
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/product/Product.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/Product.groovy
@@ -45,23 +45,12 @@ import grails.util.Holders
  */
 class Product implements Comparable, Serializable {
 
-
     def beforeInsert = {
-        User.withNewSession {
-            def currentUser = AuthService.currentUser.get()
-            if (currentUser) {
-                createdBy = currentUser
-                updatedBy = currentUser
-            }
-        }
+        createdBy = AuthService.currentUser
     }
+
     def beforeUpdate = {
-        User.withNewSession {
-            def currentUser = AuthService.currentUser.get()
-            if (currentUser) {
-                updatedBy = currentUser
-            }
-        }
+        updatedBy = AuthService.currentUser
     }
 
     def publishPersistenceEvent = {

--- a/grails-app/domain/org/pih/warehouse/product/ProductPackage.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/ProductPackage.groovy
@@ -21,21 +21,11 @@ import org.pih.warehouse.core.User
 class ProductPackage implements Comparable<ProductPackage>, Serializable {
 
     def beforeInsert = {
-        User.withNewSession {
-            def currentUser = AuthService.currentUser.get()
-            if (currentUser) {
-                createdBy = currentUser
-                updatedBy = currentUser
-            }
-        }
+        createdBy = AuthService.currentUser
     }
+
     def beforeUpdate = {
-        User.withNewSession {
-            def currentUser = AuthService.currentUser.get()
-            if (currentUser) {
-                updatedBy = currentUser
-            }
-        }
+        updatedBy = AuthService.currentUser
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/requisition/Requisition.groovy
+++ b/grails-app/domain/org/pih/warehouse/requisition/Requisition.groovy
@@ -22,17 +22,11 @@ import org.pih.warehouse.product.Product
 class Requisition implements Comparable<Requisition>, Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser
     }
+
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/requisition/RequisitionItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/requisition/RequisitionItem.groovy
@@ -21,24 +21,15 @@ import org.pih.warehouse.product.Category
 import org.pih.warehouse.product.Product
 import org.pih.warehouse.product.ProductGroup
 import org.pih.warehouse.product.ProductPackage
-import org.pih.warehouse.core.Person
-import org.pih.warehouse.inventory.InventoryItem
-import org.pih.warehouse.product.Product
 
 class RequisitionItem implements Comparable<RequisitionItem>, Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser
     }
+
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser
     }
 
     String id

--- a/grails-app/domain/org/pih/warehouse/shipping/Shipment.groovy
+++ b/grails-app/domain/org/pih/warehouse/shipping/Shipment.groovy
@@ -29,20 +29,13 @@ import org.pih.warehouse.requisition.Requisition
 class Shipment implements Comparable, Serializable {
 
     def beforeInsert = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            createdBy = currentUser
-            updatedBy = currentUser
-        }
+        createdBy = AuthService.currentUser
         currentEvent = mostRecentEvent
         currentStatus = status.code
-
     }
+
     def beforeUpdate = {
-        def currentUser = AuthService.currentUser.get()
-        if (currentUser) {
-            updatedBy = currentUser
-        }
+        updatedBy = AuthService.currentUser
     }
 
     def afterUpdate = {

--- a/grails-app/services/org/pih/warehouse/auth/AuthService.groovy
+++ b/grails-app/services/org/pih/warehouse/auth/AuthService.groovy
@@ -9,12 +9,41 @@
  **/
 package org.pih.warehouse.auth
 
+import grails.gorm.transactions.Transactional
+import groovy.transform.CompileStatic
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.User
 
+@CompileStatic
+@Transactional(readOnly = true)
 class AuthService {
 
-    static ThreadLocal<User> currentUser = new ThreadLocal<User>()
-    static ThreadLocal<Location> currentLocation = new ThreadLocal<Location>()
+    private static ThreadLocal<User> threadLocalUser
+    private static ThreadLocal<Location> threadLocalLocation
 
+    void setCurrentUser(User user) {
+        if (!threadLocalUser) {
+            threadLocalUser = new ThreadLocal<User>()
+        }
+
+        // misuse get() to prevent javax.persistence.EntityExistsException
+        threadLocalUser.set(user?.id ? User.get(user.id) : null)
+    }
+
+    static User getCurrentUser() {
+        return threadLocalUser?.get()
+    }
+
+    void setCurrentLocation(Location location) {
+        if (!threadLocalLocation) {
+            threadLocalLocation = new ThreadLocal<Location>()
+        }
+
+        // misuse get() to prevent javax.persistence.EntityExistsException
+        threadLocalLocation.set(location?.id ? Location.get(location.id) : null)
+    }
+
+    static Location getCurrentLocation() {
+        return threadLocalLocation?.get()
+    }
 }

--- a/grails-app/services/org/pih/warehouse/core/UserService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/UserService.groovy
@@ -19,6 +19,7 @@ import org.pih.warehouse.auth.AuthService
 @Transactional
 class UserService {
 
+    def authService
     def dataSource
     GrailsApplication grailsApplication
 
@@ -226,7 +227,7 @@ class UserService {
     }
 
     Boolean canEditUserRoles(User currentUser, User otherUser) {
-        def location = AuthService.currentLocation.get()
+        def location = authService.currentLocation
         return isSuperuser(currentUser) || (currentUser.getHighestRole(location) >= otherUser.getHighestRole(location))
     }
 
@@ -245,12 +246,12 @@ class UserService {
     }
 
     boolean hasRoleFinance() {
-        User user = AuthService.currentUser.get()
+        User user = authService.currentUser
         return hasRoleFinance(user)
     }
 
     void assertCurrentUserHasRoleFinance() {
-        User user = AuthService.currentUser.get()
+        User user = authService.currentUser
         if (!hasRoleFinance(user)) {
             throw new IllegalStateException("User ${user.username} must have ROLE_FINANCE role")
         }
@@ -360,7 +361,7 @@ class UserService {
     }
 
     private def getEffectiveRoles(User user) {
-        def currentLocation = AuthService.currentLocation?.get()
+        def currentLocation = authService.currentLocation
         return user.getEffectiveRoles(currentLocation)
     }
 

--- a/grails-app/services/org/pih/warehouse/data/OutboundStockMovementDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/OutboundStockMovementDataService.groovy
@@ -17,9 +17,10 @@ import org.pih.warehouse.requisition.Requisition
 import org.pih.warehouse.requisition.RequisitionItem
 import org.pih.warehouse.requisition.RequisitionStatus
 import org.springframework.validation.BeanPropertyBindingResult
-import org.pih.warehouse.auth.AuthService
 
 class OutboundStockMovementDataService {
+
+    def authService
 
     Boolean validateData(ImportDataCommand command) {
         log.info "Validate data " + command.filename
@@ -92,7 +93,7 @@ class OutboundStockMovementDataService {
             }
             requisition.destination = destination
             requisition.requestedDeliveryDate = deliveryDate.toDate()
-            requisition.requestedBy = AuthService.currentUser.get()
+            requisition.requestedBy = authService.currentUser
             requisition.save(failOnError: true)
         }
 

--- a/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
@@ -18,14 +18,12 @@ import org.hibernate.criterion.CriteriaSpecification
 import org.joda.time.LocalDate
 import org.pih.warehouse.PagedResultList
 import org.pih.warehouse.api.AvailableItem
-import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.Tag
 import org.pih.warehouse.core.User
 import org.pih.warehouse.importer.ImportDataCommand
 import org.pih.warehouse.importer.ImporterUtil
-import org.pih.warehouse.importer.InventoryExcelImporter
 import org.pih.warehouse.product.Category
 import org.pih.warehouse.product.Product
 import org.pih.warehouse.product.ProductAvailability
@@ -33,10 +31,10 @@ import org.pih.warehouse.product.ProductCatalog
 import org.pih.warehouse.product.ProductException
 import org.pih.warehouse.shipping.Shipment
 import org.pih.warehouse.shipping.ShipmentItem
-import org.pih.warehouse.DateUtil
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextAware
 import org.springframework.validation.Errors
+
 import java.sql.Timestamp
 import java.text.NumberFormat
 import java.text.ParseException
@@ -49,8 +47,8 @@ class InventoryService implements ApplicationContextAware {
     def persistenceInterceptor
     GrailsApplication grailsApplication
 
+    def authService
     def dataService
-    def productService
     def identifierService
     def messageService
     def locationService
@@ -1018,7 +1016,7 @@ class InventoryService implements ApplicationContextAware {
      * @return current location from thread local
      */
     Location getCurrentLocation() {
-        def currentLocation = AuthService?.currentLocation?.get()
+        def currentLocation = authService?.currentLocation
         if (!currentLocation?.inventory)
             throw new Exception("Inventory not found")
         return currentLocation

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -9,12 +9,12 @@
  **/
 package org.pih.warehouse.inventory
 
-import grails.gorm.transactions.Transactional
 import grails.core.GrailsApplication
-import org.pih.warehouse.PagedResultList
+import grails.gorm.transactions.Transactional
 import grails.validation.ValidationException
 import org.grails.web.json.JSONObject
 import org.hibernate.ObjectNotFoundException
+import org.pih.warehouse.PagedResultList
 import org.pih.warehouse.api.AvailableItem
 import org.pih.warehouse.api.AvailableItemStatus
 import org.pih.warehouse.api.DocumentGroupCode
@@ -25,7 +25,6 @@ import org.pih.warehouse.api.StockMovementDirection
 import org.pih.warehouse.api.StockMovementItem
 import org.pih.warehouse.api.SubstitutionItem
 import org.pih.warehouse.api.SuggestedItem
-import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.Comment
 import org.pih.warehouse.core.Constants
@@ -63,6 +62,7 @@ import org.pih.warehouse.shipping.ShipmentWorkflow
 @Transactional
 class StockMovementService {
 
+    def authService
     def productService
     def identifierService
     def requisitionService
@@ -2431,7 +2431,7 @@ class StockMovementService {
     }
 
     void issueShipmentBasedStockMovement(String id) {
-        User user = AuthService.currentUser.get()
+        User user = authService.currentUser
         StockMovement stockMovement = getStockMovement(id)
         Shipment shipment = stockMovement.shipment
         if (!shipment) {
@@ -2442,7 +2442,7 @@ class StockMovementService {
 
     void issueRequisitionBasedStockMovement(String id) {
 
-        User user = AuthService.currentUser.get()
+        User user = authService.currentUser
         StockMovement stockMovement = getStockMovement(id)
         Requisition requisition = stockMovement.requisition
         def shipment = requisition.shipment

--- a/grails-app/services/org/pih/warehouse/invoice/InvoiceService.groovy
+++ b/grails-app/services/org/pih/warehouse/invoice/InvoiceService.groovy
@@ -10,7 +10,6 @@
 package org.pih.warehouse.invoice
 
 import grails.gorm.transactions.Transactional
-import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.UnitOfMeasure
 import org.pih.warehouse.order.Order
@@ -26,6 +25,7 @@ import org.joda.time.LocalDate
 @Transactional
 class InvoiceService {
 
+    def authService
     def identifierService
 
     def getInvoices(Invoice invoiceTemplate, Map params) {
@@ -75,7 +75,7 @@ class InvoiceService {
             return []
         }
 
-        def currentLocation = AuthService?.currentLocation?.get()
+        def currentLocation = authService.currentLocation
         List<InvoiceItemCandidate> invoiceItemCandidates = InvoiceItemCandidate.createCriteria()
             .list() {
                 if (invoice.party) {
@@ -109,7 +109,7 @@ class InvoiceService {
             return []
         }
 
-        def currentLocation = AuthService?.currentLocation?.get()
+        def currentLocation = authService.currentLocation
         List<InvoiceItemCandidate> invoiceItemCandidates = InvoiceItemCandidate.createCriteria()
             .list() {
                 projections {

--- a/grails-app/services/org/pih/warehouse/product/ProductService.groovy
+++ b/grails-app/services/org/pih/warehouse/product/ProductService.groovy
@@ -15,7 +15,6 @@ import grails.validation.ValidationException
 import groovy.xml.Namespace
 import org.hibernate.criterion.CriteriaSpecification
 import org.hibernate.sql.JoinType
-import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.ApiException
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.GlAccount
@@ -34,6 +33,8 @@ class ProductService {
 
     def sessionFactory
     GrailsApplication grailsApplication
+
+    def authService
     def identifierService
     def userService
     def dataService
@@ -591,7 +592,7 @@ class ProductService {
 
         int rowCount = 1
 
-        Location currentLocation = AuthService?.currentLocation?.get()
+        Location currentLocation = authService.currentLocation
 
         // Iterate over each line and either update an existing product or create a new product
         csv.toCsvReader(['skipLines': 1, 'separatorChar': delimiter]).eachLine { tokens ->

--- a/grails-app/services/org/pih/warehouse/receiving/ReceiptService.groovy
+++ b/grails-app/services/org/pih/warehouse/receiving/ReceiptService.groovy
@@ -11,8 +11,8 @@ package org.pih.warehouse.receiving
 
 import grails.core.GrailsApplication
 import grails.gorm.transactions.Transactional
+import grails.util.Holders
 import grails.validation.ValidationException
-import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.api.PartialReceipt
 import org.pih.warehouse.api.PartialReceiptContainer
 import org.pih.warehouse.api.PartialReceiptItem
@@ -22,19 +22,19 @@ import org.pih.warehouse.core.EventCode
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.LocationType
 import org.pih.warehouse.inventory.InventoryItem
+import org.pih.warehouse.inventory.RefreshProductAvailabilityEvent
 import org.pih.warehouse.inventory.Transaction
 import org.pih.warehouse.inventory.TransactionEntry
-import org.pih.warehouse.inventory.RefreshProductAvailabilityEvent
 import org.pih.warehouse.inventory.TransactionType
 import org.pih.warehouse.shipping.Shipment
 import org.pih.warehouse.shipping.ShipmentItem
 import org.pih.warehouse.shipping.ShipmentStatusCode
 import org.pih.warehouse.shipping.ShipmentStatusTransitionEvent
-import grails.util.Holders
 
 @Transactional
 class ReceiptService {
 
+    def authService
     def shipmentService
     def inventoryService
     def locationService
@@ -73,7 +73,7 @@ class ReceiptService {
      * @return
      */
     PartialReceipt getPartialReceiptFromShipment(Shipment shipment) {
-        def currentUser = AuthService.currentUser.get()
+        def currentUser = authService.currentUser
         PartialReceipt partialReceipt = new PartialReceipt()
         partialReceipt.shipment = shipment
         partialReceipt.recipient = currentUser

--- a/grails-app/services/org/pih/warehouse/requisition/RequisitionService.groovy
+++ b/grails-app/services/org/pih/warehouse/requisition/RequisitionService.groovy
@@ -13,7 +13,6 @@ import grails.core.GrailsApplication
 import grails.gorm.transactions.Transactional
 import grails.validation.ValidationException
 import org.pih.warehouse.DateUtil
-import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.Person
@@ -31,6 +30,7 @@ import org.pih.warehouse.product.Product
 class RequisitionService {
 
     GrailsApplication grailsApplication
+    def authService
     def identifierService
     def inventoryService
 
@@ -258,7 +258,7 @@ class RequisitionService {
                     eq("status", requisition.status)
                 }
                 if (params?.relatedToMe) {
-                    def currentUser = AuthService.getCurrentUser().get()
+                    def currentUser = authService.currentUser
                     or {
                         eq("createdBy.id", currentUser.id)
                         eq("updatedBy.id", currentUser.id)

--- a/grails-app/services/org/pih/warehouse/shipping/ShipmentService.groovy
+++ b/grails-app/services/org/pih/warehouse/shipping/ShipmentService.groovy
@@ -19,7 +19,6 @@ import org.apache.poi.ss.usermodel.Cell
 import org.apache.poi.ss.usermodel.Row
 import org.hibernate.FetchMode
 import org.pih.warehouse.api.StockTransfer
-import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.Comment
 import org.pih.warehouse.core.Constants
@@ -1084,7 +1083,7 @@ class ShipmentService {
             throw new IllegalArgumentException("Can't find shipment for given order: ${order.id}")
         }
 
-        User user = AuthService.currentUser.get()
+        User user = authService.currentUser
 
         shipments.each { Shipment shipment ->
             sendShipment(shipment, null, user, order.origin, shipment?.dateShipped() ?: new Date())
@@ -2269,7 +2268,7 @@ class ShipmentService {
 
     def createShipmentItems(OrderItem orderItem) {
         def shipmentItems = orderItem.shipmentItems ?: []
-        def currentLocation = AuthService?.currentLocation?.get()
+        def currentLocation = authService.currentLocation
         if (shipmentItems) {
             shipmentItems.each { ShipmentItem shipmentItem ->
                 if (orderItem?.order?.isOutbound(currentLocation)) {

--- a/grails-app/services/org/pih/warehouse/stockTransfer/StockTransferService.groovy
+++ b/grails-app/services/org/pih/warehouse/stockTransfer/StockTransferService.groovy
@@ -16,7 +16,6 @@ import org.pih.warehouse.api.DocumentGroupCode
 import org.pih.warehouse.api.StockTransfer
 import org.pih.warehouse.api.StockTransferItem
 import org.pih.warehouse.api.StockTransferStatus
-import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.inventory.InventoryItem
 import org.pih.warehouse.inventory.TransferStockCommand
@@ -195,7 +194,7 @@ class StockTransferService {
         }
         order.save(failOnError: true)
 
-        def currentLocation = AuthService?.currentLocation?.get()
+        def currentLocation = authService.currentLocation
         if (order.orderType.isReturnOrder() && order.isOutbound(currentLocation) && order?.orderItems) {
             picklistService.createPicklistFromItem(order)
         }

--- a/src/test/groovy/integration-test/org/pih/warhouse/core/UserServiceIntegrationTests.groovy
+++ b/src/test/groovy/integration-test/org/pih/warhouse/core/UserServiceIntegrationTests.groovy
@@ -5,8 +5,6 @@ import org.junit.Ignore
 import org.pih.warehouse.core.Role
 import org.pih.warehouse.core.User
 
-// import AuthService
-
 import testutils.DbHelper;
 
 @Ignore

--- a/src/test/groovy/integration-test/org/pih/warhouse/product/ProductServiceIntegrationTests.groovy
+++ b/src/test/groovy/integration-test/org/pih/warhouse/product/ProductServiceIntegrationTests.groovy
@@ -4,7 +4,6 @@ import org.junit.Ignore
 
 // import org.apache.commons.lang.StringUtils
 import org.junit.Test
-import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.Role
 import org.pih.warehouse.core.RoleType
@@ -21,8 +20,8 @@ import testutils.DbHelper
 
 @Ignore
 class ProductServiceIntegrationTests extends GroovyTestCase {
-	
-	
+
+	def authService
 	def productService
 	def product1;
 	def product2;
@@ -43,7 +42,7 @@ class ProductServiceIntegrationTests extends GroovyTestCase {
 		user.addToRoles(financeRole)
 		user.save()
 
-		AuthService.currentUser.set(user)
+		authService.currentUser = user
 
 		product1 = DbHelper.createProductWithGroups("boo floweree 250mg",["Hoo moodiccina", "Boo floweree"])
 		product2 = DbHelper.createProductWithGroups("boo pill",["Boo floweree"])

--- a/src/test/groovy/unit/org/pih/warehouse/core/UserServiceTests.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/core/UserServiceTests.groovy
@@ -1,7 +1,6 @@
 package org.pih.warehouse.core
 
 // import grails.test.GrailsUnitTestCase
-import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.LocationRole
 import org.pih.warehouse.core.Role
@@ -9,6 +8,8 @@ import org.pih.warehouse.core.User
 import org.pih.warehouse.core.UserService
 
 class UserServiceTests {
+
+    def authService
     def user1
     def user2
     def user3
@@ -72,8 +73,7 @@ class UserServiceTests {
         user6.addToLocationRoles(locationRole3)
         user1.addToLocationRoles(locationRole4)
 
-        AuthService.currentLocation = new ThreadLocal<Location>()
-        AuthService.currentLocation.set(boston)
+        authService.currentLocation = boston
 
         service = new UserService()
     }


### PR DESCRIPTION
This PR is aimed against another PR to ease review. I'll merge it into the appropriate feature branch once approved.

I moved some of the session logic from `SecurityInterceptor` to `AuthService` so that grails does its usual transactional management for service methods.

Then I updated all consumers of AuthService to call getters instead of accessing thread local objects directly, which is a little cleaner, and while I was doing that I put in a fix for OBPIH-4325 (we don't need withNewSession when we get User info from a transactional service).

Finally I fixed a Grails-1-ism in RoleInterceptor and made sure that Interceptors that depend on AuthService.currentUser run after the two interceptors that set it.