### PR TITLE
OBPIH-5355 Restyling components for notifications

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -1300,6 +1300,9 @@ openboxes.expirationDate.format = Constants.EXPIRATION_DATE_FORMAT
 openboxes.display.date.format = Constants.DISPLAY_DATE_FORMAT
 openboxes.display.date.defaultValue = Constants.DISPLAY_DATE_DEFAULT_VALUE
 
+// Notifications configuration
+openboxes.notification.disappear.time.ms = 8000
+
 // Global megamenu configuration
 
 openboxes.menuSectionsUrlParts = [

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -1301,7 +1301,9 @@ openboxes.display.date.format = Constants.DISPLAY_DATE_FORMAT
 openboxes.display.date.defaultValue = Constants.DISPLAY_DATE_DEFAULT_VALUE
 
 // Notifications configuration
-openboxes.notification.disappear.time.ms = 8000
+
+// delay is in ms
+openboxes.client.notification.autohide.delay = 8000
 
 // Global megamenu configuration
 

--- a/grails-app/controllers/org/pih/warehouse/api/ApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/ApiController.groovy
@@ -93,7 +93,7 @@ class ApiController {
         def displayDateFormat = grailsApplication.config.openboxes.display.date.format
         def displayDateDefaultValue = grailsApplication.config.openboxes.display.date.defaultValue
         // Notification disappear time in miliseconds
-        def notificationDisappearTime = grailsApplication.config.openboxes.notification.disappear.time.ms
+        def notificationAutohideDelay = grailsApplication.config.openboxes.client.notification.autohide.delay
 
         if (session.useDebugLocale) {
 
@@ -208,7 +208,7 @@ class ApiController {
                 localizationModeLocale   : localizationModeLocale,
                 displayDateFormat        : displayDateFormat,
                 displayDateDefaultValue  : displayDateDefaultValue,
-                notificationDisappearTime: notificationDisappearTime,
+                notificationAutohideDelay: notificationAutohideDelay,
             ],
         ] as JSON)
     }

--- a/grails-app/controllers/org/pih/warehouse/api/ApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/ApiController.groovy
@@ -92,6 +92,8 @@ class ApiController {
         def localizationModeLocale = grailsApplication.config.openboxes.locale.localizationModeLocale
         def displayDateFormat = grailsApplication.config.openboxes.display.date.format
         def displayDateDefaultValue = grailsApplication.config.openboxes.display.date.defaultValue
+        // Notification disappear time in miliseconds
+        def notificationDisappearTime = grailsApplication.config.openboxes.notification.disappear.time.ms
 
         if (session.useDebugLocale) {
 
@@ -205,7 +207,8 @@ class ApiController {
                 localizationModeEnabled  : localizationModeEnabled,
                 localizationModeLocale   : localizationModeLocale,
                 displayDateFormat        : displayDateFormat,
-                displayDateDefaultValue  : displayDateDefaultValue
+                displayDateDefaultValue  : displayDateDefaultValue,
+                notificationDisappearTime: notificationDisappearTime,
             ],
         ] as JSON)
     }

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -1262,3 +1262,91 @@ div.search-input:focus-within {
   }
 }
 
+// Styling of custom alerts
+
+.s-alert-box {
+  width: 388px;
+  max-width: 388px;
+  color: var(--gray-600);
+  border-radius: 4px;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.25);
+  background-color: #FFFFFF;
+}
+
+.no-details {
+  padding-bottom: 4px;
+}
+
+.s-alert-info {
+  border: 1px solid var(--gray-500);
+}
+
+.s-alert-success {
+  border: 1px solid var(--color-green);
+
+  svg {
+    color: var(--color-green);
+  }
+}
+
+.s-alert-warning {
+  border: 1px solid var(--color-yellow);
+
+  svg {
+    color: var(--color-yellow);
+  }
+}
+
+.s-alert-error {
+  border: 1px solid var(--color-red);
+
+  svg {
+    color: var(--color-red);
+  }
+}
+
+
+.s-alert-box-inner {
+  display: grid;
+  grid-template-columns: 1fr 8fr 1fr;
+  grid-template-rows: auto auto;
+  row-gap: 13px;
+  font-size: 14px;
+
+  svg {
+    width: 22px;
+    height: 22px;
+  }
+
+  .alert-start-icon {
+    grid-column: 1;
+  }
+
+  .alert-title {
+    grid-column: 2;
+    grid-row: 1;
+    font-weight: 600;
+    line-height: 16px;
+    display: flex;
+    align-items: center;
+  }
+
+  .alert-details {
+    grid-column: 2;
+    grid-row: 2;
+    font-weight: 400;
+    line-height: 21px;
+  }
+
+  .alert-close-icon {
+    grid-column: 3;
+    display: flex;
+    justify-content: flex-end;
+
+    svg {
+      cursor: pointer;
+      color: var(--gray-600);
+    }
+  }
+}
+

