### PR TITLE
OBPIH-5344 Fix deleting stock requests from React side

### DIFF
--- a/grails-app/domain/org/pih/warehouse/inventory/OutboundStockMovement.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/OutboundStockMovement.groovy
@@ -224,8 +224,12 @@ class OutboundStockMovement implements Serializable {
         boolean isDestination = destination?.id == currentLocation.id
         boolean canOriginManageInventory = origin?.supports(ActivityCode.MANAGE_INVENTORY)
         boolean isCentralPurchasingEnabled = currentLocation?.supports(ActivityCode.ENABLE_CENTRAL_PURCHASING)
-
-        return ((canOriginManageInventory && isOrigin) || (!canOriginManageInventory && isDestination) || (isCentralPurchasingEnabled && isFromOrder))
+        return (
+                (canOriginManageInventory && isOrigin) ||
+                (!canOriginManageInventory && isDestination) ||
+                (isCentralPurchasingEnabled && isFromOrder) ||
+                (isDestination && electronicType)
+        )
     }
 
     Boolean isEditAuthorized(Location currentLocation) {


### PR DESCRIPTION
The line I added is `231`. The problem was twice fixed - once by me a long time ago: [PR](https://github.com/openboxes/openboxes/pull/3537) and then half of it was cherry-picked by Dariusz for some other hotfix: [PR](https://github.com/openboxes/openboxes/pull/3630).
Why it was working on the hotfix branch and it is not working here, is that on the `release/0.8.19-hotfix2` version of the `def delete` for the `StockMovementApiController` was not the version that @awalkowiak has refactored (28 of September) and that is currently both on develop and `release/0.8.21`, but it was like that:
```
def delete = {
     stockMovementService.deleteStockMovement(params.id)
     render status: 204
}
```
So we were using `stockMovementService` for all cases and we were calling the `StockMovement` class for `isDeleteAuthorized` (where the case for the stock request was covered), not the `OutboundStockMovement` like we are doing now, where this case for request was not covered.
It was not working not only for wards, but also for regular stock request creation and clicking `Cancel request` from Add items page. I will report it to Katarzyna to add a test case for that, because we also don't have this "Cancel request" button on develop yet, as it was added only to a 0.8.19 hotfix branch.

This accident just confirms that we should come up with some idea how to deal with hotfixing and bringing it then to develop, because again we had some differences between hotfix and release/develop branch.

cc @jmiranda @drodzewicz @alannadolny 
