### PR TITLE
OBS-1385 Improve Quartz configuration and dependency management under Grails 3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -295,7 +295,6 @@ configurations {
             force 'org.checkerframework:checker-qual:3.12.0'  // use consistent version
             force 'org.dom4j:dom4j:2.1.3'  // security patch
             force 'org.objenesis:objenesis:2.1'  // openjdk support
-            force 'org.quartz-scheduler:quartz:2.3.2'  // security patch
         }
     }
 }
@@ -627,10 +626,9 @@ dependencies {
     // use a release optimized for Grails 3.3.x for this `excel-import` sub-dependency
     implementation 'org.grails.plugins:joda-time:2.1.0'
 
-    // enable `import org.quartz.*`
+    // enable `import grails.plugins.quartz.Job*`
     compile('org.grails.plugins:quartz:2.0.13') {
-        exclude group: 'com.mchange'
-        exclude group: 'com.zaxxer'
+        transitive = false  // we pull in quartz-scheduler directly, below
     }
 
     // list all scheduled jobs at e.g. http://localhost:8080/openboxes/quartz
@@ -677,6 +675,17 @@ dependencies {
 
     // strict dependency of database-migration plugin; see gradle.properties
     compile "org.liquibase:liquibase-core:${liquibaseVersion}"
+
+    // enable `import org.quartz.*`
+    compile('org.quartz-scheduler:quartz:2.3.2') {
+        /*
+         * We currently use tomcat-jdbc, but Quartz pulls in these two
+         * alternative pooling libraries. If we see connection issues
+         * in Grails 3, we may want to switch to one of these.
+         */
+        exclude group: 'com.mchange'
+        exclude group: 'com.zaxxer'
+    }
 
     testRuntime "org.seleniumhq.selenium:htmlunit-driver:${htmlUnitVersion}"
 


### PR DESCRIPTION
This PR resolves a few issues I found while testing OBS-1360 Ansible deployments.

config-wise, I reduced the number of Quartz threads and "niced" them to prevent thrashing the CPU when a bunch of jobs kick off.

build-wise, I cleaned up the way we pull in Quartz dependencies and added a clarifying comment to our future selves should we see connection-pooling problems in Grails 3. (See also #3809.)