### PR TITLE
OBGM-362 Configure New Relic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -370,6 +370,8 @@ dependencies {
 
     testImplementation 'com.icegreen:greenmail:1.6.11'
 
+    compile 'com.newrelic.agent.java:newrelic-api:7.11.1'
+
     // expose com.sun.mail.imap.IMAPStore to MailServiceTests
     testImplementation 'com.sun.mail:javax.mail:1.6.2'
 
@@ -575,14 +577,6 @@ dependencies {
 
     // use a release optimized for Grails 3.3.x for this `excel-import` sub-dependency
     implementation 'org.grails.plugins:joda-time:2.1.0'
-
-    /*
-     * FIXME Configure this properly.
-     *
-     * See https://plugins.grails.org/plugin/agorapulse/newrelic
-     * and https://docs.newrelic.com/docs/new-relic-solutions/best-practices-guides/full-stack-observability/browser-monitoring-best-practices-java/
-     */
-    implementation 'org.grails.plugins:newrelic:5.2.0'
 
     // enable `import org.quartz.*`
     compile 'org.grails.plugins:quartz:2.0.13'

--- a/grails-app/controllers/org/pih/warehouse/NewRelicInterceptor.groovy
+++ b/grails-app/controllers/org/pih/warehouse/NewRelicInterceptor.groovy
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2012 Partners In Health.  All rights reserved.
+ * The use and distribution terms for this software are covered by the
+ * Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+ * which can be found in the file epl-v10.html at the root of this distribution.
+ * By using this software in any fashion, you are agreeing to be bound by
+ * the terms of this license.
+ * You must not remove this notice, or any other, from this software.
+ **/
+package org.pih.warehouse
+
+import com.newrelic.api.agent.NewRelic
+import groovy.transform.CompileStatic
+
+/**
+ * Glue code between Grails and New Relic.
+ */
+@CompileStatic
+class NewRelicInterceptor {
+
+    NewRelicInterceptor() {
+        matchAll().except(uri: '/static/**')
+    }
+
+    /**
+     * Tell New Relic the current URL at each page load.
+     */
+    @Override
+    boolean before() {
+        NewRelic.setTransactionName(request.servletContext.servletContextName, request.servletPath)
+        return true
+    }
+
+}

--- a/grails-app/views/layouts/bootstrap.gsp
+++ b/grails-app/views/layouts/bootstrap.gsp
@@ -1,10 +1,11 @@
-<%@ page contentType="text/html;charset=UTF-8" %>
+<%@ page import="com.newrelic.api.agent.NewRelic" contentType="text/html;charset=UTF-8" %>
 <!doctype html>
 <html lang="en">
 <head>
     <!-- Required meta tags -->
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <%= NewRelic.getBrowserTimingHeader() %>
     <title><g:layoutTitle default="OpenBoxes"/></title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/css/bootstrap.min.css"
           rel="stylesheet"
@@ -56,5 +57,6 @@
         });
     });
     </script>
+    <%= NewRelic.getBrowserTimingFooter() %>
 </body>
 </html>

--- a/grails-app/views/layouts/custom.gsp
+++ b/grails-app/views/layouts/custom.gsp
@@ -1,7 +1,9 @@
-<%@ page import="java.util.Locale" %>
+<%@ page import="com.newrelic.api.agent.NewRelic; java.util.Locale" %>
 <?xml version="1.0" encoding="UTF-8"?>
 <html lang="en">
 <head>
+    <%= NewRelic.getBrowserTimingHeader() %>
+
     <!-- Include default page title -->
     <title><g:layoutTitle default="OpenBoxes" /></title>
 
@@ -649,6 +651,6 @@
     </g:if>
 </g:if>
 <r:layoutResources/>
-
+<%= NewRelic.getBrowserTimingFooter() %>
 </body>
 </html>

--- a/grails-app/views/layouts/main.gsp
+++ b/grails-app/views/layouts/main.gsp
@@ -1,12 +1,14 @@
+<%@ page import="com.newrelic.api.agent.NewRelic" %>
 <!doctype html>
 <html lang="en" class="no-js">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <%= NewRelic.getBrowserTimingHeader() %>
     <title>
         <g:layoutTitle default="OpenBoxes"/>
     </title>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <asset:link rel="icon" href="favicon.ico" type="image/x-ico"/>
 
     <asset:stylesheet src="application.css"/>
@@ -86,5 +88,6 @@
 
 <asset:javascript src="application.js"/>
 
+<%= NewRelic.getBrowserTimingFooter() %>
 </body>
 </html>

--- a/grails-app/views/layouts/mobile.gsp
+++ b/grails-app/views/layouts/mobile.gsp
@@ -1,10 +1,11 @@
-<%@ page contentType="text/html;charset=UTF-8" %>
+<%@ page import="com.newrelic.api.agent.NewRelic" contentType="text/html;charset=UTF-8" %>
 <!doctype html>
 <html lang="en">
 <head>
     <!-- Required meta tags -->
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <%= NewRelic.getBrowserTimingHeader() %>
     <title><g:layoutTitle default="OpenBoxes"/></title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/css/bootstrap.min.css"
           rel="stylesheet"
@@ -54,5 +55,6 @@
         });
     });
     </script>
+    <%= NewRelic.getBrowserTimingFooter() %>
 </body>
 </html>


### PR DESCRIPTION
This PR sends a lot of telemetry to New Relic, including

- [crash reports](https://onenr.io/0EjOgdylAj6),
- [logs](https://onenr.io/08jqn1Ny1Ql),
- [timing by url](https://onenr.io/0VjYneP0EQ0),
- [JVM CPU/memory use](https://onenr.io/0MR2G3Z9JjY),
- [database usage](https://onenr.io/0OQMnZNWvwG),
- [host process stats](https://onenr.io/0dQe6BNpowe), and
- (finally!) [disk consumption and usage](https://onenr.io/0qwyeaNpdwn).

It also supports [New Relic's thread profiler](https://onenr.io/0VRV6OzqMRa)

This is presently running on obnavtest1. Note, for all this stuff to work, I needed to wire it to a different New Relic account than what we use for obnav, obnavstage and obdev.

It should not be difficult to back-port this to Grails 1. Maybe on obnavtest2? If we like the results then we can migrate our other hosts to this flavor of New Relic.
