### PR TITLE
OBPIH-5301 Fix validation for lot and exp date on inbound add items step

### DIFF
--- a/src/js/components/returns/inbound/AddItemsPage.jsx
+++ b/src/js/components/returns/inbound/AddItemsPage.jsx
@@ -497,7 +497,7 @@ class AddItemsPage extends Component {
                   <Translate id="react.default.button.previous.label" defaultMessage="Previous" />
                 </button>
                 <button
-                  type="button"
+                  type="submit"
                   onClick={() => {
                     if (!invalid) {
                       this.nextPage(values);

--- a/src/js/components/stock-movement-wizard/inbound/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/inbound/AddItemsPage.jsx
@@ -1046,7 +1046,7 @@ class AddItemsPage extends Component {
                   <Translate id="react.default.button.previous.label" defaultMessage="Previous" />
                 </button>
                 <button
-                  type="button"
+                  type="submit"
                   onClick={() => {
                     if (!invalid) {
                       this.nextPage(values);

--- a/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
@@ -1050,7 +1050,7 @@ class AddItemsPage extends Component {
                   <Translate id="react.default.button.previous.label" defaultMessage="Previous" />
                 </button>
                 <button
-                  type="button"
+                  type="submit"
                   onClick={() => {
                     if (!invalid) {
                       this.nextPage(values);


### PR DESCRIPTION
After discussing it with @drodzewicz and the reasons why it was changed to `button` in one of the latest PRs by him we couldn't reproduce the issue he had before when the type was `submit`, probably this:
```
event.stopPropagation();
```
fixed the issue Dariusz had with the enter case, so we could just simply bring back `type="submit"` here