### PR TITLE
OBPIH-5323 Save line by line in outbound add items step (Fix for duplicating items)

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -1355,6 +1355,10 @@ div.search-input:focus-within {
 .line-item-save-indicator {
   width: 3px;
 
+  &.saving {
+    background-color: var(--color-yellow);
+  }
+
   &.pending {
     background-color: var(--color-yellow);
   }

--- a/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
@@ -355,7 +355,7 @@ class AddItemsPage extends Component {
       !item.statusCode &&
       parseInt(item.quantityRequested, 10) > 0 &&
       item.product);
-    // Here I am changing rowSaveStatus from EDITED to SAVING
+    // Here I am changing rowSaveStatus from PENDING to SAVING
     // because all of these lines were sent to save
     this.setState(previousState => ({
       values: {

--- a/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
@@ -372,7 +372,7 @@ class AddItemsPage extends Component {
     const lineItemsToBeUpdated = [];
     _.forEach(lineItemsWithStatus, (item) => {
       // We wouldn't update items with quantity requested < 0
-      if (parseInt(item.quantityRequested, 10) < 0) {
+      if (parseInt(item.quantityRequested, 10) <= 0) {
         return; // lodash continue
       }
       const oldItem = _.find(this.state.currentLineItems, old => old.id === item.id);
@@ -392,7 +392,7 @@ class AddItemsPage extends Component {
         key => key !== 'product',
       );
 
-      if (newQty === oldQty && oldItem.rowSaveStatus === RowSaveStatus.ERROR) {
+      if (newQty === oldQty) {
         this.setState(prev => ({
           values: {
             ...prev.values,

--- a/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
@@ -145,15 +145,15 @@ const NO_STOCKLIST_FIELDS = {
           disabled: (fieldValue && fieldValue.statusCode === 'SUBSTITUTED') || _.isNil(fieldValue && fieldValue.product),
           onTabPress: rowCount === rowIndex + 1 ? () => {
             updateTotalCount(1);
-            addRow({ sortOrder: getSortOrder() });
+            addRow({ sortOrder: getSortOrder(), rowSaveStatus: RowSaveStatus.PENDING });
           } : null,
           arrowRight: rowCount === rowIndex + 1 ? () => {
             updateTotalCount(1);
-            addRow({ sortOrder: getSortOrder() });
+            addRow({ sortOrder: getSortOrder(), rowSaveStatus: RowSaveStatus.PENDING });
           } : null,
           arrowDown: rowCount === rowIndex + 1 ? () => () => {
             updateTotalCount(1);
-            addRow({ sortOrder: getSortOrder() });
+            addRow({ sortOrder: getSortOrder(), rowSaveStatus: RowSaveStatus.PENDING });
           } : null,
           onBlur: () => {
             updateRow(values, rowIndex);

--- a/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
@@ -755,7 +755,7 @@ class AddItemsPage extends Component {
             const savedItemsIds = lineItemsBackendData.map(item => item.id);
             // We are sending item by item to API. Here we have to find
             // newly saved item to replace its equivalent in state
-            const itemToChange = _.differenceBy(lineItemsBackendData, itemCandidatesToSave, 'id')[0];
+            const itemToChange = _.last(_.differenceBy(lineItemsBackendData, itemCandidatesToSave, 'id'));
             const lineItemsAfterSave = this.state.values.lineItems.map((item) => {
               // In this case we check if we're editing item
               // We don't have to disable edited item, because this

--- a/src/js/consts/rowSaveStatus.js
+++ b/src/js/consts/rowSaveStatus.js
@@ -1,6 +1,7 @@
 const RowSaveStatus = {
   SAVED: 'SAVED',
-  PENDING: 'PENDING',
+  PENDING: 'PENDING', // Row is newly created or edited
+  SAVING: 'SAVING',
   ERROR: 'ERROR',
 };
 


### PR DESCRIPTION
In this pr I added:

- Fix for `rowSaveStatus: RowSaveStatus.PENDING` after adding new line using tab or arrows
- Fix for duplicating items when they are being added too fast
- Fix for showing previously added item in next line (connected to previous point)
- Enable next button after using save button when item is not autosaved (i.e when we don't have internet connection and we click save button when connection is restored)

I fixed duplicating item by adding new property in `state`. In this variable we are storing items which were sent and then we are excluding it from checking items to save during next trigger of autosave.