### PR TITLE
Fix menu on GSP not to show deprecated sections by default

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -1757,12 +1757,12 @@ openboxes {
             ]
         }
         shipping {
-            enabled = true
+            enabled = false
             label = "shipping.label"
             defaultLabel = "Shipping"
         }
         receiving {
-            enabled = true
+            enabled = false
             label = "receiving.label"
             defaultLabel = "Receiving"
         }


### PR DESCRIPTION
When fixing the GSP menu some days ago, I forgot to bring back two deprecated sections to `enabled = false` by default, which caused that on GSP pages those were seen by default. On React they were not visible, because they are taken from inside inbound/outbound section where their menuItems are `enabled = false`, but on GSP the menuItems are hardcoded, and it was only checking `if (megamenuConfig.shipping.enabled)`.
On obnavstage it was also not visible, because the menu is overwritten here, so it's just my fault here, that I haven't spotted this when pushing previous ticket even though I thought, everything was fine.