### PR TITLE
OBPIH-5367 Fix validation for multiple DISPLAY_NAME synonyms in a sin…

### DIFF
--- a/grails-app/services/org/pih/warehouse/data/ProductSynonymDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSynonymDataService.groovy
@@ -68,12 +68,12 @@ class ProductSynonymDataService {
             // Check if none error occures to be sure, that we have correct product, locale and synonymTypeCode
             // before we check the duplicates
             if (!command.errors.allErrors && synonymTypeCode == SynonymTypeCode.DISPLAY_NAME) {
-                Set<Synonym> duplicates = product?.synonyms?.findAll { Synonym synonym ->
+                Synonym duplicate = product?.synonyms?.find { Synonym synonym ->
                     synonym.locale == new Locale(params['locale']) && synonym.synonymTypeCode == SynonymTypeCode.DISPLAY_NAME
                 }
                 // If the product already has a synonym of type DISPLAY_NAME and a locale
                 // or we are trying to add it in any of the line above for this single import, throw a validation error
-                if (duplicates || productsWithDisplayName.find{ it?.code == product?.productCode && it?.locale == params['locale'] }) {
+                if (duplicate || productsWithDisplayName.find{ it?.code == product?.productCode && it?.locale == params['locale'] }) {
                     command.errors.reject("Row ${index + 1}: You cannot add multiple display names in the same language. Edit the existing synonym instead.")
                     return
                 }

--- a/grails-app/services/org/pih/warehouse/data/ProductSynonymDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSynonymDataService.groovy
@@ -22,8 +22,8 @@ class ProductSynonymDataService {
     Boolean validateData(ImportDataCommand command) {
         log.info "Validate data " + command.filename
 
-        // List to store product codes that we've already added a DISPLAY_NAME synonym during this one import
-        List<String> productsWithDisplayName = []
+        // List to store product codes and a locale that we've already added a DISPLAY_NAME synonym for during this one import
+        List<Map<String, Object>> productsWithDisplayName = []
 
         command.data.eachWithIndex { params, index ->
             // check for required fields
@@ -71,13 +71,13 @@ class ProductSynonymDataService {
                 Set<Synonym> duplicates = product?.synonyms?.findAll { Synonym synonym ->
                     synonym.locale == new Locale(params['locale']) && synonym.synonymTypeCode == SynonymTypeCode.DISPLAY_NAME
                 }
-                // If the product already has a synonym of type DISPLAY_NAME
+                // If the product already has a synonym of type DISPLAY_NAME and a locale
                 // or we are trying to add it in any of the line above for this single import, throw a validation error
-                if (duplicates || productsWithDisplayName.find{ it == product?.productCode }) {
+                if (duplicates || productsWithDisplayName.find{ it?.code == product?.productCode && it?.locale == params['locale'] }) {
                     command.errors.reject("Row ${index + 1}: You cannot add multiple display names in the same language. Edit the existing synonym instead.")
                     return
                 }
-                productsWithDisplayName.add(product?.productCode)
+                productsWithDisplayName.add([code: product?.productCode, locale: params['locale']])
             }
 
         }


### PR DESCRIPTION
…gle import

It is my bad, because I haven't checked adding two `DISPLAY_NAME` synonyms in a single import, but was only checking it for the case, where product already had a `DISPLAY_NAME` synonym.

The idea of the fix is that when we loop over the rows and whenever we add a `DISPLAY_NAME` synonym, I'm adding this `productCode` to a List, and then in the `if` statement I check not only if the product already has the synonym of `DISPLAY_NAME` (in the database), but also "in cache" (in cache = we want to add the `DISPLAY_NAME` for this product in any line above for this single import).

I also fixed some weird indents in the lines from yesterday, so actually the only lines I added is `25-27` and `76`, `80`.