### PR TITLE
OBPIH-4837 Transactions Report in csv makes credits and debits 0 for …

### DIFF
--- a/grails-app/domain/org/pih/warehouse/inventory/TransactionType.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/TransactionType.groovy
@@ -9,6 +9,8 @@
  **/
 package org.pih.warehouse.inventory
 
+import org.pih.warehouse.core.Constants
+
 class TransactionType implements Serializable {
 
     String id
@@ -33,4 +35,8 @@ class TransactionType implements Serializable {
         sort "sortOrder"
     }
 
+    Boolean compareName(String transactionTypeName) {
+        String regex = "\\${Constants.LOCALIZED_STRING_SEPARATOR}"
+        return name.split(regex)[0] == transactionTypeName.split(regex)[0]
+    }
 }

--- a/grails-app/services/org/pih/warehouse/inventory/InventorySnapshotService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventorySnapshotService.groovy
@@ -467,9 +467,9 @@ class InventorySnapshotService {
 
         def transactionData = getTransactionReportData(location, startDate, endDate)
 
-        def transactionTypeNames = TransactionType.createCriteria().list {
+        def transactionTypes = TransactionType.createCriteria().list {
             'in'("transactionCode", [TransactionCode.DEBIT, TransactionCode.CREDIT])
-        }.collect { it.name }
+        }
 
         // Get starting balance
         def balanceOpeningMap = getQuantityOnHandByProduct(location, startDate)
@@ -524,14 +524,14 @@ class InventorySnapshotService {
             ]
             row.put("Opening", balanceOpening)
             def includeRow = balanceOpening || balanceClosing || quantityAdjustments
-            transactionTypeNames.each { String transactionTypeName ->
-                String translatedTransactionTypeName = transactionTypeName
-                if (transactionTypeName.contains(Constants.LOCALIZED_STRING_SEPARATOR)) {
-                    translatedTransactionTypeName = LocalizationUtil.getLocalizedString(transactionTypeName)
+            transactionTypes.each { TransactionType transactionType ->
+                String translatedTransactionTypeName = transactionType?.name
+                if (transactionType?.name?.contains(Constants.LOCALIZED_STRING_SEPARATOR)) {
+                    translatedTransactionTypeName = LocalizationUtil.getLocalizedString(transactionType?.name)
                 }
                 def quantity =
                         transactionData.find {
-                            it.productCode == product.productCode && it.transactionTypeName == transactionTypeName.split("\\|")[0]
+                            it.productCode == product.productCode && transactionType.compareName(it?.transactionTypeName)
                         }?.quantity?:0
                 row[translatedTransactionTypeName] = quantity
                 includeRow = quantity != 0 ? true : includeRow

--- a/grails-app/services/org/pih/warehouse/inventory/InventorySnapshotService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventorySnapshotService.groovy
@@ -525,14 +525,15 @@ class InventorySnapshotService {
             row.put("Opening", balanceOpening)
             def includeRow = balanceOpening || balanceClosing || quantityAdjustments
             transactionTypeNames.each { String transactionTypeName ->
+                String translatedTransactionTypeName = transactionTypeName
                 if (transactionTypeName.contains(Constants.LOCALIZED_STRING_SEPARATOR)) {
-                    transactionTypeName = LocalizationUtil.getLocalizedString(transactionTypeName)
+                    translatedTransactionTypeName = LocalizationUtil.getLocalizedString(transactionTypeName)
                 }
                 def quantity =
                         transactionData.find {
-                            it.productCode == product.productCode && it.transactionTypeName == transactionTypeName
+                            it.productCode == product.productCode && it.transactionTypeName == transactionTypeName.split("\\|")[0]
                         }?.quantity?:0
-                row[transactionTypeName] = quantity
+                row[translatedTransactionTypeName] = quantity
                 includeRow = quantity != 0 ? true : includeRow
             }
 


### PR DESCRIPTION
…locale in Fr

Like I told to @awalkowiak I don't feel good about this solution, but couldn't figure out anything better for now.
The problem was, that `transactionData` stores `transactionTypeName` always in English, for example: `Transfer in`, but `transactionTypeNames` example is: `Transfer in|fr:<french_translation>`, which resulted in comparing in line `534` for example `Transfer In == <its_french_translation>`, so the result was always `0`.
So the solution I figured out was just to split the `transationTypeName` by the delimiter (`|`) and take the first element (English), so we compare it propely.
Still, the translated version is needed in order to put it to the header of CSV, so I kept it
