### PR TITLE
OBS-1253 Don't run Quartz jobs during DB migrations; consistently disable concurrent job execution

### DIFF
--- a/grails-app/jobs/org/pih/warehouse/jobs/AssignIdentifierJob.groovy
+++ b/grails-app/jobs/org/pih/warehouse/jobs/AssignIdentifierJob.groovy
@@ -1,28 +1,20 @@
 package org.pih.warehouse.jobs
 
-import org.codehaus.groovy.grails.commons.ConfigurationHolder as CH
 import org.quartz.DisallowConcurrentExecution
-import util.LiquibaseUtil
 
 @DisallowConcurrentExecution
 class AssignIdentifierJob {
 
     def identifierService
 
+    def concurrent = false  // make `static` in Grails 3
     static triggers = {
-        cron name: 'assignIdentifierCronTrigger',
-                cronExpression: CH.config.openboxes.jobs.assignIdentifierJob.cronExpression
+        cron name: JobUtils.getCronName(AssignIdentifierJob),
+            cronExpression: JobUtils.getCronExpression(AssignIdentifierJob)
     }
 
     def execute() {
-
-        Boolean enabled = CH.config.openboxes.jobs.assignIdentifierJob.enabled
-        if (!enabled) {
-            return
-        }
-
-        if (LiquibaseUtil.isRunningMigrations()) {
-            log.info "Postponing job execution until liquibase migrations are complete"
+        if (!JobUtils.shouldExecute(AssignIdentifierJob)) {
             return
         }
 
@@ -33,6 +25,4 @@ class AssignIdentifierJob {
         identifierService.assignRequisitionIdentifiers()
         identifierService.assignTransactionIdentifiers()
     }
-
-
 }

--- a/grails-app/jobs/org/pih/warehouse/jobs/DataMigrationJob.groovy
+++ b/grails-app/jobs/org/pih/warehouse/jobs/DataMigrationJob.groovy
@@ -1,31 +1,20 @@
 package org.pih.warehouse.jobs
 
-import org.codehaus.groovy.grails.commons.ConfigurationHolder as ConfigHolder
 import org.quartz.DisallowConcurrentExecution
-import util.LiquibaseUtil
 
 @DisallowConcurrentExecution
 class DataMigrationJob {
 
+    def concurrent = false  // make `static` in Grails 3
     def migrationService
-
     static triggers = {}
 
-    def execute(context) {
-
-        if (ConfigHolder.config.openboxes.jobs.dataMigrationJob.enabled ?: false) {
-
-            if (LiquibaseUtil.isRunningMigrations()) {
-                log.info "Postponing job execution until liquibase migrations are complete"
-                return
-            }
-
+    def execute() {
+        if (JobUtils.shouldExecute(DataMigrationJob)) {
             log.info "Starting data migration job at ${new Date()}"
             def startTime = System.currentTimeMillis()
             migrationService.migrateInventoryTransactions()
             log.info "Finished data migration job in " + (System.currentTimeMillis() - startTime) + " ms"
         }
     }
-
-
 }

--- a/grails-app/jobs/org/pih/warehouse/jobs/JobUtils.groovy
+++ b/grails-app/jobs/org/pih/warehouse/jobs/JobUtils.groovy
@@ -1,0 +1,39 @@
+package org.pih.warehouse.jobs
+
+import org.apache.commons.lang.WordUtils
+
+// replace the following with grails.util.Holders in Grails 3
+import org.codehaus.groovy.grails.commons.ConfigurationHolder
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import util.LiquibaseUtil
+
+class JobUtils {
+
+    private static final transient Logger log = LoggerFactory.getLogger(JobUtils)
+
+    private static String getKey(Class clazz) {
+        return WordUtils.uncapitalize(clazz.simpleName)
+    }
+
+    /** Return true if the given job class can run safely at the present time. */
+    static boolean shouldExecute(Class clazz) {
+        if (!ConfigurationHolder.flatConfig["openboxes.jobs.${getKey(clazz)}.enabled"]) {
+            return false
+        }
+        if (LiquibaseUtil.isRunningMigrations()) {
+            log.info "Postponing job execution for ${getKey(clazz)} until liquibase migrations are complete"
+            return false
+        }
+        return true
+    }
+
+    static String getCronName(Class clazz) {
+        return "${getKey(clazz)}CronTrigger"
+    }
+
+    static String getCronExpression(Class clazz) {
+        return ConfigurationHolder.flatConfig["openboxes.jobs.${getKey(clazz)}.cronExpression"]
+    }
+}

--- a/grails-app/jobs/org/pih/warehouse/jobs/RefreshDemandDataJob.groovy
+++ b/grails-app/jobs/org/pih/warehouse/jobs/RefreshDemandDataJob.groovy
@@ -1,22 +1,21 @@
 package org.pih.warehouse.jobs
 
-import org.codehaus.groovy.grails.commons.ConfigurationHolder
 import org.quartz.DisallowConcurrentExecution
 import org.quartz.JobExecutionContext
 
 @DisallowConcurrentExecution
 class RefreshDemandDataJob {
 
+    def concurrent = false  // make `static` in Grails 3
     def reportService
 
     static triggers = {
-        cron name: 'refreshDemandDataJobCronTrigger',
-                cronExpression: ConfigurationHolder.config.openboxes.jobs.refreshDemandDataJob.cronExpression
+        cron name: JobUtils.getCronName(RefreshDemandDataJob),
+            cronExpression: JobUtils.getCronExpression(RefreshDemandDataJob)
     }
 
     def execute(JobExecutionContext context) {
-        Boolean enabled = ConfigurationHolder.config.openboxes.jobs.refreshDemandDataJob.enabled
-        if (enabled) {
+        if (JobUtils.shouldExecute(RefreshDemandDataJob)) {
             def startTime = System.currentTimeMillis()
             log.info("Refreshing demand data: " + context.mergedJobDataMap)
             reportService.refreshProductDemandData()

--- a/grails-app/jobs/org/pih/warehouse/jobs/RefreshInventorySnapshotJob.groovy
+++ b/grails-app/jobs/org/pih/warehouse/jobs/RefreshInventorySnapshotJob.groovy
@@ -9,17 +9,15 @@
  **/
 package org.pih.warehouse.jobs
 
-import org.codehaus.groovy.grails.commons.ConfigurationHolder
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.product.Product
 import org.quartz.DisallowConcurrentExecution
 import org.quartz.JobExecutionContext
-import org.quartz.JobExecutionException
 
 @DisallowConcurrentExecution
 class RefreshInventorySnapshotJob {
 
-    def concurrent = false
+    def concurrent = false  // make `static` in Grails 3
     def inventorySnapshotService
 
     // Should never be triggered on a schedule - should only be triggered by persistence event listener
@@ -27,16 +25,13 @@ class RefreshInventorySnapshotJob {
 
     def execute(JobExecutionContext context) {
 
-        Boolean enabled = ConfigurationHolder.config.openboxes.jobs.refreshInventorySnapshotJob.enabled
-        log.info("Refreshing inventory snapshots with data (enabled=${enabled}): " + context.mergedJobDataMap)
-        if (enabled) {
-
+        if (JobUtils.shouldExecute(RefreshInventorySnapshotJob)) {
+            log.info("Refreshing inventory snapshots with data: ${context.mergedJobDataMap}")
             def startTime = System.currentTimeMillis()
             def userId = context.mergedJobDataMap.get('user')
             def date = context.mergedJobDataMap.get('date')
             def locationId = context.mergedJobDataMap.get('locationId')
             def productId = context.mergedJobDataMap.get('productId')
-            boolean forceRefresh = context.mergedJobDataMap.getBoolean("forceRefresh")
             try {
                 Product product = Product.load(productId)
                 Location location = Location.load(locationId)

--- a/grails-app/jobs/org/pih/warehouse/jobs/RefreshProductAvailabilityJob.groovy
+++ b/grails-app/jobs/org/pih/warehouse/jobs/RefreshProductAvailabilityJob.groovy
@@ -9,22 +9,18 @@
  **/
 package org.pih.warehouse.jobs
 
-import org.codehaus.groovy.grails.commons.ConfigurationHolder
-import org.quartz.DisallowConcurrentExecution
 import org.quartz.JobExecutionContext
 
-//@DisallowConcurrentExecution
 class RefreshProductAvailabilityJob {
 
-    //def concurrent = false
+    def concurrent = true  // make `static` in Grails 3
     def productAvailabilityService
 
     // Should never be triggered on a schedule - should only be triggered by persistence event listener
     static triggers = {}
 
     def execute(JobExecutionContext context) {
-        Boolean enabled = ConfigurationHolder.config.openboxes.jobs.refreshProductAvailabilityJob.enabled
-        if (enabled) {
+        if (JobUtils.shouldExecute(RefreshProductAvailabilityJob)) {
             def startTime = System.currentTimeMillis()
             log.info("Refreshing product availability data: " + context.mergedJobDataMap)
             boolean forceRefresh = context.mergedJobDataMap.getBoolean("forceRefresh")?:false

--- a/grails-app/jobs/org/pih/warehouse/jobs/RefreshStockoutDataJob.groovy
+++ b/grails-app/jobs/org/pih/warehouse/jobs/RefreshStockoutDataJob.groovy
@@ -1,26 +1,24 @@
 package org.pih.warehouse.jobs
 
-import org.codehaus.groovy.grails.commons.ConfigurationHolder
 import org.quartz.DisallowConcurrentExecution
 import org.quartz.JobExecutionContext
 
 @DisallowConcurrentExecution
 class RefreshStockoutDataJob {
 
-    def grailsApplication
+    def concurrent = false  // make `static` in Grails 3
     def reportService
 
     static triggers = {
-        cron name: 'refreshProductStockoutDataJobCronTrigger',
-                cronExpression: ConfigurationHolder.config.openboxes.jobs.refreshStockoutDataJob.cronExpression
+        cron name: JobUtils.getCronName(RefreshStockoutDataJob),
+            cronExpression: JobUtils.getCronExpression(RefreshStockoutDataJob)
     }
 
     def execute(JobExecutionContext context) {
-        Boolean enabled = grailsApplication.config.openboxes.jobs.refreshStockoutDataJob.enabled
-        if (enabled) {
+        if (JobUtils.shouldExecute(RefreshStockoutDataJob)) {
             def startTime = System.currentTimeMillis()
             log.info("Refreshing stockout data: " + context.mergedJobDataMap)
-            Date yesterday = new Date()-1
+            Date yesterday = new Date() - 1
             reportService.buildStockoutFact(yesterday)
             log.info "Refreshed stockout data in " + (System.currentTimeMillis() - startTime) + " ms"
         }

--- a/grails-app/jobs/org/pih/warehouse/jobs/UpdateExchangeRatesJob.groovy
+++ b/grails-app/jobs/org/pih/warehouse/jobs/UpdateExchangeRatesJob.groovy
@@ -1,39 +1,24 @@
 package org.pih.warehouse.jobs
 
-import org.codehaus.groovy.grails.commons.ConfigurationHolder
-import org.codehaus.groovy.grails.commons.ConfigurationHolder as ConfigHolder
 import org.quartz.DisallowConcurrentExecution
-import org.quartz.JobExecutionContext
-import util.LiquibaseUtil
 
 @DisallowConcurrentExecution
 class UpdateExchangeRatesJob {
 
-    def concurrent = false
+    def concurrent = false  // make `static` in Grails 3
     def currencyService
 
-    // cron job needs to be triggered after the staging deployment
     static triggers = {
-        cron name: 'updateExchangeRatesCronTrigger',
-                cronExpression: ConfigurationHolder.config.openboxes.jobs.updateExchangeRatesJob.cronExpression
+        cron name: JobUtils.getCronName(UpdateExchangeRatesJob),
+            cronExpression: JobUtils.getCronExpression(UpdateExchangeRatesJob)
     }
 
-    def execute(JobExecutionContext context) {
-
-        Boolean enabled = ConfigHolder.config.openboxes.jobs.updateExchangeRatesJob.enabled ?: false
-        if (enabled) {
-
-            if (LiquibaseUtil.isRunningMigrations()) {
-                log.info "Postponing job execution until liquibase migrations are complete"
-                return
-            }
-
+    def execute() {
+        if (JobUtils.shouldExecute(UpdateExchangeRatesJob)) {
             log.info "Starting job at ${new Date()}"
             def startTime = System.currentTimeMillis()
             currencyService.updateExchangeRates()
             log.info "Finished running job in " + (System.currentTimeMillis() - startTime) + " ms"
         }
     }
-
-
 }


### PR DESCRIPTION
This one is from the icebox, but since I was dinking around with Quartz config last week I figured I'd bring it back to life for a tech huddle.

- some Quartz jobs have a `@DisallowConcurrentExecution` annotation;
- some declare `def concurrent = false`;
- some check whether a migration is happening before running;
- each one of the above is not done by at least one job :-( .

This PR makes all Quartz jobs perform all 3 checks and consolidates common code in a new JobsUtil class. (I also added comments to ease Grails 1/3 rebases going forward.)

I'm not sure whether the 0.8.19 deploy was actually affected by this; the migrations there took longer than they have on any other push so the window for error was wider -- but I think these bugs should be fixed even if they haven't bitten us in the last week or two. Let me know what y'all think.