### PR TITLE
OBPIH-5123 hotfix bins just do not appear for some reason in record stock

### DIFF
--- a/grails-app/taglib/org/pih/warehouse/SelectTagLib.groovy
+++ b/grails-app/taglib/org/pih/warehouse/SelectTagLib.groovy
@@ -683,7 +683,7 @@ class SelectTagLib {
                 writer.println()
 
                 from.eachWithIndex { el, i ->
-                    if (el.properties[groupBy].equals(optGroup)) {
+                    if (el.properties[groupBy]?.id == optGroup?.id) {
 
                         def keyValue = null
                         writer << '<option '


### PR DESCRIPTION
- same binLocation comparison resulting in false because of different HashCodes