--- a/src/js/components/Layout/notifications/notification.jsx
+++ b/src/js/components/Layout/notifications/notification.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { RiInformationLine } from 'react-icons/all';
-import { RiAlertLine, RiCheckboxCircleLine, RiErrorWarningFill, RiErrorWarningLine } from 'react-icons/ri';
+import { RiAlertLine, RiCheckboxCircleLine, RiErrorWarningFill, RiErrorWarningLine, RiInformationLine } from 'react-icons/ri';
 import Alert from 'react-s-alert';
 
 import NotificationType from 'consts/notificationTypes';

--- a/src/js/components/Layout/notifications/notification.jsx
+++ b/src/js/components/Layout/notifications/notification.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import { RiInformationLine } from 'react-icons/all';
+import { RiAlertLine, RiCheckboxCircleLine, RiErrorWarningFill, RiErrorWarningLine } from 'react-icons/ri';
+import Alert from 'react-s-alert';
+
+import NotificationType from 'consts/notificationTypes';
+
+const notification = type => ({ message, details, startIcon }) => {
+  const alertsProps = {
+    customFields: {
+      details,
+      startIcon,
+    },
+  };
+  switch (type) {
+    case NotificationType.SUCCESS:
+      return Alert.success(message, {
+        ...alertsProps,
+        customFields: {
+          ...alertsProps.customFields,
+          startIcon: alertsProps.customFields.startIcon ?? <RiCheckboxCircleLine />,
+        },
+      });
+    case NotificationType.WARNING:
+      return Alert.warning(message, {
+        ...alertsProps,
+        customFields: {
+          ...alertsProps.customFields,
+          startIcon: alertsProps.customFields.startIcon ?? <RiAlertLine />,
+        },
+      });
+    case NotificationType.ERROR_OUTLINED:
+      return Alert.error(message, {
+        ...alertsProps,
+        customFields: {
+          ...alertsProps.customFields,
+          startIcon: alertsProps.customFields.startIcon ?? <RiErrorWarningLine />,
+        },
+      });
+    case NotificationType.ERROR_FILLED:
+      return Alert.error(message, {
+        ...alertsProps,
+        customFields: {
+          ...alertsProps.customFields,
+          startIcon: alertsProps.customFields.startIcon ?? <RiErrorWarningFill />,
+        },
+      });
+    default:
+      return Alert.info(message, {
+        ...alertsProps,
+        customFields: {
+          ...alertsProps.customFields,
+          startIcon: alertsProps.customFields.startIcon ?? <RiInformationLine />,
+        },
+      });
+  }
+};
+
+export default notification;

--- a/src/js/components/Layout/notifications/notification.jsx
+++ b/src/js/components/Layout/notifications/notification.jsx
@@ -5,11 +5,11 @@ import Alert from 'react-s-alert';
 
 import NotificationType from 'consts/notificationTypes';
 
