### PR TITLE
OBS-1385 Update c3p0; resolve gpars dependency conflict; add default Quartz config

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -67,10 +67,10 @@ grails.project.dependency.resolution = {
         runtime "org.slf4j:jul-to-slf4j:1.7.33"
 
         // Required by database connection
-        compile 'mysql:mysql-connector-java:5.1.47'
+        compile 'mysql:mysql-connector-java:5.1.49'
 
         // Required by database connection pool
-        compile 'com.mchange:c3p0:0.9.5.3'
+        compile 'com.mchange:c3p0:0.9.5.5'
 
         // Required by docx4j functionality
         compile('org.docx4j:docx4j:2.8.1') {
@@ -131,10 +131,15 @@ grails.project.dependency.resolution = {
          */
         test("com.icegreen:greenmail:1.5.10") { excludes "junit" }
 
-        // Required for GPars
+        build 'org.codehaus.gpars:gpars:0.12'  // otherwise early build chain uses 0.9
         compile "org.codehaus.gpars:gpars:0.12"
+        // Required for GPars
         compile "org.codehaus.jsr166-mirror:jsr166y:1.7.0"
         compile "org.codehaus.jsr166-mirror:extra166y:1.7.0"
+
+        compile('org.quartz-scheduler:quartz:2.1.6') {
+            exclude 'c3p0'  // otherwise Quartz pulls in an ancient release from 2007
+        }
 
         // Unknown
         build('org.jboss.tattletale:tattletale-ant:1.2.0.Beta2') { excludes "ant", "javassist" }


### PR DESCRIPTION
This PR resolves a few issues I found while testing OBS-1360 Ansible deployments.

config-wise, I reduced the number of Quartz threads and "niced" them to prevent thrashing the CPU when a bunch of jobs kick off.

build-wise, the following nits are resolved:

- `gant` now uses the same `GPars` release across all build phases,
- We had duplicate symbols between a 15-year-old release and a 5-year-old one. `c3p0` was renamed in 2007 (`c3p0:c3p0` -> `com.mchange:c3p0`) and one of our old dependencies was pulling in the old version. At least once I saw Grails come up using the 2007 version, although I think the runtime dependency resolution was more or less arbitrary.

(See also #3810.)