### PR TITLE
OBPIH-5367 Add validation to prevent multiple display names per locale

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
@@ -1141,7 +1141,7 @@ class ProductController {
     def importProductSynonyms = { ImportDataCommand command ->
 
         log.info params
-        log.info command.location
+        log.info command?.location
 
         if (request.method == "POST") {
             File localFile = null
@@ -1167,12 +1167,13 @@ class ProductController {
             command.data = excelImporter.data
 
             command.errors = null
-            excelImporter.importData(command)
+            excelImporter.validateData(command)
 
             if (command.errors.allErrors) {
                 flash.errors = command.errors
             } else {
                 flash.message = "Succesfully imported product synonyms"
+                excelImporter.importData(command)
             }
         }
 

--- a/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
@@ -1014,14 +1014,18 @@ class ProductController {
     def addSynonymToProduct = {
         println "addSynonymToProduct() " + params
         Product product = null
+        def inputValues = null
         try {
             product = productService.addSynonymToProduct(params.id, params.synonymTypeCode, params.synonym, params.locale)
         } catch (IllegalArgumentException e) {
             // If adding a synonym fails, we still want to return the product to the view
             product = Product.read(params.id)
+            // If a validation error occurs, we want to return those values to the view,
+            // and set them as initialValues of the form, so a user can correct him/herself
+            inputValues = params
             flash.error = e.message
         }
-        render(template: 'productSynonyms', model: [productInstance: product])
+        render(template: 'productSynonyms', model: [productInstance: product, inputValues: inputValues])
     }
 
     /**

--- a/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
@@ -1017,19 +1017,13 @@ class ProductController {
         def inputValues = null
         try {
             product = productService.addSynonymToProduct(params.id, params.synonymTypeCode, params.synonym, params.locale)
-        } catch (Exception e) {
+        } catch (ValidationException e) {
             // If adding a synonym fails, we still want to return the product to the view
             product = Product.read(params.id)
             // If a validation error occurs, we want to return those values to the view,
             // and set them as initialValues of the form, so a user can correct him/herself
             inputValues = params
-            flash.error = e.message
-            if (e instanceof ValidationException) {
-                // If the ValidationError occurs, we don't want to display it as a flash error,
-                // but render it as productInstance's errors using <g:renderErrors>
-                flash.error = null
-                product.errors = e.errors
-            }
+            product.errors = e.errors
         }
         render(template: 'productSynonyms', model: [productInstance: product, inputValues: inputValues])
     }

--- a/grails-app/domain/org/pih/warehouse/core/Synonym.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Synonym.groovy
@@ -49,7 +49,15 @@ class Synonym implements Serializable {
 
     static constraints = {
         name(nullable: false, maxSize: 255)
-        locale(nullable: true)
+        locale(nullable: true, validator: { val, obj ->
+            // Validate not to allow multiple DISPLAY_NAME for one locale
+            if (obj?.synonymTypeCode == SynonymTypeCode.DISPLAY_NAME) {
+                Set<Synonym> duplicates = obj?.product?.synonyms?.findAll { Synonym synonym ->
+                    synonym.locale == val && synonym.synonymTypeCode == SynonymTypeCode.DISPLAY_NAME
+                }
+                return duplicates.size() > 1 ? ["validator.multipleError"] : true
+            }
+        })
         synonymTypeCode(nullable: false)
         updatedBy(nullable: true)
         createdBy(nullable: true)

--- a/grails-app/domain/org/pih/warehouse/core/Synonym.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Synonym.groovy
@@ -48,8 +48,8 @@ class Synonym implements Serializable {
     }
 
     static constraints = {
-        name(nullable: false, maxSize: 255)
-        locale(nullable: true, validator: { val, obj ->
+        name(nullable: false, maxSize: 255, blank: false)
+        locale(nullable: false, validator: { val, obj ->
             // Validate not to allow multiple DISPLAY_NAME for one locale
             if (obj?.synonymTypeCode == SynonymTypeCode.DISPLAY_NAME) {
                 Set<Synonym> duplicates = obj?.product?.synonyms?.findAll { Synonym synonym ->

--- a/grails-app/domain/org/pih/warehouse/core/Synonym.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Synonym.groovy
@@ -55,7 +55,7 @@ class Synonym implements Serializable {
                 Set<Synonym> duplicates = obj?.product?.synonyms?.findAll { Synonym synonym ->
                     synonym.locale == val && synonym.synonymTypeCode == SynonymTypeCode.DISPLAY_NAME
                 }
-                return duplicates.size() > 1 ? ["validator.multipleError"] : true
+                return duplicates?.size() > 1 ? ["validator.multipleError"] : true
             }
         })
         synonymTypeCode(nullable: false)

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -2738,7 +2738,7 @@ synonym.typeSynonym.placeholder.label=Type the synonym here
 synonym.synonymTypeCode.placeholder.label=Select a classification
 synonym.selectLocale.placeholder.label=Select a locale
 synonym.productSynonyms.label=Product Synonyms
-synonym.validation.multipleSynonym.error.label=You cannot add multiple display names in the same language. Edit the existing synonym instead.
+synonym.locale.validator.multipleError=You cannot add multiple display names in the same language. Edit the existing synonym instead.
 
 # Supplier
 supplier.label=Supplier

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -2739,6 +2739,8 @@ synonym.synonymTypeCode.placeholder.label=Select a classification
 synonym.selectLocale.placeholder.label=Select a locale
 synonym.productSynonyms.label=Product Synonyms
 synonym.locale.validator.multipleError=You cannot add multiple display names in the same language. Edit the existing synonym instead.
+synonym.locale.nullable=You must provide a locale
+synonym.name.blank=Synonym can't be an empty string
 
 # Supplier
 supplier.label=Supplier

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -2738,6 +2738,7 @@ synonym.typeSynonym.placeholder.label=Type the synonym here
 synonym.synonymTypeCode.placeholder.label=Select a classification
 synonym.selectLocale.placeholder.label=Select a locale
 synonym.productSynonyms.label=Product Synonyms
+synonym.validation.multipleSynonym.error.label=For one locale the product can't have more than one synonym of type
 
 # Supplier
 supplier.label=Supplier

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -2738,7 +2738,7 @@ synonym.typeSynonym.placeholder.label=Type the synonym here
 synonym.synonymTypeCode.placeholder.label=Select a classification
 synonym.selectLocale.placeholder.label=Select a locale
 synonym.productSynonyms.label=Product Synonyms
-synonym.validation.multipleSynonym.error.label=For one locale the product can't have more than one synonym of type
+synonym.validation.multipleSynonym.error.label=You cannot add multiple display names in the same language. Edit the existing synonym instead.
 
 # Supplier
 supplier.label=Supplier

--- a/grails-app/services/org/pih/warehouse/data/ProductSynonymDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSynonymDataService.groovy
@@ -64,14 +64,12 @@ class ProductSynonymDataService {
 
             // Check if none error occures to be sure, that we have correct product, locale and synonymTypeCode
             // before we check the duplicates
-            if (!command.errors.allErrors) {
-               if (synonymTypeCode == SynonymTypeCode.DISPLAY_NAME) {
-                   Set<Synonym> duplicates = product?.synonyms?.findAll { Synonym synonym ->
-                       synonym.locale == new Locale(params['locale']) && synonym.synonymTypeCode == SynonymTypeCode.DISPLAY_NAME
-                   }
-                   if (duplicates) {
-                       command.errors.reject("Row ${index + 1}: You cannot add multiple display names in the same language. Edit the existing synonym instead.")
-                   }
+            if (!command.errors.allErrors && synonymTypeCode == SynonymTypeCode.DISPLAY_NAME) {
+               Set<Synonym> duplicates = product?.synonyms?.findAll { Synonym synonym ->
+                   synonym.locale == new Locale(params['locale']) && synonym.synonymTypeCode == SynonymTypeCode.DISPLAY_NAME
+               }
+               if (duplicates) {
+                   command.errors.reject("Row ${index + 1}: You cannot add multiple display names in the same language. Edit the existing synonym instead.")
                }
             }
 

--- a/grails-app/services/org/pih/warehouse/data/ProductSynonymDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSynonymDataService.groovy
@@ -68,7 +68,7 @@ class ProductSynonymDataService {
                         SynonymTypeCode.DISPLAY_NAME,
                         new Locale(params['locale']))
                 ) {
-                    command.errors.reject("Row ${index + 1}: ${g.message(code: 'synonym.validation.multipleSynonym.error.label')} ${SynonymTypeCode.DISPLAY_NAME}")
+                    command.errors.reject("Row ${index + 1}: ${g.message(code: 'synonym.validation.multipleSynonym.error.label')}")
                 }
             }
         }

--- a/grails-app/services/org/pih/warehouse/product/ProductService.groovy
+++ b/grails-app/services/org/pih/warehouse/product/ProductService.groovy
@@ -1390,29 +1390,7 @@ class ProductService {
         }
     }
 
-    Set<Synonym> getSynonymsOfTypeAndLocale(Set<Synonym> synonyms, SynonymTypeCode synonymTypeCode, Locale locale) {
-        return synonyms.findAll{ it.synonymTypeCode == synonymTypeCode && it.locale == locale }
-    }
-
-    /**
-     * Validation for having multiple synonyms of a given type code and a locale.
-     * @param synonyms
-     * @param synonymTypeCode
-     * @param typeCodeToValidate
-     * @param locale
-     * @return If a product already has a synonym of given type code to validate and we are trying to add a synonym with that type code,
-     * we want to return false. If the synonym passes the validation, we return true.
-     */
-    Boolean validateMultipleSynonymsOfType(Set<Synonym> synonyms, SynonymTypeCode synonymTypeCode, SynonymTypeCode typeCodeToValidate, Locale locale) {
-        Set<Synonym> synonymsOfTypeAndLocale = getSynonymsOfTypeAndLocale(synonyms, synonymTypeCode, locale)
-        if (synonymTypeCode == typeCodeToValidate && synonymsOfTypeAndLocale) {
-            return false
-        }
-        return true
-    }
-
     Product addSynonymToProduct(String productId, String synonymTypeCodeName, String synonymValue, String localeName) {
-        def g = grailsApplication.mainContext.getBean('org.codehaus.groovy.grails.plugins.web.taglib.ApplicationTagLib')
         Product product = Product.get(productId)
         if (!localeName) {
             throw new IllegalArgumentException("You must provide a locale")
@@ -1423,13 +1401,11 @@ class ProductService {
             throw new IllegalArgumentException("Synonym can't be an empty string")
         }
 
-        // Validation not to allow having more than one synonym of DISPLAY_NAME type for one locale
-        if (!validateMultipleSynonymsOfType(product.synonyms, synonymTypeCode, SynonymTypeCode.DISPLAY_NAME, locale)) {
-            throw new IllegalArgumentException("${g.message(code: 'synonym.validation.multipleSynonym.error.label')}")
-        }
         Synonym synonym = new Synonym(name: synonymValue, locale: locale, synonymTypeCode: synonymTypeCode)
         product.addToSynonyms(synonym)
-        product.save(flush: true, failOnError: true)
+        if (!synonym.validate() || !product.save(flush: true, failOnError: true)) {
+            throw new ValidationException("Invalid synonym", synonym.errors)
+        }
         return product
     }
 }

--- a/grails-app/services/org/pih/warehouse/product/ProductService.groovy
+++ b/grails-app/services/org/pih/warehouse/product/ProductService.groovy
@@ -1425,7 +1425,7 @@ class ProductService {
 
         // Validation not to allow having more than one synonym of DISPLAY_NAME type for one locale
         if (!validateMultipleSynonymsOfType(product.synonyms, synonymTypeCode, SynonymTypeCode.DISPLAY_NAME, locale)) {
-            throw new IllegalArgumentException("${g.message(code: 'synonym.validation.multipleSynonym.error.label')} ${SynonymTypeCode.DISPLAY_NAME}")
+            throw new IllegalArgumentException("${g.message(code: 'synonym.validation.multipleSynonym.error.label')}")
         }
         Synonym synonym = new Synonym(name: synonymValue, locale: locale, synonymTypeCode: synonymTypeCode)
         product.addToSynonyms(synonym)

--- a/grails-app/services/org/pih/warehouse/product/ProductService.groovy
+++ b/grails-app/services/org/pih/warehouse/product/ProductService.groovy
@@ -1392,15 +1392,8 @@ class ProductService {
 
     Product addSynonymToProduct(String productId, String synonymTypeCodeName, String synonymValue, String localeName) {
         Product product = Product.get(productId)
-        if (!localeName) {
-            throw new IllegalArgumentException("You must provide a locale")
-        }
-        Locale locale = new Locale(localeName)
+        Locale locale = localeName ? new Locale(localeName) : null
         SynonymTypeCode synonymTypeCode = synonymTypeCodeName ? SynonymTypeCode.valueOf(synonymTypeCodeName) : SynonymTypeCode.ALTERNATE_NAME
-        if (!synonymValue) {
-            throw new IllegalArgumentException("Synonym can't be an empty string")
-        }
-
         Synonym synonym = new Synonym(name: synonymValue, locale: locale, synonymTypeCode: synonymTypeCode)
         product.addToSynonyms(synonym)
         if (!synonym.validate() || !product.save(flush: true, failOnError: true)) {

--- a/grails-app/views/inventoryLevel/_form.gsp
+++ b/grails-app/views/inventoryLevel/_form.gsp
@@ -50,7 +50,7 @@
                                       from="${[productInstance]}"
                                       optionKey="id" value="${productInstance}" disabled="true"
                                       optionValue="${{it?.translatedName ?: it?.name}}"
-                                      title="${productInstance?.translatedName ? productInstance.name : null}"
+                                      title="${productInstance?.translatedName ? productInstance?.name : null}"
                             />
                         </g:else>
                     </td>

--- a/grails-app/views/product/_productSynonyms.gsp
+++ b/grails-app/views/product/_productSynonyms.gsp
@@ -1,6 +1,11 @@
 <%@ page import="org.pih.warehouse.core.SynonymTypeCode" %>
 <div id="synonyms">
     <div class="box">
+        <g:hasErrors bean="${productInstance}">
+            <div class="errors">
+                <g:renderErrors bean="${productInstance}" as="list"/>
+            </div>
+        </g:hasErrors>
         <g:if test="${flash.message}">
             <div class="message">${flash.message}</div>
         </g:if>

--- a/grails-app/views/product/_productSynonyms.gsp
+++ b/grails-app/views/product/_productSynonyms.gsp
@@ -66,6 +66,7 @@
                                     noSelection="['':'']"
                                     class="chzn-select-deselect"
                                     data-placeholder="${g.message(code: 'synonym.selectLocale.placeholder.label', default: 'Select a locale')}"
+                                    value="${inputValues?.locale}"
                                 />
                                 <g:select
                                     name="synonymTypeCode"
@@ -74,12 +75,13 @@
                                     noSelection="['':'']"
                                     data-placeholder="${g.message(code: 'synonym.synonymTypeCode.placeholder.label', default: 'Select a classification')}"
                                     class="chzn-select-deselect"
+                                    value="${inputValues?.synonymTypeCode}"
                                 />
                                 <input
                                     id="synonym"
                                     type="text"
                                     name="synonym"
-                                    value=""
+                                    value="${inputValues?.synonym}"
                                     size="80"
                                     class="medium text"
                                     placeholder="${g.message(code: 'synonym.typeSynonym.placeholder.label', default: 'Type the synonym here')}"

--- a/src/groovy/org/pih/warehouse/importer/ProductSynonymExcelImporter.groovy
+++ b/src/groovy/org/pih/warehouse/importer/ProductSynonymExcelImporter.groovy
@@ -45,13 +45,12 @@ class ProductSynonymExcelImporter extends AbstractExcelImporter {
         return ExcelImportUtils.convertColumnMapConfigManyRows(workbook, columnMap, null, propertyMap)
     }
 
-    void importData(ImportDataCommand command) {
-        dataService.importData(command)
+    void validateData(ImportDataCommand command) {
+        dataService.validateData(command)
     }
 
-    void validateData(ImportDataCommand command) {
-        // Do nothing for now
-        // needs to be implemented, because AbstractExcelImporter has it as abstract method
+    void importData(ImportDataCommand command) {
+        dataService.importData(command)
     }
 
 }

--- a/src/groovy/org/pih/warehouse/importer/ProductSynonymExcelImporter.groovy
+++ b/src/groovy/org/pih/warehouse/importer/ProductSynonymExcelImporter.groovy
@@ -45,12 +45,13 @@ class ProductSynonymExcelImporter extends AbstractExcelImporter {
         return ExcelImportUtils.convertColumnMapConfigManyRows(workbook, columnMap, null, propertyMap)
     }
 
-    void validateData(ImportDataCommand command) {
-        dataService.validateData(command)
-    }
-
     void importData(ImportDataCommand command) {
         dataService.importData(command)
+    }
+
+    void validateData(ImportDataCommand command) {
+        // Do nothing for now
+        // needs to be implemented, because AbstractExcelImporter has it as abstract method
     }
 
 }

--- a/test/integration/org/pih/warehouse/product/ProductIntegrationTests.groovy
+++ b/test/integration/org/pih/warehouse/product/ProductIntegrationTests.groovy
@@ -118,7 +118,7 @@ class ProductIntegrationTests extends GroovyTestCase {
         def productType = DbHelper.findOrCreateProductType("Default")
         def product1 = new Product(name: "new product 1", category: category, productType: productType).save(flush: true, failOnError: true)
 
-        def synonym = new Synonym(name: "new synonym", synonymTypeCode: SynonymTypeCode.DISPLAY_NAME)
+        def synonym = new Synonym(name: "new synonym", synonymTypeCode: SynonymTypeCode.DISPLAY_NAME, locale: new Locale("en"))
         product1.addToSynonyms(synonym)
         product1.save(flush: true)
 
@@ -144,7 +144,7 @@ class ProductIntegrationTests extends GroovyTestCase {
         def productType = DbHelper.findOrCreateProductType("Default")
         def product1 = new Product(name: "new product 1", category: category, productType: productType).save(flush: true, failOnError: true)
 
-        def synonym = new Synonym(name: "new synonym", synonymTypeCode: SynonymTypeCode.DISPLAY_NAME)
+        def synonym = new Synonym(name: "new synonym", synonymTypeCode: SynonymTypeCode.DISPLAY_NAME, locale: new Locale("en"))
         product1.addToSynonyms(synonym)
         product1.save(flush: true)
 

--- a/test/unit/org/pih/warehouse/core/SynonymTests.groovy
+++ b/test/unit/org/pih/warehouse/core/SynonymTests.groovy
@@ -43,7 +43,7 @@ class SynonymTests extends GrailsUnitTestCase {
 
     @Test
     void validate_shouldPassValidation() {
-        def synonym = new Synonym(name: "a synonym", product: new Product(), synonymTypeCode: SynonymTypeCode.DISPLAY_NAME)
+        def synonym = new Synonym(name: "a synonym", product: new Product(), synonymTypeCode: SynonymTypeCode.DISPLAY_NAME, locale: new Locale("en"))
         assertTrue synonym.validate()
         println synonym.errors
         assertTrue !synonym.hasErrors()
@@ -55,7 +55,7 @@ class SynonymTests extends GrailsUnitTestCase {
         assertTrue !synonym.validate()
         println synonym.errors
         assertTrue synonym.hasErrors()
-        assertEquals 3, synonym.errors.errorCount
+        assertEquals 4, synonym.errors.errorCount
     }
 
     @Test


### PR DESCRIPTION
I tried to make it as generic as I could, so that the methods I created, e.g. `getSynonymsOfTypeAndLocale` or `validateMultipleSynonymsOfType` are "ready" to be used in the future if we for example add some new synonym type codes that would have to be unique.

What is done:

- validation not to allow multiple synonyms of type `DISPLAY_NAME` per locale (included both - adding manually and through import)
- preventing from clearing the form values if an error occurs (so that the user can correct him/herself without having to re-write everything again)
- I also added a potential fix for another `NullPointerException` that Katarzyna has discovered today at inventory level dialog (probably the source is the same as yesterday - I found only one potential place in the dialog file which could cause it here)