### PR TITLE
OBS-1373 Improve GPars logging and exception handling.

### DIFF
--- a/grails-app/jobs/org/pih/warehouse/jobs/SendStockAlertsJob.groovy
+++ b/grails-app/jobs/org/pih/warehouse/jobs/SendStockAlertsJob.groovy
@@ -9,7 +9,7 @@
  **/
 package org.pih.warehouse.jobs
 
-import groovyx.gpars.GParsPool
+import org.codehaus.groovy.grails.commons.ConfigurationHolder
 import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.RoleType
@@ -20,6 +20,7 @@ import org.quartz.JobExecutionContext
 class SendStockAlertsJob {
 
     def concurrent = false  // make `static` in Grails 3
+    def gparsService
     def locationService
     def notificationService
 
@@ -36,7 +37,7 @@ class SendStockAlertsJob {
         if (JobUtils.shouldExecute(SendStockAlertsJob)) {
             def startTime = System.currentTimeMillis()
             log.info("Send stock alerts: " + context.mergedJobDataMap)
-            GParsPool.withPool {
+            gparsService.withPool('SendStockAlerts') {
                 def depotLocations = locationService.getDepots()
                 depotLocations.eachParallel { Location location ->
                     if (location.active && location.supports(ActivityCode.ENABLE_NOTIFICATIONS)) {

--- a/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
@@ -11,7 +11,6 @@ package org.pih.warehouse.inventory
 
 import grails.orm.PagedResultList
 import grails.validation.ValidationException
-import groovyx.gpars.GParsPool
 import org.apache.commons.lang.StringUtils
 import org.hibernate.criterion.CriteriaSpecification
 import org.joda.time.LocalDate
@@ -47,7 +46,7 @@ class InventoryService implements ApplicationContextAware {
     def grailsApplication
 
     def dataService
-    def productService
+    def gparsService
     def identifierService
     def messageService
     def locationService
@@ -766,7 +765,7 @@ class InventoryService implements ApplicationContextAware {
         def startTime = System.currentTimeMillis()
         List binLocations
         def products = getProductsWithTransactions(location)
-        GParsPool.withPool(8) {
+        gparsService.withPool('QuantityByBinLocation', 8) {
             log.info "Processing ${products.size()} products"
             binLocations = products.collectParallel { product ->
                 persistenceInterceptor.init()

--- a/grails-app/services/org/pih/warehouse/inventory/InventorySnapshotService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventorySnapshotService.groovy
@@ -11,7 +11,6 @@ package org.pih.warehouse.inventory
 
 import groovy.sql.BatchingStatementWrapper
 import groovy.sql.Sql
-import groovyx.gpars.GParsPool
 import org.apache.commons.lang.StringEscapeUtils
 import org.codehaus.groovy.grails.commons.ConfigurationHolder
 import org.pih.warehouse.core.ApplicationExceptionEvent
@@ -32,6 +31,7 @@ class InventorySnapshotService {
     boolean transactional = true
 
     def dataSource
+    def gparsService
     def locationService
     def productAvailabilityService
     def persistenceInterceptor
@@ -46,7 +46,7 @@ class InventorySnapshotService {
 
         // Compute bin locations from transaction entries for given location and date
         // Uses GPars to improve performance
-        GParsPool.withPool {
+        gparsService.withPool('PopulateInventorySnapshots') {
             def depotLocations = locationService.getDepots()
             results = depotLocations.collectParallel { Location loc ->
                 def binLocations

--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -12,7 +12,6 @@ package org.pih.warehouse.inventory
 import grails.orm.PagedResultList
 import groovy.sql.BatchingStatementWrapper
 import groovy.sql.Sql
-import groovyx.gpars.GParsPool
 import org.apache.commons.lang.StringEscapeUtils
 import org.codehaus.groovy.grails.commons.ConfigurationHolder
 import org.hibernate.Criteria
@@ -35,6 +34,7 @@ class ProductAvailabilityService {
     boolean transactional = true
 
     def dataSource
+    def gparsService
     def grailsApplication
     def persistenceInterceptor
     def locationService
@@ -82,7 +82,7 @@ class ProductAvailabilityService {
         // Compute bin locations from transaction entries for all products over all depot locations
         // Uses GPars to improve performance (OBNAV Benchmark: 5 minutes without, 45 seconds with)
         def startTime = System.currentTimeMillis()
-        GParsPool.withPool {
+        gparsService.withPool('RefreshAllProducts') {
             locationService.depots.eachParallel { Location loc ->
                 persistenceInterceptor.init()
                 Location location = Location.get(loc.id)
@@ -98,7 +98,7 @@ class ProductAvailabilityService {
         // Compute bin locations from transaction entries for specific product over all depot locations
         // Uses GPars to improve performance (OBNAV Benchmark: 5 minutes without, 45 seconds with)
         def startTime = System.currentTimeMillis()
-        GParsPool.withPool {
+        gparsService.withPool('RefreshSingleProduct') {
             locationService.depots.eachParallel { Location loc ->
                 persistenceInterceptor.init()
                 Location location = Location.get(loc.id)

--- a/grails-app/services/org/pih/warehouse/jobs/GparsService.groovy
+++ b/grails-app/services/org/pih/warehouse/jobs/GparsService.groovy
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2023 Partners In Health.  All rights reserved.
+ * The use and distribution terms for this software are covered by the
+ * Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+ * which can be found in the file epl-v10.html at the root of this distribution.
+ * By using this software in any fashion, you are agreeing to be bound by
+ * the terms of this license.
+ * You must not remove this notice, or any other, from this software.
+ */
+package org.pih.warehouse.jobs
+
+import groovyx.gpars.GParsPool
+import groovyx.gpars.util.PoolUtils
+import jsr166y.ForkJoinPool
+import jsr166y.ForkJoinWorkerThread
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import java.lang.Thread.UncaughtExceptionHandler
+import java.util.concurrent.TimeUnit
+
+/**
+ * A thin service that wraps GPars to improve logging and exception handling.
+ *
+ * gparsService.withPool() behaves just like GParsPool.withPool(),
+ * with the following modifications:
+ *
+ * (a) it assigns names to pool workers to clarify log messages,
+ * (b) it logs uncaught exceptions instead of printing them.
+ *
+ * Cf. https://github.com/GPars/GPars/blob/release-0.12/src/main/groovy/groovyx/gpars/GParsPool.groovy
+ */
+class GparsService {
+
+    private static final Logger log = LoggerFactory.getLogger(GparsService)
+
+    /**
+     * Factory that creates named threads for use by GPars.
+     */
+    private static class GParsForkJoinWorkerThreadFactory implements ForkJoinPool.ForkJoinWorkerThreadFactory {
+
+        private static int indexCounter = 0
+
+        private final String poolName
+        private final int poolIndex
+
+        GParsForkJoinWorkerThreadFactory(String poolName = null) {
+            this.poolIndex = indexCounter++
+            this.poolName = poolName ?: 'OpenBoxes'
+        }
+
+        @Override
+        ForkJoinWorkerThread newThread(ForkJoinPool pool) {
+            ForkJoinWorkerThread worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool)
+            worker.name = "${poolName}GParsPool_Worker-${poolIndex}.${worker.poolIndex}"
+            return worker
+        }
+    }
+
+    /**
+     * Create threads for use by GPars; the poolName field makes logs clearer.
+     */
+    private static ForkJoinPool.ForkJoinWorkerThreadFactory createForkJoinWorkerThreadFactoryForPool(String poolName) {
+        return new GParsForkJoinWorkerThreadFactory(poolName)
+    }
+
+    /**
+     * Log any uncaught exceptions from pool workers.
+     *
+     * GPars 0.12 prints them to stdout, which is invisible to Sentry.
+     */
+    private static class LogEveryUncaughtExceptionHandler implements UncaughtExceptionHandler {
+
+        @Override
+        void uncaughtException(Thread failedThread, Throwable throwable) {
+            log.error("GPars thread ${failedThread.name} threw ${throwable.message}", throwable)
+        }
+    }
+
+    /**
+     * Create a named pool for GPars with `poolSize` workers.
+     *
+     * GPars 0.12's implementation (q.v.) defaults to one more than the
+     * core count, which is high for a host that also runs a database.
+     */
+    private static ForkJoinPool createPool(String poolName, int poolSize) {
+        log.info("creating new pool '${poolName}' of size ${poolSize}")
+        return new ForkJoinPool(
+            poolSize,
+            createForkJoinWorkerThreadFactoryForPool(poolName),
+            new LogEveryUncaughtExceptionHandler(),
+            false
+        )
+    }
+
+    /**
+     * Create a pool, run a closure within it and wait for it to finish.
+     *
+     * Behaves like GParsPool.withPool().
+     */
+    static withPool(String poolName, int poolSize, Closure cl) {
+        ForkJoinPool pool = createPool(poolName, poolSize)
+        try {
+            return GParsPool.withExistingPool(pool, cl)
+        } finally {
+            log.info("draining pool '${poolName}' of size ${poolSize}")
+            pool.shutdown()
+            pool.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS)
+            log.debug("finished draining pool '${poolName}'")
+        }
+    }
+
+    /**
+     * Create a pool, run a closure within it and wait for it to finish.
+     *
+     * Behaves like GParsPool.withPool().
+     */
+    static withPool(String poolName, Closure cl) {
+        return withPool(poolName, PoolUtils.retrieveDefaultPoolSize(), cl)
+    }
+}


### PR DESCRIPTION
This PR, along with #3809 and #3810, splits #3785 into more focused chunks. #3809 and #3810 make changes to dependencies and config. This PR fixes some logging issues:

- Replace `GParsPool.withPool()` with `gparsService.withPool('informative name')`
- GPars workers now log their parent pool to indicate who brought them into being, and how many siblings they have
- uncaught exceptions get properly logged instead of `println`'ed, which means Sentry and New Relic can see them