-const notification = type => ({ message, details, startIcon }) => {
+const notification = type => ({ message, details, icon }) => {
   const alertsProps = {
     customFields: {
       details,
-      startIcon,
+      icon,
     },
   };
   switch (type) {
@@ -18,7 +18,7 @@ const notification = type => ({ message, details, startIcon }) => {
         ...alertsProps,
         customFields: {
           ...alertsProps.customFields,
-          startIcon: alertsProps.customFields.startIcon ?? <RiCheckboxCircleLine />,
+          icon: alertsProps.customFields.icon ?? <RiCheckboxCircleLine />,
         },
       });
     case NotificationType.WARNING:
@@ -26,7 +26,7 @@ const notification = type => ({ message, details, startIcon }) => {
         ...alertsProps,
         customFields: {
           ...alertsProps.customFields,
-          startIcon: alertsProps.customFields.startIcon ?? <RiAlertLine />,
+          icon: alertsProps.customFields.icon ?? <RiAlertLine />,
         },
       });
     case NotificationType.ERROR_OUTLINED:
@@ -34,7 +34,7 @@ const notification = type => ({ message, details, startIcon }) => {
         ...alertsProps,
         customFields: {
           ...alertsProps.customFields,
-          startIcon: alertsProps.customFields.startIcon ?? <RiErrorWarningLine />,
+          icon: alertsProps.customFields.icon ?? <RiErrorWarningLine />,
         },
       });
     case NotificationType.ERROR_FILLED:
@@ -42,7 +42,7 @@ const notification = type => ({ message, details, startIcon }) => {
         ...alertsProps,
         customFields: {
           ...alertsProps.customFields,
-          startIcon: alertsProps.customFields.startIcon ?? <RiErrorWarningFill />,
+          icon: alertsProps.customFields.icon ?? <RiErrorWarningFill />,
         },
       });
     default:
@@ -50,7 +50,7 @@ const notification = type => ({ message, details, startIcon }) => {
         ...alertsProps,
         customFields: {
           ...alertsProps.customFields,
-          startIcon: alertsProps.customFields.startIcon ?? <RiInformationLine />,
+          icon: alertsProps.customFields.icon ?? <RiInformationLine />,
         },
       });
   }

--- a/src/js/components/Layout/notifications/notification.md
+++ b/src/js/components/Layout/notifications/notification.md
@@ -4,7 +4,7 @@
 notification is implemented as curried function - as argument it expects `type` of the notification which is from the:
 `NotificationType` enum.
 
-It returns a function that expects `message` (required), `details`, `startIcon` as arguments to then call the proper `Alert` function from `react-s-alert` package.
+It returns a function that expects `message` (required), `details`, `icon` as arguments to then call the proper `Alert` function from `react-s-alert` package.
 
                                                                                                         
 #### Examples:
@@ -12,7 +12,7 @@ It returns a function that expects `message` (required), `details`, `startIcon` 
  notification(NotificationType.INFO)({
     message: 'Lost connection',
     details: 'You are now offline. The changes you made will not be saved',
-    startIcon: <RiWifiOffLine />,
+    icon: <RiWifiOffLine />,
 });
 ````
 The above generates the Alert of info type (gray border) with message (title [bold]) of "Lost connection" and the details of the message with the start icon of Wifi icon.
@@ -24,6 +24,6 @@ The above generates the Alert of info type (gray border) with message (title [bo
 });
 ````
 
-The above generates the Alert of type success. We have not provided the `startIcon` prop, so the default will be: `<RiCheckboxCircleLine />`
+The above generates the Alert of type success. We have not provided the `icon` prop, so the default will be: `<RiCheckboxCircleLine />`
 
 

--- a/src/js/components/Layout/notifications/notification.md
+++ b/src/js/components/Layout/notifications/notification.md
@@ -1,0 +1,29 @@
+## notification documentation
+* `notification(...)(...)`
+#### Usage:
+notification is implemented as curried function - as argument it expects `type` of the notification which is from the:
+`NotificationType` enum.
+
+It returns a function that expects `message` (required), `details`, `startIcon` as arguments to then call the proper `Alert` function from `react-s-alert` package.
+
+                                                                                                        
+#### Examples:
+````md
+ notification(NotificationType.INFO)({
+    message: 'Lost connection',
+    details: 'You are now offline. The changes you made will not be saved',
+    startIcon: <RiWifiOffLine />,
+});
+````
+The above generates the Alert of info type (gray border) with message (title [bold]) of "Lost connection" and the details of the message with the start icon of Wifi icon.
+
+````
+ notification(NotificationType.SUCCESS)({
+    message: 'Lorem ipsum',
+    details: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+});
+````
+
+The above generates the Alert of type success. We have not provided the `startIcon` prop, so the default will be: `<RiCheckboxCircleLine />`
+
+

