### PR TITLE
OBPIH-5047 Keep orderType when clicking Cancel on putaway list

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -1766,6 +1766,30 @@ openboxes {
             label = "receiving.label"
             defaultLabel = "Receiving"
         }
+
+        orders {
+            enabled = true
+            label = "orders.label"
+            defaultLabel = "Orders"
+        }
+
+        stockRequest {
+            enabled = true
+            label = "stockRequests.label"
+            defaultLabel = "Stock Requests"
+        }
+
+        stockMovement {
+            enabled = true
+            label = "stockMovements.label"
+            defaultLabel = "Stock Movements"
+        }
+
+        putaways {
+            enabled = true
+            label = "putaways.label"
+            defaultLabel = "Putaways"
+        }
     }
     requestorMegamenu {
         request {

--- a/grails-app/views/order/_filters.gsp
+++ b/grails-app/views/order/_filters.gsp
@@ -156,7 +156,7 @@
                         </div>
                     </div>
                 </span>
-                <g:link controller="order" action="list" class="button icon reload">
+                <g:link controller="order" action="list" class="button icon reload" params="[orderType: 'PUTAWAY_ORDER']">
                     <warehouse:message code="default.button.cancel.label"/>
                 </g:link>
             </div>


### PR DESCRIPTION
I had to revert back delete of (surprisingly used though) menu sections. 'If' statements using those sections are nested deep into e.g. `if (megamenuConfig.inbound.enabled)`, that's why I haven't realized that at first sight. The result was that Inbound and Outbound menu were there, but there was nothing inside them after removing those stockMovement, putaways sections from config. Now I made sure a few times section by section that everything works propely on default settings.