### PR TITLE
OBPIH-5207 Fix crowdin translations on Dashboard

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -3506,6 +3506,18 @@ react.dashboard.requisitionCountByYear.info.label=Shows the number of created Re
 react.dashboard.fiscalYear.label=Fiscal Year
 react.dashboard.calendarYear.label=Calendar Year
 
+react.dashboard.hasBeenEdited.message=The dashboard layout has been edited
+react.dashboard.saveConfiguration.label=Save configuration
+react.dashboard.archive.label=Archive indicator
+
+# Dashboards
+react.dashboard.fillRate.label=Fill Rate
+react.dashboard.transaction.label=Transaction Management
+react.dashboard.inventory.label=Inventory Management
+react.dashboard.warehouse.label=Warehouse Management
+react.dashboard.personal.label=My Dashboard
+react.dashboard.supplier.label=Supplier Dashboard
+
 # Dashboard labels lists
 react.dashboard.timeline.today.label=today
 react.dashboard.timeline.within30Days.label=within 30 days
@@ -3539,8 +3551,8 @@ react.dashboard.subtitle.items.label=Items
 react.dashboard.requests.subtitle.label=Requests
 
 # Dashboard timeFilters
-react.dashboard.timeFilter.last.label=Last
-react.dashboard.timeFilter.next.label=Next
+react.dashboard.timeFilter.last.label=Last ${number} ${timeUnit}
+react.dashboard.timeFilter.next.label=Next ${number} ${timeUnit}
 react.dashboard.timeFilter.month.label=Month
 react.dashboard.timeFilter.months.label=Months
 react.dashboard.timeFilter.year.label=Year

--- a/src/js/components/dashboard/Dashboard.jsx
+++ b/src/js/components/dashboard/Dashboard.jsx
@@ -21,6 +21,7 @@ import LoadingNumbers from 'components/dashboard/LoadingNumbers';
 import NumberCard from 'components/dashboard/NumberCard';
 import UnarchiveIndicators from 'components/dashboard/UnarchiveIndicators';
 import apiClient from 'utils/apiClient';
+import Translate from 'utils/Translate';
 
 import 'react-table/react-table.css';
 import 'react-confirm-alert/src/react-confirm-alert.css';
