### PR TITLE
OBS-1375 Do not crash ProductAvailabilityService threads if deadlock occurs

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -39,7 +39,6 @@ class ProductAvailabilityService {
     def persistenceInterceptor
     def locationService
     def inventoryService
-    def dataService
 
     def triggerRefreshProductAvailability(String locationId, List<String> productIds, Boolean forceRefresh) {
         Boolean delayStart = grailsApplication.config.openboxes.jobs.refreshProductAvailabilityJob.delayStart
@@ -111,19 +110,20 @@ class ProductAvailabilityService {
     }
 
     def refreshProductAvailability(Location location, Boolean forceRefresh) {
-        log.info "Refreshing product availability location (${location}), forceRefresh (${forceRefresh}) ..."
-        def startTime = System.currentTimeMillis()
-        List binLocations = calculateBinLocations(location)
-        saveProductAvailability(location, null, binLocations, forceRefresh)
-        log.info "Refreshed  ${binLocations?.size()} product availability records for location (${location}) in ${System.currentTimeMillis() - startTime}ms"
+        return refreshProductAvailability(location, null, forceRefresh)
     }
 
     def refreshProductAvailability(Location location, Product product, Boolean forceRefresh) {
         log.info "Refreshing product availability location ${location}, product ${product}, forceRefresh ${forceRefresh}..."
         def startTime = System.currentTimeMillis()
-        List binLocations = calculateBinLocations(location, product)
-        saveProductAvailability(location, product, binLocations, forceRefresh)
-        log.info "Refreshed ${binLocations?.size()} product availability records for product (${product}) and location (${location}) in ${System.currentTimeMillis() - startTime}ms"
+        List binLocations = product ? calculateBinLocations(location, product) : calculateBinLocations(location)
+        // FIXME: if this deadlocks, it safe to auto-retry here?
+        boolean success = saveProductAvailability(location, product, binLocations, forceRefresh)
+        if (success) {
+            log.info "Refreshed ${binLocations?.size()} product availability records for product (${product}) and location (${location}) in ${System.currentTimeMillis() - startTime}ms"
+        } else {
+            log.error "Could not refresh ${binLocations?.size()} product availability records for product (${product}) and location (${location}) after ${System.currentTimeMillis() - startTime}ms"
+        }
     }
 
     def calculateBinLocations(Location location, Date date) {
@@ -133,17 +133,18 @@ class ProductAvailabilityService {
     }
 
     def calculateBinLocations(Location location) {
-        def binLocations = inventoryService.getBinLocationDetails(location)
-        def picked = getQuantityPickedByProductAndLocation(location, null)
-        binLocations = transformBinLocations(binLocations, picked)
-        return binLocations
+        return calculateBinLocations(location, null as Product)
     }
 
     def calculateBinLocations(Location location, Product product) {
-        def binLocations = inventoryService.getProductQuantityByBinLocation(location, product, Boolean.TRUE)
+        def binLocations
+        if (product) {
+            binLocations = inventoryService.getProductQuantityByBinLocation(location, product, Boolean.TRUE)
+        } else {
+            binLocations = inventoryService.getBinLocationDetails(location)
+        }
         def picked = getQuantityPickedByProductAndLocation(location, product)
-        binLocations = transformBinLocations(binLocations, picked)
-        return binLocations
+        return transformBinLocations(binLocations, picked)
     }
 
     def getQuantityPickedByProductAndLocation(Location location, Product product) {
@@ -175,7 +176,7 @@ class ProductAvailabilityService {
         return results.collect { [binLocation: it[0]?.id, inventoryItem: it[1]?.id, quantityAllocated: it[2]] }
     }
 
-    def saveProductAvailability(Location location, Product product, List binLocations, Boolean forceRefresh) {
+    boolean saveProductAvailability(Location location, Product product, List binLocations, Boolean forceRefresh) {
         log.info "Saving product availability for product=${product?.productCode}, location=${location}"
         def batchSize = ConfigurationHolder.config.openboxes.inventorySnapshot.batchSize ?: 1000
         def startTime = System.currentTimeMillis()
@@ -184,6 +185,7 @@ class ProductAvailabilityService {
             Sql sql = new Sql(dataSource)
 
             // Execute SQL in batches
+            // FIXME recover from deadlocks
             sql.withBatch(batchSize) { BatchingStatementWrapper stmt ->
                 // If we need to force refresh then we want to set quantity on hand for all
                 // matching records to 0.
@@ -209,8 +211,10 @@ class ProductAvailabilityService {
         } catch (Exception e) {
             log.error("Error executing batch update for ${location.name}: " + e.message, e)
             publishEvent(new ApplicationExceptionEvent(e, location))
-            throw e;
+            return false
         }
+
+        return true
     }
 
     String generateInsertStatement(Location location, Map entry) {
@@ -261,62 +265,6 @@ class ProductAvailabilityService {
         }
 
         return binLocationsTransformed
-    }
-
-    def deleteProductAvailability() {
-        deleteProductAvailability(null, null)
-    }
-
-    def deleteProductAvailability(Location location) {
-        deleteProductAvailability(location, null)
-    }
-
-    def deleteProductAvailability(Location location, Product product) {
-        Map params = [:]
-
-        String deleteStmt = """delete from ProductAvailability pa where 1=1"""
-
-        if (location) {
-            deleteStmt += " and pa.location = :location"
-            params.put("location", location)
-        }
-
-        if (product) {
-            deleteStmt += " and pa.product = :product"
-            params.put("product", product)
-        }
-
-        def results = ProductAvailability.executeUpdate(deleteStmt, params)
-        log.info "Deleted ${results} records for location ${location}, product ${product}"
-    }
-
-    def refreshInventorySnapshot(Location location, Product product, Boolean forceRefresh) {
-        String productId = product ? "'${product?.id}'" : null
-        if (forceRefresh) {
-            String forceRefreshStatement = """
-                DELETE FROM inventory_snapshot 
-                WHERE date = DATE_ADD(CURDATE(),INTERVAL 1 DAY)
-                AND location_id = '${location.id}' 
-                AND product_id = IFNULL(${productId}, product_id);
-            """
-            dataService.executeStatement(forceRefreshStatement)
-        }
-        String updateStatement = """
-            REPLACE INTO inventory_snapshot 
-            (
-                id, version, date, location_id, product_id, product_code, 
-                inventory_item_id, lot_number, bin_location_id, bin_location_name, 
-                quantity_on_hand, date_created, last_updated
-            ) 
-            SELECT 
-                id, version, DATE_ADD(CURDATE(),INTERVAL 1 DAY), location_id, product_id, product_code, 
-                inventory_item_id, lot_number, bin_location_id, bin_location_name,
-                quantity_on_hand, date_created, last_updated 
-            FROM product_availability 
-            WHERE location_id = '${location.id}' 
-            AND product_id = IFNULL(${productId}, product_id);
-        """
-        dataService.executeStatement(updateStatement)
     }
 
     def getQuantityOnHand(Location location) {


### PR DESCRIPTION
I figured it was easier to talk about this head-scratcher over a PR.

Current `saveProductAvailability` behavior is to log and then re-raise the exception, which can cause the GPars worker running it to crash. Since the blast radius for this issue is fairly small, for debugging purposes I made `saveProductAvailability` return a boolean if it succeeded, then call log.info() if it works, or log.error() if it doesn't. What I really want to know is what the other GPars threads are doing, but they stop logging after the deadlock exception is raised.

Not sure what the "right" behavior here is. Is `saveProductAvailability()` idempotent? If so, we could retry it (perhaps after an incremental delay) since the deadlock conditions likely pass a few seconds after the error is raised. Or we could resolve the root of the issue, but I think that'll need cleaner logging.