### PR TITLE
OBPIH-5047 Order Type filter content is cleared when apply filters on…

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -1766,29 +1766,6 @@ openboxes {
             label = "receiving.label"
             defaultLabel = "Receiving"
         }
-
-        orders {
-            enabled = true
-            label = "orders.label"
-            defaultLabel = "Orders"
-        }
-        stockRequest {
-            enabled = true
-            label = "stockRequests.label"
-            defaultLabel = "Stock Requests"
-        }
-        stockMovement {
-            enabled = true
-            label = "stockMovements.label"
-            defaultLabel = "Stock Movements"
-        }
-        putaways {
-            enabled = true
-            label = "putaways.label"
-            defaultLabel = "Putaways"
-        }
-
-
     }
     requestorMegamenu {
         request {

--- a/grails-app/views/order/_filters.gsp
+++ b/grails-app/views/order/_filters.gsp
@@ -8,6 +8,7 @@
     <g:form id="listForm" action="list" method="GET">
         <g:hiddenField name="type" value="${params.type}"/>
         <g:hiddenField name="max" value="${params.max ?: 10}"/>
+        <g:hiddenField name="orderType" value="${params.orderType}"/>
         <div class="filter-list">
             <div class="filter-list-item">
                 <label>${warehouse.message(code: 'default.search.label')}</label>


### PR DESCRIPTION
… putaway list

The filter was cleared out due to the fact, that grails' `<g:select>` if is `disabled="true"` it doesn't pass the value to the API even though the value is not null. So the fix is to make a hiddenField additionally for orderType.

Additonally I removed unused menu sections 