--- a/src/js/components/Router.jsx
+++ b/src/js/components/Router.jsx
@@ -227,7 +227,7 @@ const Router = (props) => {
         />
       </div>
       <Alert
-        timeout={props.notificationDisappearTime}
+        timeout={props.notificationAutohideDelay}
         stack={{ limit: 3 }}
         contentTemplate={CustomAlert}
         position="top-right"
@@ -241,7 +241,7 @@ const Router = (props) => {
 const mapStateToProps = state => ({
   spinner: state.spinner.show,
   supportedActivities: state.session.supportedActivities,
-  notificationDisappearTime: state.session.notificationDisappearTime,
+  notificationAutohideDelay: state.session.notificationAutohideDelay,
 });
 
 export default connect(mapStateToProps, {})(Router);
@@ -249,5 +249,5 @@ export default connect(mapStateToProps, {})(Router);
 Router.propTypes = {
   spinner: PropTypes.bool.isRequired,
   supportedActivities: PropTypes.arrayOf(PropTypes.string).isRequired,
-  notificationDisappearTime: PropTypes.number.isRequired,
+  notificationAutohideDelay: PropTypes.number.isRequired,
 };

--- a/src/js/components/Router.jsx
+++ b/src/js/components/Router.jsx
@@ -228,7 +228,7 @@ const Router = (props) => {
       </div>
       <Alert
         timeout={props.notificationDisappearTime}
-        stack={{ limit: 5 }}
+        stack={{ limit: 3 }}
         contentTemplate={CustomAlert}
         position="top-right"
         effect="bouncyflip"

--- a/src/js/components/Router.jsx
+++ b/src/js/components/Router.jsx
@@ -8,6 +8,7 @@ import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
 import Alert from 'react-s-alert';
 import { ClimbingBoxLoader } from 'react-spinners';
 
+import CustomAlert from 'components/dashboard/CustomAlert';
 import MainLayoutRoute from 'components/Layout/MainLayoutRoute';
 import Loading from 'components/Loading';
 
@@ -226,12 +227,12 @@ const Router = (props) => {
         />
       </div>
       <Alert
-        timeout="none"
-        stack={{ limit: 3 }}
-        offset={20}
-        html
+        timeout={props.notificationDisappearTime}
+        stack={{ limit: 5 }}
+        contentTemplate={CustomAlert}
         position="top-right"
         effect="bouncyflip"
+        offset={20}
       />
     </div>
   );
@@ -240,6 +241,7 @@ const Router = (props) => {
 const mapStateToProps = state => ({
   spinner: state.spinner.show,
   supportedActivities: state.session.supportedActivities,
+  notificationDisappearTime: state.session.notificationDisappearTime,
 });
 
 export default connect(mapStateToProps, {})(Router);
@@ -247,4 +249,5 @@ export default connect(mapStateToProps, {})(Router);
 Router.propTypes = {
   spinner: PropTypes.bool.isRequired,
   supportedActivities: PropTypes.arrayOf(PropTypes.string).isRequired,
+  notificationDisappearTime: PropTypes.number.isRequired,
 };

--- a/src/js/components/dashboard/CustomAlert.jsx
+++ b/src/js/components/dashboard/CustomAlert.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import PropTypes from 'prop-types';
+import { RiAlertLine, RiCheckboxCircleLine, RiCloseLine, RiErrorWarningFill, RiInformationLine } from 'react-icons/ri';
+
+import NotificationType from 'consts/notificationTypes';
+
+const defaultStartIcon = {
+  [NotificationType.SUCCESS]: <RiCheckboxCircleLine />,
+  [NotificationType.INFO]: <RiInformationLine />,
+  [NotificationType.ERROR]: <RiErrorWarningFill />,
+  [NotificationType.WARNING]: <RiAlertLine />,
+};
+
+const CustomAlert = ({
+  message, classNames, customFields, id, styles, condition, handleClose,
+}) => {
+  // Show default start icon for already existing Alerts,
+  // which are not called by notification(), but Alert
+  const getStartIcon = () => {
+    if (customFields?.startIcon) {
+      return customFields.startIcon;
+    }
+    return defaultStartIcon[condition ?? NotificationType.INFO];
+  };
+
+  return (
+    <div className={`${classNames} ${!customFields?.details ? 'no-details' : ''}`} id={id} style={styles}>
+      <div className="s-alert-box-inner">
+        <div className="alert-start-icon">
+          {getStartIcon()}
+        </div>
+        <span className="alert-title">{message}</span>
+        {customFields?.details && <span className="alert-details">{customFields?.details}</span>}
+        <div className="alert-close-icon">
+          <span role="presentation" onClick={handleClose}>
+            <RiCloseLine />
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+
+export default CustomAlert;
+
+
+CustomAlert.propTypes = {
+  classNames: PropTypes.string.isRequired,
+  /** Condition is a built-in prop in the Alert and the types of it can be:
+    success, error, warning, info.
+  */
+  condition: PropTypes.string.isRequired,
+  /** customFields can contain anything in the future - for now we use details and startIcon */
+  customFields: PropTypes.shape({
+    details: PropTypes.string.isRequired,
+    startIcon: PropTypes.element.isRequired,
+  }).isRequired,
+  handleClose: PropTypes.func.isRequired,
+  id: PropTypes.string.isRequired,
+  /** message (title) is the first param passed to the Alert.(..) */
+  message: PropTypes.string.isRequired,
+  styles: PropTypes.shape({}).isRequired,
+};

--- a/src/js/components/dashboard/CustomAlert.jsx
+++ b/src/js/components/dashboard/CustomAlert.jsx
@@ -17,9 +17,9 @@ const CustomAlert = ({
 }) => {
   // Show default start icon for already existing Alerts,
   // which are not called by notification(), but Alert
-  const getStartIcon = () => {
-    if (customFields?.startIcon) {
-      return customFields.startIcon;
+  const getIcon = () => {
+    if (customFields?.icon) {
+      return customFields.icon;
     }
     return defaultStartIcon[condition ?? NotificationType.INFO];
   };
@@ -28,7 +28,7 @@ const CustomAlert = ({
     <div className={`${classNames} ${!customFields?.details ? 'no-details' : ''}`} id={id} style={styles}>
       <div className="s-alert-box-inner">
         <div className="alert-start-icon">
-          {getStartIcon()}
+          {getIcon()}
         </div>
         <span className="alert-title">{message}</span>
         {customFields?.details && <span className="alert-details">{customFields?.details}</span>}
@@ -55,7 +55,7 @@ CustomAlert.propTypes = {
   /** customFields can contain anything in the future - for now we use details and startIcon */
   customFields: PropTypes.shape({
     details: PropTypes.string.isRequired,
-    startIcon: PropTypes.element.isRequired,
+    icon: PropTypes.element.isRequired,
   }).isRequired,
   handleClose: PropTypes.func.isRequired,
   id: PropTypes.string.isRequired,

--- a/src/js/consts/notificationTypes.js
+++ b/src/js/consts/notificationTypes.js
@@ -1,0 +1,10 @@
+const NotificationType = {
+  SUCCESS: 'success',
+  WARNING: 'warning',
+  INFO: 'info',
+  ERROR: 'error',
+  ERROR_OUTLINED: 'error-outlined',
+  ERROR_FILLED: 'error-filled',
+};
+
+export default NotificationType;

--- a/src/js/reducers/sessionReducer.jsx
+++ b/src/js/reducers/sessionReducer.jsx
@@ -76,7 +76,7 @@ const initialState = {
   localizationModeLocale: 'ach',
   displayDateFormat: 'MMM DD, yyyy',
   displayDateDefaultValue: '-',
-  notificationDisappearTime: 8000,
+  notificationAutohideDelay: 8000,
 };
 
 export default function (state = initialState, action) {
@@ -118,7 +118,7 @@ export default function (state = initialState, action) {
         localizationModeLocale: _.get(action, 'payload.data.data.localizationModeLocale', 'ach'),
         displayDateFormat: _.get(action, 'payload.data.data.displayDateFormat', 'MMM DD, yyyy'),
         displayDateDefaultValue: _.get(action, 'payload.data.data.displayDateDefaultValue', '-'),
-        notificationDisappearTime: _.get(action, 'payload.data.data.notificationDisappearTime', 8000),
+        notificationAutohideDelay: _.get(action, 'payload.data.data.notificationAutohideDelay', 8000),
       };
     case FETCH_MENU_CONFIG:
       return {

--- a/src/js/reducers/sessionReducer.jsx
+++ b/src/js/reducers/sessionReducer.jsx
@@ -118,7 +118,7 @@ export default function (state = initialState, action) {
         localizationModeLocale: _.get(action, 'payload.data.data.localizationModeLocale', 'ach'),
         displayDateFormat: _.get(action, 'payload.data.data.displayDateFormat', 'MMM DD, yyyy'),
         displayDateDefaultValue: _.get(action, 'payload.data.data.displayDateDefaultValue', '-'),
-        notificationDisappearTime: _.get(action, 'payload.data.data.notificationDisappearTime', 8000)
+        notificationDisappearTime: _.get(action, 'payload.data.data.notificationDisappearTime', 8000),
       };
     case FETCH_MENU_CONFIG:
       return {

--- a/src/js/reducers/sessionReducer.jsx
+++ b/src/js/reducers/sessionReducer.jsx
@@ -76,6 +76,7 @@ const initialState = {
   localizationModeLocale: 'ach',
   displayDateFormat: 'MMM DD, yyyy',
   displayDateDefaultValue: '-',
+  notificationDisappearTime: 8000,
 };
 
 export default function (state = initialState, action) {
@@ -117,6 +118,7 @@ export default function (state = initialState, action) {
         localizationModeLocale: _.get(action, 'payload.data.data.localizationModeLocale', 'ach'),
         displayDateFormat: _.get(action, 'payload.data.data.displayDateFormat', 'MMM DD, yyyy'),
         displayDateDefaultValue: _.get(action, 'payload.data.data.displayDateDefaultValue', '-'),
+        notificationDisappearTime: _.get(action, 'payload.data.data.notificationDisappearTime', 8000)
       };
     case FETCH_MENU_CONFIG:
       return {

--- a/src/js/utils/apiClient.jsx
+++ b/src/js/utils/apiClient.jsx
@@ -54,10 +54,10 @@ export function flattenRequest(data) {
 export const handleSuccess = response => response;
 
 export const handleError = (error) => {
+  const errorMessage = _.get(error, 'response.data.errorMessage', '');
+  const errorMessages = _.map(_.get(error, 'response.data.errorMessages', ''), message => `${message}, `);
   switch (error.response.status) {
     case 400: {
-      const errorMessages = _.map(_.get(error, 'response.data.errorMessages', ''), errorMessage => `${errorMessage}, `);
-      const errorMessage = _.get(error, 'response.data.errorMessage', '');
       notification(NotificationType.ERROR_OUTLINED)({
         message: 'Bad request',
         details: errorMessage ?? errorMessages,
@@ -73,25 +73,25 @@ export const handleError = (error) => {
     case 403:
       notification(NotificationType.WARNING)({
         message: 'Access denied',
-        details: _.get(error, 'response.data.errorMessage', ''),
+        details: errorMessage ?? errorMessages,
       });
       break;
     case 404:
       notification(NotificationType.ERROR_OUTLINED)({
         message: 'Not found',
-        details: _.get(error, 'response.data.errorMessage', ''),
+        details: errorMessage ?? errorMessages,
       });
       break;
     case 500:
       notification(NotificationType.ERROR_FILLED)({
         message: 'Internal server error',
-        details: _.get(error, 'response.data.errorMessage', ''),
+        details: errorMessage ?? errorMessages,
       });
       break;
     default:
       notification(NotificationType.ERROR_FILLED)({
         message: error,
-        details: _.get(error, 'response.data.errorMessage', ''),
+        details: errorMessage ?? errorMessages,
       });
   }
   return Promise.reject(error);

--- a/src/js/utils/apiClient.jsx
+++ b/src/js/utils/apiClient.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 import axios from 'axios';
 import _ from 'lodash';
 import { confirmAlert } from 'react-confirm-alert';
-import Alert from 'react-s-alert';
 
 import notification from 'components/Layout/notifications/notification';
 import LoginModal from 'components/LoginModal';

--- a/src/js/utils/apiClient.jsx
+++ b/src/js/utils/apiClient.jsx
@@ -6,7 +6,9 @@ import _ from 'lodash';
 import { confirmAlert } from 'react-confirm-alert';
 import Alert from 'react-s-alert';
 
+import notification from 'components/Layout/notifications/notification';
 import LoginModal from 'components/LoginModal';
+import NotificationType from 'consts/notificationTypes';
 
 const justRejectRequestError = error => Promise.reject(error);
 
@@ -55,9 +57,12 @@ export const handleSuccess = response => response;
 export const handleError = (error) => {
   switch (error.response.status) {
     case 400: {
-      const errorMessages = _.map(_.get(error, 'response.data.errorMessages', ''), errorMessage => `<div>${errorMessage}</div>`);
+      const errorMessages = _.map(_.get(error, 'response.data.errorMessages', ''), errorMessage => `${errorMessage}, `);
       const errorMessage = _.get(error, 'response.data.errorMessage', '');
-      Alert.error(`Bad Request.</br> ${errorMessage || errorMessages}`);
+      notification(NotificationType.ERROR_OUTLINED)({
+        message: 'Bad request',
+        details: errorMessage ?? errorMessages,
+      });
       break;
     }
 
@@ -67,17 +72,28 @@ export const handleError = (error) => {
       });
       break;
     case 403:
-      Alert.error(`Access denied.</br>${_.get(error, 'response.data.errorMessage', '')}`);
+      notification(NotificationType.WARNING)({
+        message: 'Access denied',
+        details: _.get(error, 'response.data.errorMessage', ''),
+      });
       break;
     case 404:
-      Alert.error(`Not found.</br>${_.get(error, 'response.data.errorMessage', '')}`);
+      notification(NotificationType.ERROR_OUTLINED)({
+        message: 'Not found',
+        details: _.get(error, 'response.data.errorMessage', ''),
+      });
       break;
     case 500:
-      Alert.error(`Internal server error.</br>${_.get(error, 'response.data.errorMessage', '')}`);
+      notification(NotificationType.ERROR_FILLED)({
+        message: 'Internal server error',
+        details: _.get(error, 'response.data.errorMessage', ''),
+      });
       break;
-    default: {
-      Alert.error(`${error}</br>${_.get(error, 'response.data.errorMessage', '')}`);
-    }
+    default:
+      notification(NotificationType.ERROR_FILLED)({
+        message: error,
+        details: _.get(error, 'response.data.errorMessage', ''),
+      });
   }
   return Promise.reject(error);
 };


### PR DESCRIPTION
I tried to make it as much configurable as I could - the usage is pretty simple and described in the `notification.md` file.

I made `notification()` as **curried** function, so it takes as an argument `type` of the notification from enum `NotificationType` and then returns a function which expects arguments: `message` (required), `details` (the description of the error, optional), `startIcon` (optional, each type of the notification has its default `startIcon`).

I also tried to cause as little regression as I could, so I also took care of already existing notifications (which are called by `Alert.success(...)` directly), and managed to make them look as close as to the new design:
![Screenshot from 2023-02-27 11-24-19](https://user-images.githubusercontent.com/93163821/221572397-30f94552-21df-4d8d-8eea-41d33d146603.png)
Manon has said it looked good, and said, that we would have in the future some tickets to change the existing alerts and their messages.
I also refactored our error handler in the `apiClient` to make it use our new notification function. An example below:
![Screenshot from 2023-02-27 13-46-59](https://user-images.githubusercontent.com/93163821/221572685-92da24f2-4e00-406e-a3aa-0ddfe74b1c95.png)


Overall I've managed to come up with this:

![Screenshot from 2023-02-27 13-40-45](https://user-images.githubusercontent.com/93163821/221572834-55012ede-51d7-4b77-b972-5539ab05c572.png)


@drodzewicz to create a notification for lost connection you just have to do this:
```
notification(NotificationType.INFO)({
      message: 'Lost connection',
      details: 'You are now offline. The changes you made will not be saved',
      startIcon: <RiWifiOffLine />,
});
```