### PR TITLE
OBPIH-5315 Display product name translation on stock card header and in the global search

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/JsonController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/JsonController.groovy
@@ -1079,8 +1079,10 @@ class JsonController {
                     type : product.class,
                     url  : request.contextPath + "/" + type + "/redirect/" + product.id,
                     value: product.name,
-                    label: product.productCode + " " + product.name + " " + quantity,
-                    color: product.color
+                    label: product.productCode + " " + (product.translatedName ?: product.name) + " " + quantity,
+                    color: product.color,
+                    // Do not remove double negation even if IDE recommends this - we want to convert string/null to boolean
+                    hasTranslatedName: !!product.translatedName
             ]
         }
         render json.findAll { it != null } as JSON

--- a/grails-app/domain/org/pih/warehouse/product/Product.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/Product.groovy
@@ -18,6 +18,7 @@ import org.pih.warehouse.core.Document
 import org.pih.warehouse.core.GlAccount
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.Synonym
+import org.pih.warehouse.core.SynonymTypeCode
 import org.pih.warehouse.core.Tag
 import org.pih.warehouse.core.UnitOfMeasure
 import org.pih.warehouse.core.User
@@ -28,6 +29,7 @@ import org.pih.warehouse.inventory.InventorySnapshotEvent
 import org.pih.warehouse.inventory.TransactionCode
 import org.pih.warehouse.inventory.TransactionEntry
 import org.pih.warehouse.shipping.ShipmentItem
+import org.pih.warehouse.util.LocalizationUtil
 
 /**
  * An product is an instance of a generic.  For instance,
@@ -241,7 +243,8 @@ class Product implements Comparable, Serializable {
                          "substitutions",
                          "applicationTagLib",
                          "handlingIcons",
-                         "uoms"
+                         "uoms",
+                         "translatedName"
     ]
 
     static hasMany = [
@@ -675,6 +678,14 @@ class Product implements Comparable, Serializable {
 
     List getUoms() {
        return packages.collect { [uom: it.uom.code, quantity: it.quantity] }.unique()
+    }
+
+    String getTranslatedName() {
+        Locale currentLocale = LocalizationUtil.localizationService.getCurrentLocale()
+        Synonym synonym = synonyms.find { Synonym synonym ->
+            synonym.synonymTypeCode == SynonymTypeCode.DISPLAY_NAME && synonym.locale == currentLocale
+        }
+        return synonym?.name
     }
 
     Map toJson() {

--- a/grails-app/views/product/_summary.gsp
+++ b/grails-app/views/product/_summary.gsp
@@ -26,7 +26,9 @@
 			            <div id="product-title" class="title">
 			            	<small class="font-weight-bold">${productInstance?.productCode }</small>
 			            	<g:link controller="inventoryItem" action="showStockCard" params="['product.id': productInstance?.id]">
-			                	${productInstance?.name }
+								<span title="${productInstance?.translatedName ? productInstance.name : null}">
+									${productInstance?.translatedName ?: productInstance?.name }
+								</span>
 			                </g:link>
 			            </div>
                         <div id="product-catalogs">

--- a/grails-app/views/taglib/_globalSearch.gsp
+++ b/grails-app/views/taglib/_globalSearch.gsp
@@ -78,7 +78,10 @@
         .data("autocomplete")._renderItem = function (ul, item) {
         const { before, matched, after } = splitMatchingStr(item.label, $("#global-search-input").val());
         var link = $("<a></a>").css("color", item.color);
-
+        // If we display translated name, we want to have tooltip with original name of the product
+        if (item.hasTranslatedName) {
+          link.attr('title', item.value)
+        }
         if (before) link.append("<span>" + before + "</span>");
         if (matched) link.append("<strong class='font-weight-bold'>" + matched + "</strong>");
         if (after) link.append("<span>" + after + "</span>");

--- a/src/js/components/GlobalSearch/GlobalSearch.jsx
+++ b/src/js/components/GlobalSearch/GlobalSearch.jsx
@@ -5,6 +5,7 @@ import { RiCloseLine, RiSearchLine } from 'react-icons/ri';
 import { getTranslate } from 'react-localize-redux';
 import { connect } from 'react-redux';
 import { Async, components } from 'react-select';
+import { Tooltip } from 'react-tippy';
 
 import { debounceGlobalSearch } from 'utils/option-utils';
 import { translateWithDefaultMessage } from 'utils/Translate';
@@ -69,11 +70,18 @@ const GlobalSearch = ({
     const { before, matched, after } = splitMatchingStr(data.label, inputValue);
     return (
       <components.Option {...props}>
-        <div style={{ color: data.color }}>
-          {before && <span>{before}</span>}
-          {matched && <strong className="font-weight-bold">{matched}</strong>}
-          {after && <span>{after}</span>}
-        </div>
+        <Tooltip
+          html={<div className="custom-tooltip">{data.originalName}</div>}
+          theme="transparent"
+          disabled={!data?.hasTranslatedName}
+          position="top-start"
+        >
+          <div style={{ color: data.color }}>
+            {before && <span>{before}</span>}
+            {matched && <strong className="font-weight-bold">{matched}</strong>}
+            {after && <span>{after}</span>}
+          </div>
+        </Tooltip>
       </components.Option>
     );
   };

--- a/src/js/utils/option-utils.jsx
+++ b/src/js/utils/option-utils.jsx
@@ -62,6 +62,8 @@ export const debounceGlobalSearch = (waitTime, minSearchLength) =>
             url: obj.url,
             label: obj.label,
             color: obj.color,
+            hasTranslatedName: obj.hasTranslatedName,
+            originalName: obj.value,
           }
         ))))
         .catch(() => callback([]));


### PR DESCRIPTION
Added:

- separate getter for translated product name - I think it's a better approach instead of overriding the `name` getter, so that we have better control of that, especially that we don't cover the translations for all places at once
- if a synonym for user's current locale exists, we want to display it and have a tooltip with the original name of the product. If the synonym doesn't exist, we don't need to have the tooltip
- for now implemented only for stock card header and the global search, so that I do not block other tickets. The rest of cases for stock card (all the tabs and modals) will be covered in a separate, already existing ticket

What we might consider thinking about in the future (consulted with Manon) is that what to do if someone creates a product with e.g. Spanish name - so that the "original" name of the product is not in English.