### PR TITLE
Updated documentation to recommend adding a uploads folder

### DIFF
--- a/docs/installation/ubuntu1804/configuration.md
+++ b/docs/installation/ubuntu1804/configuration.md
@@ -15,6 +15,7 @@ sudo vi /opt/tomcat/.grails/openboxes-config.properties
 dataSource.username=<username>
 dataSource.password=<password>
 dataSource.url=jdbc:mysql://localhost:3306/openboxes?useSSL=false
+openboxes.uploads.location=/opt/tomcat/webapps/openboxes/uploads/
 
 # Used primarily with g:link when absoluteUrl is true (e.g. links in emails)
 grails.serverURL=http://localhost:8080/openboxes
@@ -24,10 +25,13 @@ grails.serverURL=http://localhost:8080/openboxes
 ```
 
 !!! note "Reminder" 
-    Change `dataSource.username` and `dataSource.password` to the `username` and `password` you set in the `grant all` command above.
+    Change `dataSource.username` and `dataSource.password` to the `username` and `password` you set in the `create user... identified by` SQL command for the database in the MySQL step.
 
 !!! note "Reminder" 
     Change `grails.serverURL` to the IP address or domain name you plan to use for your server.
+    
+!!! note "Reminder"
+    The uploads directory must be a location the tomcat user can write to, without this line it will default to /uploads which can be created manually, but won't be created automatically as tomcat cannot create a folder here. The above path should work, but you can change this to put the uploads folder anywhere provided tomcat can write to it. If the uploads folder does not exist, tomcat will attempt to create it (which will only work if it can write to the parent location)
 
 
 !!! note 


### PR DESCRIPTION
Added a line to the suggested configuration file to put the uploads folder in a functional location and a note that this can be changed. Without this line the default is /uploads which tomcat cannot write to (and while this could be created manually, this is a poor location for segregation of multiple services on a system)