@@ -91,7 +92,11 @@ const SortableNumberCards = SortableContainer(({ data, personalDashboardActive }
 const ArchiveIndicator = ({ hideArchive }) => (
   <div className={hideArchive ? 'archive-div hide-archive' : 'archive-div'}>
     <span>
-      Archive indicator <i className="fa fa-archive" />
+      <Translate
+        id="react.dashboard.archive.label"
+        defaultMessage="Archive indicator"
+      />
+      <i className="fa fa-archive ml-2" />
     </span>
   </div>
 );
@@ -117,7 +122,7 @@ const ConfigurationsList = ({
           <li className={`configs-list-item ${activeConfig === key ? 'active' : ''}`} key={key}>
             <button onClick={() => loadConfigData(key)}>
               <i className="fa fa-bar-chart" aria-hidden="true" />
-              {value.name}
+              <Translate id={`react.dashboard.${key}.label`} defaultMessage={value.name} />
             </button>
           </li>
           ))}
@@ -126,10 +131,19 @@ const ConfigurationsList = ({
         (activeConfig === 'personal' && configModified) ?
           <div className="update-section">
             <div className="division-line" />
-            <span> <i className="fa fa-info-circle" aria-hidden="true" />The dashboard layout has been edited</span>
+            <span>
+              <i className="fa fa-info-circle" aria-hidden="true" />
+              <Translate
+                id="react.dashboard.hasBeenEdited.message"
+                defaultMessage="The dashboard layout has been edited"
+              />
+            </span>
             <button onClick={updateConfig} >
               <i className="fa fa-floppy-o" aria-hidden="true" />
-              Save configuration
+              <Translate
+                id="react.dashboard.saveConfiguration.label"
+                defaultMessage="Save configuration"
+              />
             </button>
           </div>
         : null

--- a/src/js/components/dashboard/GraphCard.jsx
+++ b/src/js/components/dashboard/GraphCard.jsx
@@ -62,7 +62,7 @@ class FilterComponent extends Component {
   render() {
     return (
       <div className="data-filter">
-        { this.props.locationFilter === true ?
+        { this.props.locationFilter &&
           <select
             className="location-filter custom-select"
             size="1"
@@ -85,8 +85,8 @@ class FilterComponent extends Component {
             })}
 
           </select>
- : null }
-        { this.props.timeFilter === true ?
+        }
+        { this.props.timeFilter &&
           <select
             className="time-filter custom-select"
             onChange={e => this.handleChange(e, this.props.cardId, this.props.loadIndicator)}
@@ -94,14 +94,60 @@ class FilterComponent extends Component {
             defaultValue={this.state.timeFrame}
             id="timeFrameSelector"
           >
-            <option value="1">{this.props.translate(this.props.label[0], this.props.label[1])} {this.props.translate('react.dashboard.timeFilter.month.label', 'Month')}</option>
-            <option value="3">{this.props.translate(this.props.label[0], this.props.label[1])} 3 {this.props.translate('react.dashboard.timeFilter.months.label', 'Months')}</option>
-            <option value="6">{this.props.translate(this.props.label[0], this.props.label[1])} 6 {this.props.translate('react.dashboard.timeFilter.months.label', 'Months')}</option>
-            <option value="12">{this.props.translate(this.props.label[0], this.props.label[1])} {this.props.translate('react.dashboard.timeFilter.year.label', 'Year')}</option>
-            { this.props.timeLimit === 24 ?
-              <option value="24">{this.props.translate(this.props.label[0], this.props.label[1])} 2 {this.props.translate('react.dashboard.timeFilter.years.label', 'Years')}</option>
-            : null }
-          </select> : null
+            <option value="1">
+              {this.props.translate(
+                this.props.label[0],
+                this.props.label[1],
+              {
+                number: '',
+                timeUnit: this.props.translate('react.dashboard.timeFilter.month.label', 'Month'),
+              },
+            )}
+            </option>
+            <option value="3">
+              {this.props.translate(
+                this.props.label[0],
+                this.props.label[1],
+                {
+                  number: 3,
+                  timeUnit: this.props.translate('react.dashboard.timeFilter.month.label', 'Month'),
+                },
+              )}
+            </option>
+            <option value="6">
+              {this.props.translate(
+                this.props.label[0],
+                this.props.label[1],
+                {
+                  number: 6,
+                  timeUnit: this.props.translate('react.dashboard.timeFilter.month.label', 'Month'),
+                },
+              )}
+            </option>
+            <option value="12">
+              {this.props.translate(
+                this.props.label[0],
+                this.props.label[1],
+                {
+                  number: '',
+                  timeUnit: this.props.translate('react.dashboard.timeFilter.year.label', 'Year'),
+                },
+              )}
+            </option>
+            {
+              this.props.timeLimit === 24 &&
+              <option value="24">
+                {this.props.translate(
+                  this.props.label[0],
+                  this.props.label[1],
+                  {
+                    number: 2,
+                    timeUnit: this.props.translate('react.dashboard.timeFilter.years.label', 'Years'),
+                  },
+                )}
+              </option>
+            }
+          </select>
         }
         {this.props.yearTypeFilter && (
           <select
@@ -151,7 +197,8 @@ const GraphCard = SortableElement(({
   hideDraghandle,
 }) => {
   let graph;
-  let label = ['react.dashboard.timeFilter.last.label', 'last'];
+  // eslint-disable-next-line no-template-curly-in-string
+  let label = ['react.dashboard.timeFilter.last.label', 'last ${0} ${1}'];
 
   const translateDataLabels = (listLabels) => {
     const listTranslated = listLabels.map(labelToTranslate =>
@@ -173,7 +220,8 @@ const GraphCard = SortableElement(({
         onElementsClick={elements => handleChartClick(elements)}
       />
     );
-    label = ['react.dashboard.timeFilter.next.label', 'next'];
+    // eslint-disable-next-line no-template-curly-in-string
+    label = ['react.dashboard.timeFilter.next.label', 'next ${0} ${1}'];
   } else if (cardType === 'bar') {
     graph = <Bar data={data} options={options} />;
   } else if (cardType === 'doughnut') {

--- a/src/js/components/dashboard/NumberCard.jsx
+++ b/src/js/components/dashboard/NumberCard.jsx
@@ -13,7 +13,6 @@ import { translateWithDefaultMessage } from 'utils/Translate';
 
 import 'components/dashboard/Dashboard.scss';
 
-/* global _ */
 
 const options = {
   responsive: true,
@@ -122,8 +121,8 @@ const NumberCard = SortableElement(({
             {translate(cardTitle, cardTitle)}
           </span>
           <span className="result-card"> {cardNumberType === 'number' ? cardNumberLocale : `${cardNumberLocale} ${currencyCode}`} </span>
-          <span className="subtitle-card">
-            {_.truncate(translate(cardSubtitle, cardSubtitle), { length: 22 })}
+          <span className="subtitle-card text-overflow-ellipsis text-nowrap">
+            {translate(cardSubtitle, cardSubtitle)}
           </span>
         </div>
         {

--- a/src/js/components/dashboard/UnarchiveIndicators.jsx
+++ b/src/js/components/dashboard/UnarchiveIndicators.jsx
@@ -27,10 +27,9 @@ const PreviewIndicator = props => (
       <div className="row">
         <div className="col col-3 graph-preview">{props.children}</div>
         <div className="col col-6">
-          {
-            <span>{_.truncate(props.translate(props.title, props.title), { length: 25, omission: '...' }) }</span>
-          }
-
+          <span className="w-100 text-overflow-ellipsis text-nowrap text-left">
+            {props.translate(props.title, props.title)}
+          </span>
         </div>
         <div className="col col-3">
           <span


### PR DESCRIPTION
- Add missing translations for Dashboards sidebar items
- Add missing translation For labels on Archive indicators, save config etc.
- Fix truncated label causing crowding not to translate it properly
- Modify indicator filter component option label rendering to instead accept arguments in the label for more control on the order of words