### PR TITLE
OBPIH-5174 Fix filtering out configuration section from megamenu on react

### DIFF
--- a/src/js/components/Layout/NavbarIcons.jsx
+++ b/src/js/components/Layout/NavbarIcons.jsx
@@ -220,7 +220,7 @@ const mapStateToProps = state => ({
   username: state.session.user.username,
   highestRole: state.session.highestRole,
   menuItems: state.session.menuItems,
-  configurationMenuSection: _.find(state.session.menuConfig, section => section.label === 'Configuration'),
+  configurationMenuSection: _.find(state.session.menuConfig, section => section.id === 'configuration'),
   localizedHelpScoutKey: state.session.localizedHelpScoutKey,
   isHelpScoutEnabled: state.session.isHelpScoutEnabled,
 });

--- a/src/js/components/Layout/menu/Menu.jsx
+++ b/src/js/components/Layout/menu/Menu.jsx
@@ -64,7 +64,7 @@ const Menu = ({ menuConfig, location }) => {
     <div className="menu-wrapper" id="navbarSupportedContent">
       <ul className="d-flex align-items-center navbar-nav mr-auto flex-wrap">
         { _.chain(menuConfig)
-          .filter(section => section.label !== 'Configuration')
+          .filter(section => section.id !== 'configuration')
           .map((section) => {
             if (section.href) {
               return (


### PR DESCRIPTION
filter out configuration megamenu based on section id instead of label
The bug ocurred when switching languages which is logical because previously we were filtering out **configuration** section based on label by doing  `if (section.label === 'Configuration)` which would result in `false` in all of the cases where configuration has a different translation label than _Configuration_.
