### PR TITLE
OBGM-401 Unable to display items in outbound return workflow

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/api/StockTransferApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/StockTransferApiController.groovy
@@ -216,12 +216,12 @@ class StockTransferApiController {
     }
 
     def returnCandidates() {
-        Location location = Location.get(params.locationId)
+        Location location = Location.get(request?.JSON?.locationId)
         if (!location) {
-            throw new IllegalArgumentException("Can't find location with given id: ${params.locationId}")
+            throw new IllegalArgumentException("Can't find location with given id: ${request?.JSON?.locationId}")
         }
 
-        List<StockTransferItem> stockTransferCandidates = stockTransferService.getStockTransferCandidates(location, params)
+        List<StockTransferItem> stockTransferCandidates = stockTransferService.getStockTransferCandidates(location, request?.JSON)
         render([data: stockTransferCandidates?.collect { it.toJson() }] as JSON)
     }
 

--- a/grails-app/services/org/pih/warehouse/stockTransfer/StockTransferService.groovy
+++ b/grails-app/services/org/pih/warehouse/stockTransfer/StockTransferService.groovy
@@ -102,7 +102,7 @@ class StockTransferService {
         return orders
     }
 
-    def getStockTransferCandidates(Location location, Map params) {
+    def getStockTransferCandidates(Location location, params) {
         List<StockTransferItem> stockTransferItems = []
 
         List stockTransferCandidates = productAvailabilityService.getStockTransferCandidates(location, params)


### PR DESCRIPTION
The problem was that this is `POST` method and we pass the params as request body, but were trying to access it through `params`. 
I know that `parseRequest` in `UrlMappings` is supposed to do the job, to parse the request body to be accessible through the `params`, but from what I've read, the `parseRequest` has not been supported since Grails 2.3.

The fix for that was to change the access from `params.locationId` to `request.JSON.locationId`, but what I'd like to bring up there is that we should be aware, that many places might face the same problem, since we used to use `parseRequest` in many endpoints, so we might want to come up with some solution not to have to change it from `params` to `request.JSON` in every place that will be found.

One of the solutions could be to create a filter/interceptor, that would make the job of `parseRequest`.

Propsed solution can be found [here](https://stackoverflow.com/questions/18870003/missing-parameters-with-restful-request-when-upgrading-to-grails-2-3-0)

Let me know what you think guys