### PR TITLE
Updated grant command to include create user command, as some version…

### DIFF
--- a/docs/installation/ubuntu1804/mysql.md
+++ b/docs/installation/ubuntu1804/mysql.md
@@ -17,7 +17,8 @@ $ mysql -u root -p -e 'create database openboxes default charset utf8;'
 
 ## Grant permissions to new database user
 ```
-$ mysql -u root -p -e 'grant all on openboxes.* to openboxes@localhost identified by "<password>";'
+$ mysql -u root -p -e 'CREATE USER openboxes@localhost identified by "<password>";'
+$ mysql -u root -p -e 'grant all on openboxes.* to openboxes@localhost;'
 ```
 !!! note
     For security reasons, you will want to set a good password.  These values should be used in the 


### PR DESCRIPTION
…s of MySQL grant cannot create users.

Mysql command grant could be used to create users, but this use was deprecated and now doesn't work on current versions of MySQL - updated command twill work in them all.