### PR TITLE
OBS-1342.2 Do not call sdkman from GitHub Actions.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -75,27 +75,12 @@ jobs:
         key: ${{ runner.os }}-v3-npm-${{ hashFiles('**/package-lock.json') }}
         path: ~/.npm
 
-    - id: sdkman
+    - name: download grails SDK from GitHub (unless cached)
       if: steps.grails-sdk.outputs.cache-hit != 'true'
-      name: download grails SDK (unless cached)
-      uses: sdkman/sdkman-action@master
-      with:
-        candidate: grails
-        version: 1.3.9
-
-    - id: sdkman-unzip
-      continue-on-error: true
-      if: steps.grails-sdk.outputs.cache-hit != 'true'
-      name: unzip grails SDK (unless cached)
-      run: unzip -o ${{ steps.sdkman.outputs.file }} -d ~/
-
-    - name: unzip grails SDK (retry if sdkman failed)
-      if: failure() && steps.sdkman-unzip.outcome == 'failure'
       run: |
-        rm ${{ steps.sdkman.outputs.file }}
         curl -L https://github.com/grails/grails-core/releases/download/v1.3.9/grails-1.3.9.zip \
-             -o ${{ steps.sdkman.outputs.file }}
-        unzip -o ${{ steps.sdkman.outputs.file }} -d ~/
+             -o /tmp/grails-core.zip
+        unzip -o /tmp/grails-core.zip -d ~
 
     - name: npm install
       run: npm install

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -60,27 +60,12 @@ jobs:
         key: ${{ runner.os }}-v3-npm-${{ hashFiles('**/package-lock.json') }}
         path: ~/.npm
 
-    - id: sdkman
+    - name: download grails SDK from GitHub (unless cached)
       if: steps.grails-sdk.outputs.cache-hit != 'true'
-      name: download grails SDK (unless cached)
-      uses: sdkman/sdkman-action@master
-      with:
-        candidate: grails
-        version: 1.3.9
-
-    - id: sdkman-unzip
-      continue-on-error: true
-      if: steps.grails-sdk.outputs.cache-hit != 'true'
-      name: unzip grails SDK (unless cached)
-      run: unzip -o ${{ steps.sdkman.outputs.file }} -d ~/
-
-    - name: unzip grails SDK (retry if sdkman failed)
-      if: failure() && steps.sdkman-unzip.outcome == 'failure'
       run: |
-        rm ${{ steps.sdkman.outputs.file }}
         curl -L https://github.com/grails/grails-core/releases/download/v1.3.9/grails-1.3.9.zip \
-             -o ${{ steps.sdkman.outputs.file }}
-        unzip -o ${{ steps.sdkman.outputs.file }} -d ~/
+             -o /tmp/grails-core.zip
+        unzip -o /tmp/grails-core.zip -d ~
 
     - name: npm install
       run: npm install


### PR DESCRIPTION
This PR updates my previous OBS-1342 patch to never talk to sdkman at all, but instead download grails directly from GitHub.