### PR TITLE
OBPIH-5237 Create a transaction for inventories with entries for both…

### DIFF
--- a/grails-app/services/org/pih/warehouse/product/ProductMergeService.groovy
+++ b/grails-app/services/org/pih/warehouse/product/ProductMergeService.groovy
@@ -9,7 +9,9 @@
 **/ 
 package org.pih.warehouse.product
 
+import org.pih.warehouse.api.AvailableItem
 import org.pih.warehouse.core.Constants
+import org.pih.warehouse.inventory.Inventory
 import org.pih.warehouse.inventory.InventoryItem
 import org.pih.warehouse.inventory.Transaction
 import org.pih.warehouse.inventory.TransactionEntry
@@ -80,8 +82,11 @@ class ProductMergeService {
          * SWAP TRIVIAL RELATIONS
          * */
 
+        log.info "Merging ${obsolete.productCode} product into ${primary.productCode}"
+
         // 1. ProductSupplier
         List<ProductSupplier> obsoletedSuppliers = ProductSupplier.findAllByProduct(obsolete)
+        log.info "Moving ${obsoletedSuppliers?.size() ?: 0} Product Suppliers"
         obsoletedSuppliers?.each { ProductSupplier obsoletedSupplier ->
             // Find if primary product has already the same supplier
             ProductSupplier primarySupplier = ProductSupplier.findByProductAndCode(primary, obsoletedSupplier.code)
@@ -101,6 +106,7 @@ class ProductMergeService {
 
         // 2. ProductComponent <-- swap only components that does not exist for primary product
         List<ProductComponent> obsoletedComponents = ProductComponent.findAllByAssemblyProduct(obsolete)
+        log.info "Moving ${obsoletedComponents?.size() ?: 0} Product Components"
         obsoletedComponents?.each { ProductComponent obsoletedComponent ->
             // Find if primary product has already the same component
             List<ProductComponent> primaryComponents = ProductComponent.findAllByAssemblyProductAndComponentProduct(
@@ -124,40 +130,70 @@ class ProductMergeService {
          * TRANSACTIONS, INVENTORY ITEMS AND OTHER "ITEM" RELATIONS
          * */
 
-        // 1. Merge most recent obsolete and primary PRODUCT_INVENTORY or INVENTORY Transactions (Transaction
-        //    entries require to be moved to the primary transaction, because for stock card and product
-        //    availability calculations we always look into the most recent transaction with one of these two types).
+        // 1. Create a new common transaction that will contain current stock of both products. This is required
+        //    for inventories that have transaction entries for bot products. If this transaction won't be created,
+        //    then current stock for primary after merge might not be a proper sum of current stock of obsolete
+        //    and primary before merge action.
 
-        // Move TransactionEntries for the most recent PRODUCT_INVENTORY or INVENTORY Transaction (if any
-        // one of these exists for both products)
-        TransactionType productInventoryType = TransactionType.get(Constants.PRODUCT_INVENTORY_TRANSACTION_TYPE_ID)
-        TransactionType inventoryType = TransactionType.get(Constants.INVENTORY_TRANSACTION_TYPE_ID)
-        def transactionTypes = [productInventoryType, inventoryType]
-        List<Transaction> obsoleteTransactions = inventoryService.getMostRecentTransactionsForProductAndTypeByInventory(obsolete, transactionTypes)
-        List<Transaction> primaryTransactions = inventoryService.getMostRecentTransactionsForProductAndTypeByInventory(primary, transactionTypes)
-        if (obsoleteTransactions && primaryTransactions) {
-            obsoleteTransactions.each { Transaction obsoleteTransaction ->
-                Transaction primaryTransaction = primaryTransactions.find { it.inventory?.id == obsoleteTransaction.inventory?.id }
-                if (!primaryTransaction) {
-                    return
-                }
+        // 1.1. Get each inventory of transaction entries for obsolete product
+        List<Inventory> obsoleteInventories = inventoryService.getInventoriesWithTransactionsByProduct(obsolete)
+        // 1.2. Get each inventory of transaction entries for primary product
+        List<Inventory> primaryInventories = inventoryService.getInventoriesWithTransactionsByProduct(primary)
+        // 1.3. For each intersecting inventory create a new transaction
+        List<Inventory> intersectingInventories = obsoleteInventories.intersect(primaryInventories)
+        log.info "Creating transactions for ${intersectingInventories?.size() ?: 0} intersecting inventories"
+        intersectingInventories?.each { Inventory inventory ->
+            List<TransactionEntry> transactionEntries = []
 
-                // Refetch entries by obsolete transaction and product to avoid running into ConcurrentModificationException
-                def obsoleteEntries = TransactionEntry.findAllByTransactionAndProduct(obsoleteTransaction, obsolete)
-                obsoleteEntries?.each { TransactionEntry entry ->
-                    moveTransactionEntry(
-                        entry,
-                        obsoleteTransaction,
-                        primaryTransaction,
-                        primary
-                    )
-                }
+            // a. Calculate current stock of obsolete and primary
+            List<TransactionEntry> obsoleteTransactionEntries = inventoryService.getTransactionEntriesByInventoryAndProduct(inventory, [obsolete])
+            def obsoleteQuantityAvailableInventoryItemMap = inventoryService.getQuantityAvailableByProductAndInventoryItemMap(obsolete, inventory.warehouse)
+            def obsoleteAvailableItems = inventoryService.getAvailableItems(
+                obsoleteTransactionEntries,
+                obsoleteQuantityAvailableInventoryItemMap
+            )
+            obsoleteAvailableItems?.each { AvailableItem it ->
+                transactionEntries << new TransactionEntry(
+                    quantity: (it.quantityOnHand as Integer),
+                    product: obsolete,
+                    inventoryItem: it.inventoryItem,
+                    binLocation: it.binLocation
+                )
             }
+
+            List<TransactionEntry> primaryTransactionEntries = inventoryService.getTransactionEntriesByInventoryAndProduct(inventory, [primary])
+            def primaryQuantityAvailableInventoryItemMap = inventoryService.getQuantityAvailableByProductAndInventoryItemMap(primary, inventory.warehouse)
+            def primaryAvailableItems = inventoryService.getAvailableItems(
+                primaryTransactionEntries,
+                primaryQuantityAvailableInventoryItemMap
+            )
+            primaryAvailableItems?.each { AvailableItem it ->
+                transactionEntries << new TransactionEntry(
+                    quantity: (it.quantityOnHand as Integer),
+                    product: obsolete,
+                    inventoryItem: it.inventoryItem,
+                    binLocation: it.binLocation
+                )
+            }
+
+            // b. Create a transaction from available items
+            log.info "Creating transaction for ${inventory.warehouse.name}"
+            Transaction transaction = new Transaction()
+            transaction.inventory = inventory
+            transaction.transactionType = TransactionType.get(Constants.PRODUCT_INVENTORY_TRANSACTION_TYPE_ID)
+            transaction.transactionNumber = inventoryService.generateTransactionNumber()
+            transaction.transactionDate = new Date()
+            transaction.comment = "Created while merging product ${obsolete.productCode} into ${primary.productCode} " +
+                "(this happens if both products have transaction entries in the same inventory)"
+            transaction.disableRefresh = true // there is no need to refresh product availability, because this should not change
+            transactionEntries?.each { TransactionEntry it -> transaction.addToTransactionEntries(it) }
+            transaction.save(flush: true)
         }
 
         // 2. Copy Inventory items that are not already existing on the primary product (and InventorySnapshot change)
         Set<InventoryItem> primaryInventoryItems = InventoryItem.findAllByProduct(primary)
         Set<InventoryItem> obsoleteInventoryItems = InventoryItem.findAllByProduct(obsolete)
+        log.info "Moving ${obsoleteInventoryItems?.size() ?: 0} Inventory items"
         obsoleteInventoryItems?.each { InventoryItem obsoleteInventoryItem ->
             // Check if this lot already exists for the primary product
             def obsoleteLotNumber = obsoleteInventoryItem?.lotNumber
@@ -204,6 +240,7 @@ class ProductMergeService {
 
         // 3. Swap data on the transaction entries
         List<TransactionEntry> obsoleteTransactionEntries = getRelatedObjectsForProduct(TransactionEntry.createCriteria(), obsolete)
+        log.info "Moving ${obsoleteTransactionEntries?.size() ?: 0} Transaction Entries"
         obsoleteTransactionEntries?.each { TransactionEntry obsoleteTransactionEntry ->
             logProductMergeData(primary, obsolete, obsoleteTransactionEntry)
 
@@ -225,6 +262,7 @@ class ProductMergeService {
         // 4.1 RequisitionItem
         def requisitionItemCriteria = RequisitionItem.createCriteria()
         List<RequisitionItem> obsoleteRequisitionItems = getRelatedObjectsForProduct(requisitionItemCriteria, obsolete)
+        log.info "Moving ${obsoleteRequisitionItems?.size() ?: 0} Requisition items"
         obsoleteRequisitionItems?.each { RequisitionItem obsoleteRequisitionItem ->
             logProductMergeData(primary, obsolete, obsoleteRequisitionItem)
 
@@ -244,6 +282,7 @@ class ProductMergeService {
         // 4.2 ShipmentItem
         def shipmentItemCriteria = ShipmentItem.createCriteria()
         List<ShipmentItem> obsoleteShipmentItems = getRelatedObjectsForProduct(shipmentItemCriteria, obsolete)
+        log.info "Moving ${obsoleteShipmentItems?.size() ?: 0} Shipmen items"
         obsoleteShipmentItems?.each { ShipmentItem obsoleteShipmentItem ->
             logProductMergeData(primary, obsolete, obsoleteShipmentItem)
 
@@ -265,6 +304,7 @@ class ProductMergeService {
         // 4.3 OrderItem
         def orderItemCriteria = OrderItem.createCriteria()
         List<OrderItem> obsoleteOrderItems = getRelatedObjectsForProduct(orderItemCriteria, obsolete)
+        log.info "Moving ${obsoleteOrderItems?.size() ?: 0} Order items"
         obsoleteOrderItems?.each { OrderItem obsoleteOrderItem ->
             logProductMergeData(primary, obsolete, obsoleteOrderItem)
 
@@ -284,6 +324,7 @@ class ProductMergeService {
         // 4.4 ReceiptItem
         def receiptItemCriteria = ReceiptItem.createCriteria()
         List<ReceiptItem> obsoleteReceiptItems = getRelatedObjectsForProduct(receiptItemCriteria, obsolete)
+        log.info "Moving ${obsoleteReceiptItems?.size() ?: 0} Receipt items"
         obsoleteReceiptItems?.each { ReceiptItem obsoleteReceiptItem ->
             logProductMergeData(primary, obsolete, obsoleteReceiptItem)
 
@@ -337,45 +378,6 @@ class ProductMergeService {
                 }
             }
         }
-    }
-
-    /**
-     * Moves TransactionEntry of obsolete product from one Transaction to another for primary product. In case
-     * both transactions have both obsolete and primary product or the same lot for these entries, then
-     * sum quantities of entries and remove obsolete one.
-     * */
-    void moveTransactionEntry(TransactionEntry entry, Transaction fromTransaction, Transaction toTransaction, Product primary) {
-        // First check if the toTransaction has already entry with the same lot number and bin location for primary product
-        TransactionEntry sameEntry = toTransaction?.transactionEntries?.find {
-            (it?.product?.id == primary?.id || it?.inventoryItem?.product?.id == primary?.id) &&
-            it?.inventoryItem?.lotNumber == entry?.inventoryItem?.lotNumber &&
-            it?.binLocation?.id == entry?.binLocation?.id
-        }
-        if (sameEntry) {
-            // If toTransaction has already the same entry for primary product, then sum quantities
-            sameEntry.quantity += entry.quantity
-            sameEntry.save(flush: true)
-        } else {
-            // Clone the entry from the obsolete transaction
-            TransactionEntry clonedEntry = new TransactionEntry(
-                quantity: entry.quantity,
-                product: entry.product,
-                inventoryItem: entry.inventoryItem,
-                binLocation: entry.binLocation,
-                reasonCode: entry.reasonCode,
-                comments: entry.comments
-            )
-
-            // Add cloned entry to the primary transaction
-            toTransaction.disableRefresh = true
-            toTransaction.addToTransactionEntries(clonedEntry)
-            toTransaction.save(flush: true)
-        }
-
-        // Remove cloned/moved entry from obsolete transaction
-        fromTransaction.disableRefresh = true
-        fromTransaction.removeFromTransactionEntries(entry)
-        fromTransaction.save(flush: true)
     }
 
     void logProductMergeData(Product primary, Product obsolete, def relatedObject) {


### PR DESCRIPTION
… products

This is required because of the issues with calculating current stock of primary product after merge. Previously when moving obsolete's most recent transaction entries to the primary's most recent transaction (with types PRODUCT_INVENTORY or INVENTORY), the stock might not reflect the current status. Especially when there were additional transaction entries (DEBITS and CREDITS) after the obsolete transaction (with types PRODUCT_INVENTORY or INVENTORY) which led to discrepancies.