### PR TITLE
OBPIH-5388 Add list of orders as source for RefreshOrderSummaryEvent

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -35,6 +35,7 @@ import org.pih.warehouse.core.LocationTypeCode
 import org.pih.warehouse.core.User
 import org.pih.warehouse.order.Order
 import org.pih.warehouse.order.OrderItem
+import org.pih.warehouse.order.RefreshOrderSummaryEvent
 import org.pih.warehouse.order.ShipOrderCommand
 import org.pih.warehouse.order.ShipOrderItemCommand
 import org.pih.warehouse.picklist.Picklist
@@ -598,7 +599,7 @@ class StockMovementService {
             List<Order> orders = shipmentItem?.purchaseOrders
             removeShipmentItem(shipmentItem)
             // Trigger Order Summary event for POs after deleting the shipment item
-            orders?.each { it.publishRefreshEvent() }
+            publishEvent(new RefreshOrderSummaryEvent(orders))
         }
     }
 
@@ -2066,7 +2067,7 @@ class StockMovementService {
         List<Order> orders = shipment.purchaseOrders
         removeShipmentItems(shipment.shipmentItems)
         // Trigger Order Summary event for POs after deleting the shipment items
-        orders?.each { it.publishRefreshEvent() }
+        publishEvent(new RefreshOrderSummaryEvent(orders))
     }
 
     void removeShipmentItemsForModifiedRequisitionItem(StockMovementItem stockMovementItem) {

--- a/src/groovy/org/pih/warehouse/order/RefreshOrderSummaryEvent.groovy
+++ b/src/groovy/org/pih/warehouse/order/RefreshOrderSummaryEvent.groovy
@@ -23,14 +23,21 @@ class RefreshOrderSummaryEvent extends ApplicationEvent {
 
     RefreshOrderSummaryEvent(Order source) {
         super(source)
-        this.orderIds = source?.id ? [source?.id] : []
+        this.orderIds = source?.id && source?.isPurchaseOrder ? [source?.id] : []
         this.isDelete = isDelete
         this.disableRefresh = disableRefresh
     }
 
     RefreshOrderSummaryEvent(Order source, Boolean isDelete) {
         super(source)
-        this.orderIds = source?.id ? [source?.id] : []
+        this.orderIds = source?.id && source?.isPurchaseOrder ? [source?.id] : []
+        this.isDelete = isDelete
+        this.disableRefresh = disableRefresh
+    }
+
+    RefreshOrderSummaryEvent(List<Order> source) {
+        super(source)
+        this.orderIds = source?.findAll {it?.isPurchaseOrder }?.collect { it.id } ?: []
         this.isDelete = isDelete
         this.disableRefresh = disableRefresh
     }

--- a/src/js/components/stock-movement-wizard/combined-shipments/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/combined-shipments/AddItemsPage.jsx
@@ -787,6 +787,7 @@ class AddItemsPage extends Component {
    */
   removeAll() {
     const removeItemsUrl = `/openboxes/api/stockMovements/${this.state.values.stockMovementId}/removeAllItems`;
+    this.props.showSpinner();
 
     return apiClient.delete(removeItemsUrl)
       .then(() => {
@@ -796,10 +797,11 @@ class AddItemsPage extends Component {
             ...this.state.values,
             lineItems: [],
           },
-        });
+        }, () => this.props.hideSpinner());
       })
       .catch(() => {
         this.fetchLineItems();
+        this.props.hideSpinner();
         return Promise.reject(new Error('react.stockMovement.error.deleteRequisitionItem.label'));
       });
   }


### PR DESCRIPTION
This improves refreshing after removing shipment item or all shipment items on combined shipments for multiple POs.