### PR TITLE
OBPIH-5426 Reload Courier, etc. as needed after XDocReport calls

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/picklist/PicklistController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/picklist/PicklistController.groovy
@@ -19,7 +19,6 @@ class PicklistController {
     def scaffold = true
 
     def picklistService
-    def pdfRenderingService
 
     def save = {
         def jsonRequest = request.JSON

--- a/grails-app/controllers/org/pih/warehouse/putaway/PutAwayController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/putaway/PutAwayController.groovy
@@ -1,6 +1,5 @@
 package org.pih.warehouse.putaway
 
-import grails.plugin.rendering.pdf.PdfRenderingService
 import org.codehaus.groovy.grails.web.json.JSONObject
 import org.pih.warehouse.api.Putaway
 import org.pih.warehouse.api.PutawayItem
@@ -9,7 +8,6 @@ import org.pih.warehouse.order.Order
 
 class PutAwayController {
 
-    PdfRenderingService pdfRenderingService
     def productAvailabilityService
 
     def index = {

--- a/grails-app/services/org/pih/warehouse/core/DocumentTemplateService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/DocumentTemplateService.groovy
@@ -27,6 +27,7 @@ import org.pih.warehouse.order.OrderItem
 import org.pih.warehouse.order.OrderItemStatusCode
 import org.pih.warehouse.requisition.RequisitionItemStatus
 import org.pih.warehouse.shipping.Shipment
+import org.pih.warehouse.util.PDFUtil
 
 class DocumentTemplateService {
 
@@ -59,35 +60,37 @@ class DocumentTemplateService {
     }
 
     def renderOrderDocumentTemplate(Document documentTemplate, Order orderInstance, ConverterTypeTo targetDocumentType, OutputStream outputStream) {
+        try {
+            Boolean isVelocityTemplate = documentTemplate.filename.contains(".vm") || documentTemplate.filename.contains(".vtl")
 
-        Boolean isVelocityTemplate = documentTemplate.filename.contains(".vm") || documentTemplate.filename.contains(".vtl")
-
-        TemplateEngineKind templateEngineKind = isVelocityTemplate ?
+            TemplateEngineKind templateEngineKind = isVelocityTemplate ?
                 TemplateEngineKind.Velocity : TemplateEngineKind.Freemarker
 
-        InputStream inputStream = new ByteArrayInputStream(documentTemplate.fileContents)
-        IXDocReport report = XDocReportRegistry.getRegistry().loadReport(inputStream, templateEngineKind);
+            InputStream inputStream = new ByteArrayInputStream(documentTemplate.fileContents)
+            IXDocReport report = XDocReportRegistry.getRegistry().loadReport(inputStream, templateEngineKind);
 
-        // FIXME Need a better way to handle this generically (consider using config + dataService)
-        IContext context = orderInstance ? createOrderContext(report, orderInstance) : report.createContext();
+            // FIXME Need a better way to handle this generically (consider using config + dataService)
+            IContext context = orderInstance ? createOrderContext(report, orderInstance) : report.createContext();
 
-        ConverterTypeVia sourceDocumentType = (report.kind == "DOCX") ? ConverterTypeVia.DOCX4J :
+            ConverterTypeVia sourceDocumentType = (report.kind == "DOCX") ? ConverterTypeVia.DOCX4J :
                 (report.kind == "ODT") ? ConverterTypeVia.ODFDOM : ConverterTypeVia.XWPF
 
-        // Convert to the target type
-        if (targetDocumentType && sourceDocumentType) {
-            Options options = Options.getTo(targetDocumentType).via(sourceDocumentType);
-            report.convert(context, options, outputStream);
+            // Convert to the target type
+            if (targetDocumentType && sourceDocumentType) {
+                Options options = Options.getTo(targetDocumentType).via(sourceDocumentType);
+                report.convert(context, options, outputStream);
+            }
+            // Process document in place
+            else {
+                report.process(context, outputStream)
+            }
+            log.info "Report dump: " + report.dump()
+        } finally {
+            PDFUtil.restoreBaseFonts()
         }
-        // Process document in place
-        else {
-            report.process(context, outputStream)
-        }
-        log.info "Report dump: " + report.dump()
-
     }
 
-    def createOrderContext(IXDocReport report, Order orderInstance) {
+    private createOrderContext(IXDocReport report, Order orderInstance) {
 
         // Add data to the context
         def orderItems = orderInstance?.orderItems?.findAll {

--- a/grails-app/services/org/pih/warehouse/core/DocumentTemplateService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/DocumentTemplateService.groovy
@@ -27,7 +27,7 @@ import org.pih.warehouse.order.OrderItem
 import org.pih.warehouse.order.OrderItemStatusCode
 import org.pih.warehouse.requisition.RequisitionItemStatus
 import org.pih.warehouse.shipping.Shipment
-import org.pih.warehouse.util.PDFUtil
+import org.pih.warehouse.util.PdfUtil
 
 class DocumentTemplateService {
 
@@ -86,7 +86,7 @@ class DocumentTemplateService {
             }
             log.info "Report dump: " + report.dump()
         } finally {
-            PDFUtil.restoreBaseFonts()
+            PdfUtil.restoreBaseFonts()
         }
     }
 

--- a/grails-app/utils/org/pih/warehouse/util/DesCodec.groovy
+++ b/grails-app/utils/org/pih/warehouse/util/DesCodec.groovy
@@ -14,7 +14,7 @@ import javax.crypto.Cipher
 import javax.crypto.SecretKeyFactory
 import javax.crypto.spec.DESKeySpec
 
-class DESCodec {
+class DesCodec {
 
     static encode = { String target ->
         def cipher = getCipher(Cipher.ENCRYPT_MODE)

--- a/grails-app/utils/org/pih/warehouse/util/PDFUtil.groovy
+++ b/grails-app/utils/org/pih/warehouse/util/PDFUtil.groovy
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2012 Partners In Health.  All rights reserved.
+ * The use and distribution terms for this software are covered by the
+ * Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+ * which can be found in the file epl-v10.html at the root of this distribution.
+ * By using this software in any fashion, you are agreeing to be bound by
+ * the terms of this license.
+ * You must not remove this notice, or any other, from this software.
+ **/
+package org.pih.warehouse.util
+
+import com.lowagie.text.pdf.BaseFont
+import com.lowagie.text.pdf.PdfName
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class PDFUtil {
+
+    private static final Logger log = LoggerFactory.getLogger(PDFUtil)
+
+    static final Map PDF_BASE14_FONTS = [
+        (BaseFont.COURIER)              : PdfName.COURIER,
+        (BaseFont.COURIER_BOLD)         : PdfName.COURIER_BOLD,
+        (BaseFont.COURIER_BOLDOBLIQUE)  : PdfName.COURIER_BOLDOBLIQUE,
+        (BaseFont.COURIER_OBLIQUE)      : PdfName.COURIER_OBLIQUE,
+        (BaseFont.HELVETICA)            : PdfName.HELVETICA,
+        (BaseFont.HELVETICA_BOLD)       : PdfName.HELVETICA_BOLD,
+        (BaseFont.HELVETICA_BOLDOBLIQUE): PdfName.HELVETICA_BOLDOBLIQUE,
+        (BaseFont.HELVETICA_OBLIQUE)    : PdfName.HELVETICA_OBLIQUE,
+        (BaseFont.SYMBOL)               : PdfName.SYMBOL,
+        (BaseFont.TIMES_BOLD)           : PdfName.TIMES_BOLD,
+        (BaseFont.TIMES_BOLDITALIC)     : PdfName.TIMES_BOLDITALIC,
+        (BaseFont.TIMES_ITALIC)         : PdfName.TIMES_ITALIC,
+        (BaseFont.TIMES_ROMAN)          : PdfName.TIMES_ROMAN,
+        (BaseFont.ZAPFDINGBATS)         : PdfName.ZAPFDINGBATS,
+    ]
+
+    /**
+     * Ensure that BaseFont.BuiltinFonts14 contains all the fonts it should.
+     *
+     * XDocReport may remove some of these fonts when it runs (OBPIH-5426).
+     */
+    static void restoreBaseFonts() {
+        int numRestored = 0
+
+        PDF_BASE14_FONTS.each { k, v ->
+            if (!BaseFont.BuiltinFonts14.containsKey(k)) {
+                BaseFont.BuiltinFonts14[k] = v
+                numRestored += 1
+            }
+        }
+
+        if (numRestored) {
+            log.info "restored ${numRestored} missing base fonts (PDF)"
+        }
+    }
+}

--- a/grails-app/utils/org/pih/warehouse/util/PdfUtil.groovy
+++ b/grails-app/utils/org/pih/warehouse/util/PdfUtil.groovy
@@ -1,12 +1,12 @@
 /**
- * Copyright (c) 2012 Partners In Health.  All rights reserved.
+ * Copyright (c) 2023 Partners In Health.  All rights reserved.
  * The use and distribution terms for this software are covered by the
  * Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
  * which can be found in the file epl-v10.html at the root of this distribution.
  * By using this software in any fashion, you are agreeing to be bound by
  * the terms of this license.
  * You must not remove this notice, or any other, from this software.
- **/
+ */
 package org.pih.warehouse.util
 
 import com.lowagie.text.pdf.BaseFont
@@ -14,9 +14,9 @@ import com.lowagie.text.pdf.PdfName
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-class PDFUtil {
+class PdfUtil {
 
-    private static final Logger log = LoggerFactory.getLogger(PDFUtil)
+    private static final Logger log = LoggerFactory.getLogger(PdfUtil)
 
     static final Map PDF_BASE14_FONTS = [
         (BaseFont.COURIER)              : PdfName.COURIER,

--- a/grails-app/views/error.gsp
+++ b/grails-app/views/error.gsp
@@ -19,7 +19,7 @@
 	  			background-color:white;
 	  			border:1px solid black;
 	  			margin:3px;
-	  			font-family:courier;
+                font-family: ui-monospace, monospace, sans-serif;
 	  		}
 	  		.dialog {
 	  			display: none;

--- a/grails-app/views/unsupported.gsp
+++ b/grails-app/views/unsupported.gsp
@@ -19,7 +19,7 @@
 	  			background-color:white;
 	  			border:1px solid black;
 	  			margin:3px;
-	  			font-family:courier;
+				font-family: ui-monospace, monospace, sans-serif;
 	  		}
 	  </style>
   </head>

--- a/web-app/css/custom.css
+++ b/web-app/css/custom.css
@@ -1212,7 +1212,7 @@ span.tag { border: 1px solid #a5d24a; -moz-border-radius:2px; -webkit-border-rad
 span.tag a { font-weight: none; color: #82ad2b; text-decoration:none; font-size: 11px;  } 
 
 /*span.lotNumber { 1px solid #a5d24a; -moz-border-radius:2px; -webkit-border-radius:2px; display: block; color: black; font-weight: bold; margin-right: 5px; margin-bottom:5px;font-family: helvetica;  font-size:13px; }*/
-.lotNumber { font-family: "Courier New"; vertical-align: middle; text-transform: uppercase; }
+.lotNumber { font-family: ui-monospace, monospace, sans-serif; vertical-align: middle; text-transform: uppercase; }
 .genericName { text-transform: uppercase; }
 #more { background-color: #ddd; padding: 10px; }
 

--- a/web-app/css/openboxes.css
+++ b/web-app/css/openboxes.css
@@ -2345,9 +2345,9 @@ img.photo_tiny {
 
 
 /*span.lotNumber { 1px solid #a5d24a; -moz-border-radius:2px; -webkit-border-radius:2px; display: block; color: black; font-weight: bold; margin-right: 5px; margin-bottom:5px;font-family: helvetica;  font-size:13px; }*/
-.lotNumber { font-family: "Courier New"; vertical-align: middle; text-transform: uppercase; }
-.binLocation { font-family: "Courier New"; vertical-align: middle; text-transform: uppercase; }
-.barcode { font-family: "Courier New"; vertical-align: middle; text-transform: uppercase; letter-spacing: .1em; font-weight: normal; font-size: 11px; line-height: 20px}
+.lotNumber { font-family: ui-monospace, monospace, sans-serif; vertical-align: middle; text-transform: uppercase; }
+.binLocation { font-family: ui-monospace, monospace, sans-serif; vertical-align: middle; text-transform: uppercase; }
+.barcode { font-family: ui-monospace, monospace, sans-serif; vertical-align: middle; text-transform: uppercase; letter-spacing: .1em; font-weight: normal; font-size: 11px; line-height: 20px}
 .barcode-data { text-align: center; }
 .genericName { text-transform: uppercase; }
 #more { background-color: #ddd; padding: 10px; }

--- a/web-app/css/print.css
+++ b/web-app/css/print.css
@@ -98,5 +98,5 @@ thead {display: table-header-group;}
 tr {page-break-inside: avoid; page-break-after: auto;}
 td {vertical-align: top;}
 
-.lotNumber { font-family: "Courier New"; vertical-align: middle; text-transform: uppercase; }
-.binLocation { font-family: "Courier New"; vertical-align: middle; text-transform: uppercase; }
+.lotNumber { font-family: ui-monospace, monospace, sans-serif; vertical-align: middle; text-transform: uppercase; }
+.binLocation { font-family: ui-monospace, monospace, sans-serif; vertical-align: middle; text-transform: uppercase; }


### PR DESCRIPTION
XDocReport can clobber a global used by Grails' rendering plugin. Talk about spooky action at a distance. This PR checks that global after each call to XDocReport and repairs it as needed.

Steps to reproduce are in the associated ticket. Yuck.