### PR TITLE
Minor bugs in documentation

### DIFF
--- a/docs/installation/ubuntu1804/deployment.md
+++ b/docs/installation/ubuntu1804/deployment.md
@@ -34,7 +34,7 @@ The deployment could take about 10-20 minutes the first time because the applica
 database migrations. Keep an eye out for any errors/exceptions that pop up in the `catalina.out` log file and check 
 the Troubleshooting section for details on how to handle these issues.
 ```
-$ sudo tail -f /opt/tomcat/apache-tomcat-7.0.94/logs/catalina.out
+$ sudo tail -f /opt/tomcat/logs/catalina.out
 ```
 
 !!! note


### PR DESCRIPTION
Updated file name for log file - /opt/tomcat is a symlink to whatever version of tomcat got installed, so /opt/tomcat/tomcat-<version> does not make sense - corrected by removing extraneous component.
Also fixed documentation bug where java path ended up incorrect.