### PR TITLE
OBPIH-5148 Can't see full item description on add items to PO shipment page

### DIFF
--- a/src/js/components/product-select/ProductSelect.jsx
+++ b/src/js/components/product-select/ProductSelect.jsx
@@ -23,19 +23,12 @@ const Option = option => (
   </Tooltip>);
 
 const SelectedValue = option => (
-  <Tooltip
-    html={<div className="text-truncate">{option.name}</div>}
-    theme="dark"
-    disabled={!option.hasTranslatedName}
-    position="top-start"
-  >
-    <span className="d-flex align-items-center">
-      <span className="text-truncate">
-        {option.label || `${option.productCode} - ${option.translatedName || option.name}`}
-      </span>
-      &nbsp;{renderHandlingIcons(option?.handlingIcons)}
+  <span className="d-flex align-items-center">
+    <span className="text-truncate">
+      {option.label || `${option.productCode} - ${option.translatedName || option.name}`}
     </span>
-  </Tooltip>
+    {renderHandlingIcons(option?.handlingIcons)}
+  </span>
 );
 
 const ProductSelect = ({

--- a/src/js/components/stock-movement-wizard/combined-shipments/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/combined-shipments/AddItemsPage.jsx
@@ -105,6 +105,7 @@ const FIELDS = {
         flexWidth: '4',
         required: true,
         attributes: {
+          forceTooltip: true,
           disabled: true,
         },
       },

--- a/src/js/components/stock-movement-wizard/combined-shipments/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/combined-shipments/AddItemsPage.jsx
@@ -105,7 +105,7 @@ const FIELDS = {
         flexWidth: '4',
         required: true,
         attributes: {
-          forceTooltip: true,
+          showValueTooltip: true,
           disabled: true,
         },
       },

--- a/src/js/utils/Select.jsx
+++ b/src/js/utils/Select.jsx
@@ -262,11 +262,13 @@ class Select extends Component {
     };
 
     const isTooltipDisabled = () => {
-      if (this.props.value?.translatedName) {
+      const { forceTooltip, value: fieldValue } = this.props;
+
+      if (fieldValue?.translatedName || forceTooltip) {
         return false;
       }
 
-      return !showLabelTooltip || (showValueTooltip && this.props.value);
+      return !showLabelTooltip || (showValueTooltip && !fieldValue);
     };
 
     return (
@@ -398,9 +400,11 @@ Select.propTypes = {
   classNamePrefix: PropTypes.string,
   translate: PropTypes.func.isRequired,
   defaultPlaceholder: PropTypes.string,
+  forceTooltip: PropTypes.bool,
 };
 
 Select.defaultProps = {
+  forceTooltip: undefined,
   value: undefined,
   onChange: null,
   onMenuClose: null,

--- a/src/js/utils/Select.jsx
+++ b/src/js/utils/Select.jsx
@@ -261,6 +261,13 @@ class Select extends Component {
       return null;
     };
 
+
+    /* We would like to see the tooltip when an item
+      have translatedName or when the showLabelTooltip
+      or showValueTooltip are truthy. We return false
+      when at least one property is true, because we need
+      an information when the tooltip should be disabled.
+     */
     const isTooltipDisabled = () => {
       const { value: fieldValue } = this.props;
 

--- a/src/js/utils/Select.jsx
+++ b/src/js/utils/Select.jsx
@@ -124,7 +124,7 @@ class Select extends Component {
       );
     }
 
-    return (value && <div className="p-1">{value.label}</div>);
+    return (value && <div className="p-1">{value.label ?? value?.name}</div>);
   }
 
   handleChange(value) {
@@ -264,9 +264,11 @@ class Select extends Component {
     const isTooltipDisabled = () => {
       const { value: fieldValue } = this.props;
 
-      return !(
-        fieldValue?.translatedName || showLabelTooltip || (showValueTooltip && this.props.value)
-      );
+      if (fieldValue?.translatedName || showLabelTooltip) {
+        return false;
+      }
+
+      return !(showValueTooltip && fieldValue);
     };
 
     return (
@@ -398,11 +400,9 @@ Select.propTypes = {
   classNamePrefix: PropTypes.string,
   translate: PropTypes.func.isRequired,
   defaultPlaceholder: PropTypes.string,
-  forceTooltip: PropTypes.bool,
 };
 
 Select.defaultProps = {
-  forceTooltip: undefined,
   value: undefined,
   onChange: null,
   onMenuClose: null,

--- a/src/js/utils/Select.jsx
+++ b/src/js/utils/Select.jsx
@@ -107,6 +107,10 @@ class Select extends Component {
       multi, placeholder, showLabelTooltip, value, defaultPlaceholder,
     } = this.props;
 
+    // TODO: We should change this in the future
+    // to check only hasTranslatedName, but for now
+    // we don't have hasTranslatedName in all mappings
+    // discussion connected to OBPIH-5148
     if (value?.translatedName || value?.hasTranslatedName) {
       return (
         <div className="p-1">

--- a/src/js/utils/Select.jsx
+++ b/src/js/utils/Select.jsx
@@ -107,7 +107,7 @@ class Select extends Component {
       multi, placeholder, showLabelTooltip, value, defaultPlaceholder,
     } = this.props;
 
-    if (value?.translatedName) {
+    if (value?.translatedName || value?.hasTranslatedName) {
       return (
         <div className="p-1">
           {value?.name}
@@ -262,13 +262,11 @@ class Select extends Component {
     };
 
     const isTooltipDisabled = () => {
-      const { forceTooltip, value: fieldValue } = this.props;
+      const { value: fieldValue } = this.props;
 
-      if (fieldValue?.translatedName || forceTooltip) {
-        return false;
-      }
-
-      return !showLabelTooltip || (showValueTooltip && fieldValue);
+      return !(
+        fieldValue?.translatedName || showLabelTooltip || (showValueTooltip && this.props.value)
+      );
     };
 
     return (

--- a/src/js/utils/Select.jsx
+++ b/src/js/utils/Select.jsx
@@ -268,7 +268,7 @@ class Select extends Component {
         return false;
       }
 
-      return !showLabelTooltip || (showValueTooltip && !fieldValue);
+      return !showLabelTooltip || (showValueTooltip && fieldValue);
     };
 
     return (

--- a/src/js/utils/Select.jsx
+++ b/src/js/utils/Select.jsx
@@ -263,7 +263,7 @@ class Select extends Component {
 
 
     /* We would like to see the tooltip when an item
-      have translatedName or when the showLabelTooltip
+      has translatedName or when the showLabelTooltip
       or showValueTooltip are truthy. We return false
       when at least one property is true, because we need
       an information when the tooltip should be disabled.

--- a/src/js/utils/option-utils.jsx
+++ b/src/js/utils/option-utils.jsx
@@ -72,6 +72,9 @@ export const debounceGlobalSearch = (waitTime, minSearchLength) =>
     }
   }, waitTime);
 
+// TODO: We don't have access to translatedName directly
+// so it can be added in the future
+// discussion connected to OBPIH-5148
 export const debounceProductsFetch = (waitTime, minSearchLength, locationId) =>
   _.debounce((searchTerm, callback) => {
     if (searchTerm && searchTerm.length >= minSearchLength) {


### PR DESCRIPTION
I added a props `forceTooltip`, because if i just set `showValueTooltip=true` the tooltip doesn't work. When i changed the condition in `isTooltipDisabled()` then i found some places when two tooltips were displayed (because of using Tooltip inside `FIELDS`)