### PR TITLE
OBPIH-5502 Refactor product translations to use displayName instead of translatedName (scope: invoice, requests, receiving) [React]

### DIFF
--- a/grails-app/domain/org/pih/warehouse/invoice/InvoiceItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/invoice/InvoiceItem.groovy
@@ -175,7 +175,7 @@ class InvoiceItem implements Serializable {
                 totalPrepaymentAmount: totalPrepaymentAmount,
                 orderAdjustment: orderAdjustment,
                 productName: product?.name,
-                translatedProductName: product?.translatedName
+                displayNames: product?.displayNames
         ]
     }
 }

--- a/grails-app/domain/org/pih/warehouse/invoice/InvoiceItemCandidate.groovy
+++ b/grails-app/domain/org/pih/warehouse/invoice/InvoiceItemCandidate.groovy
@@ -114,7 +114,7 @@ class InvoiceItemCandidate {
             unitPrice: candidateUnitPrice,
             isAdjustment: adjustment,
             productName: associatedProduct?.name,
-            translatedProductName: associatedProduct?.translatedName
+            displayNames: associatedProduct?.displayNames
         ]
     }
 }

--- a/grails-app/services/org/pih/warehouse/product/ProductService.groovy
+++ b/grails-app/services/org/pih/warehouse/product/ProductService.groovy
@@ -1334,10 +1334,10 @@ class ProductService {
             (
                 select s.name from synonym s
                 where s.product_id = product.id
-                and s.synonym_type_code = 'DISPLAY_NAME'
+                and s.synonym_type_code = '${SynonymTypeCode.DISPLAY_NAME}'
                 and s.locale = '${locale}'
                 limit 1
-            ) as translatedName 
+            ) as displayName
             from product """
 
         if (terms && terms.size() > 0) {

--- a/src/groovy/org/pih/warehouse/api/PartialReceiptItem.groovy
+++ b/src/groovy/org/pih/warehouse/api/PartialReceiptItem.groovy
@@ -81,7 +81,7 @@ class PartialReceiptItem {
                 "product.id"                    : inventoryItem?.product?.id,
                 "product.productCode"           : inventoryItem?.product?.productCode,
                 "product.name"                  : inventoryItem?.product?.name,
-                "product.translatedName"        : inventoryItem?.product?.translatedName,
+                "product.displayNames"          : inventoryItem?.product?.displayNames,
                 "product.lotAndExpiryControl"   : inventoryItem?.product?.lotAndExpiryControl,
                 "product.handlingIcons"         : inventoryItem?.product?.handlingIcons,
                 "lotNumber"                     : lotNumber,

--- a/src/groovy/org/pih/warehouse/product/ProductSearchDto.groovy
+++ b/src/groovy/org/pih/warehouse/product/ProductSearchDto.groovy
@@ -8,7 +8,7 @@ class ProductSearchDto {
 
     String name
 
-    String translatedName
+    String displayName
 
     String productCode
 
@@ -45,7 +45,7 @@ class ProductSearchDto {
                 id                 : id,
                 productCode        : productCode,
                 name               : name,
-                translatedName     : translatedName,
+                displayName        : displayName,
                 color              : productColor,
                 handlingIcons      : handlingIcons,
                 lotAndExpiryControl: lotAndExpiryControl,

--- a/src/js/components/invoice/AddItemsPage.jsx
+++ b/src/js/components/invoice/AddItemsPage.jsx
@@ -6,7 +6,6 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { Form } from 'react-final-form';
 import { connect } from 'react-redux';
-import { Tooltip } from 'react-tippy';
 
 import { hideSpinner, showSpinner } from 'actions';
 import ArrayField from 'components/form-elements/ArrayField';
@@ -16,6 +15,7 @@ import TextField from 'components/form-elements/TextField';
 import InvoiceItemsModal from 'components/invoice/InvoiceItemsModal';
 import apiClient from 'utils/apiClient';
 import { renderFormField } from 'utils/form-utils';
+import { getInvoiceDescription } from 'utils/form-values-utils';
 import accountingFormat from 'utils/number-utils';
 import Translate from 'utils/Translate';
 
@@ -118,20 +118,7 @@ const FIELDS = {
             const rowValue = values?.invoiceItems?.[rowIndex];
             // If it's not an adjustment, but product, and it has a synonym, display it
             // with a tooltip with the original name of the product
-            if (!rowValue?.orderAdjustment && rowValue?.translatedProductName) {
-              return (
-                <Tooltip
-                  html={rowValue?.productName}
-                  theme="transparent"
-                  delay="150"
-                  duration="250"
-                  hideDelay="50"
-                >
-                  {rowValue.translatedProductName}
-                </Tooltip>
-              );
-            }
-            return params?.fieldValue;
+            return getInvoiceDescription(rowValue);
           },
         }),
       },

--- a/src/js/components/invoice/ConfirmInvoicePage.jsx
+++ b/src/js/components/invoice/ConfirmInvoicePage.jsx
@@ -15,6 +15,7 @@ import LabelField from 'components/form-elements/LabelField';
 import TextField from 'components/form-elements/TextField';
 import apiClient from 'utils/apiClient';
 import { renderFormField } from 'utils/form-utils';
+import { getInvoiceDescription } from 'utils/form-values-utils';
 import accountingFormat from 'utils/number-utils';
 import Translate from 'utils/Translate';
 
@@ -168,20 +169,7 @@ const INVOICE_ITEMS = {
             const rowValue = values?.invoiceItems?.[rowIndex];
             // If it's not an adjustment, but product, and it has a synonym, display it
             // with a tooltip with the original name of the product
-            if (!rowValue?.orderAdjustment && rowValue?.translatedProductName) {
-              return (
-                <Tooltip
-                  html={rowValue?.productName}
-                  theme="transparent"
-                  delay="150"
-                  duration="250"
-                  hideDelay="50"
-                >
-                  {rowValue.translatedProductName}
-                </Tooltip>
-              );
-            }
-            return params?.fieldValue;
+            return getInvoiceDescription(rowValue);
           },
         }),
       },

--- a/src/js/components/invoice/InvoiceItemsModal.jsx
+++ b/src/js/components/invoice/InvoiceItemsModal.jsx
@@ -5,7 +5,6 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { getTranslate } from 'react-localize-redux';
 import { connect } from 'react-redux';
-import { Tooltip } from 'react-tippy';
 
 import { hideSpinner, showSpinner } from 'actions';
 import ArrayField from 'components/form-elements/ArrayField';
@@ -14,6 +13,7 @@ import ModalWrapper from 'components/form-elements/ModalWrapper';
 import TextField from 'components/form-elements/TextField';
 import apiClient from 'utils/apiClient';
 import Checkbox from 'utils/Checkbox';
+import { getInvoiceDescription } from 'utils/form-values-utils';
 import accountingFormat from 'utils/number-utils';
 import Select from 'utils/Select';
 import { translateWithDefaultMessage } from 'utils/Translate';
@@ -99,20 +99,7 @@ const FIELDS = {
             const rowValue = values?.invoiceItems?.[rowIndex];
             // If it's not an adjustment, but product, and it has a synonym, display it
             // with a tooltip with the original name of the product
-            if (!rowValue?.isAdjustment && rowValue?.translatedProductName) {
-              return (
-                <Tooltip
-                  html={rowValue?.productName}
-                  theme="transparent"
-                  delay="150"
-                  duration="250"
-                  hideDelay="50"
-                >
-                  {rowValue.translatedProductName}
-                </Tooltip>
-              );
-            }
-            return params?.fieldValue;
+            return getInvoiceDescription(rowValue);
           },
         }),
       },

--- a/src/js/components/product-select/ProductSelect.jsx
+++ b/src/js/components/product-select/ProductSelect.jsx
@@ -12,7 +12,7 @@ const Option = option => (
   <Tooltip
     html={<div className="text-truncate">{option.name}</div>}
     theme="transparent"
-    disabled={!option.hasDisplayName}
+    disabled={!option.displayName}
     position="top-start"
   >
     <strong style={{ color: option.color || 'black' }} className="d-flex align-items-center">

--- a/src/js/components/product-select/ProductSelect.jsx
+++ b/src/js/components/product-select/ProductSelect.jsx
@@ -12,7 +12,7 @@ const Option = option => (
   <Tooltip
     html={<div className="text-truncate">{option.name}</div>}
     theme="transparent"
-    disabled={!option.hasTranslatedName}
+    disabled={!option.hasDisplayName}
     position="top-start"
   >
     <strong style={{ color: option.color || 'black' }} className="d-flex align-items-center">
@@ -25,7 +25,7 @@ const Option = option => (
 const SelectedValue = option => (
   <span className="d-flex align-items-center">
     <span className="text-truncate">
-      {option.label || `${option.productCode} - ${option.translatedName || option.name}`}
+      {option.label || `${option.productCode} - ${option.displayName || option.displayNames?.default || option.name}`}
     </span>
     {renderHandlingIcons(option?.handlingIcons)}
   </span>

--- a/src/js/components/receiving/PartialReceivingPage.jsx
+++ b/src/js/components/receiving/PartialReceivingPage.jsx
@@ -166,7 +166,7 @@ const TABLE_FIELDS = {
         attributes: {
           className: 'text-left ml-1',
           showValueTooltip: true,
-          formatValue: value => getReceivingItemValue(value),
+          formatValue: getReceivingItemValue,
         },
         getDynamicAttr: ({ fieldValue }) => ({
           tooltipValue: fieldValue?.name,

--- a/src/js/components/receiving/PartialReceivingPage.jsx
+++ b/src/js/components/receiving/PartialReceivingPage.jsx
@@ -19,7 +19,7 @@ import EditLineModal from 'components/receiving/modals/EditLineModal';
 import apiClient, { flattenRequest, parseResponse } from 'utils/apiClient';
 import Checkbox from 'utils/Checkbox';
 import { renderFormField } from 'utils/form-utils';
-import renderHandlingIcons from 'utils/product-handling-icons';
+import { getReceivingItemValue, getReceivingPayloadContainers } from 'utils/form-values-utils';
 import Select from 'utils/Select';
 import Translate, { translateWithDefaultMessage } from 'utils/Translate';
 
@@ -166,11 +166,7 @@ const TABLE_FIELDS = {
         attributes: {
           className: 'text-left ml-1',
           showValueTooltip: true,
-          formatValue: value => (
-            <div className="d-flex">
-              {value?.translatedName ?? value?.name}
-              {renderHandlingIcons(value?.handlingIcons)}
-            </div>),
+          formatValue: value => getReceivingItemValue(value),
         },
         getDynamicAttr: ({ fieldValue }) => ({
           tooltipValue: fieldValue?.name,
@@ -496,18 +492,7 @@ class PartialReceivingPage extends Component {
 
     const payload = {
       ...formValues,
-      containers: _.map(formValues.containers, container => ({
-        ...container,
-        shipmentItems: _.map(container.shipmentItems, (item) => {
-          if (!_.get(item, 'recipient.id')) {
-            return {
-              ...item, recipient: '',
-            };
-          }
-
-          return item;
-        }),
-      })),
+      containers: getReceivingPayloadContainers(formValues),
     };
     return apiClient.post(url, flattenRequest(payload));
   }
@@ -646,18 +631,7 @@ class PartialReceivingPage extends Component {
     const payload = {
       receiptStatus: 'CHECKING',
       ...formValues,
-      containers: _.map(formValues.containers, container => ({
-        ...container,
-        shipmentItems: _.map(container.shipmentItems, (item) => {
-          if (!_.get(item, 'recipient.id')) {
-            return {
-              ...item, recipient: '',
-            };
-          }
-
-          return item;
-        }),
-      })),
+      containers: getReceivingPayloadContainers(formValues),
     };
 
     return apiClient.post(url, flattenRequest(payload));

--- a/src/js/components/receiving/ReceivingCheckScreen.jsx
+++ b/src/js/components/receiving/ReceivingCheckScreen.jsx
@@ -106,7 +106,7 @@ const TABLE_FIELDS = {
         attributes: {
           className: 'text-left ml-1',
           showValueTooltip: true,
-          formatValue: value => getReceivingItemValue(value),
+          formatValue: getReceivingItemValue,
         },
         getDynamicAttr: ({ fieldValue }) => ({
           tooltipValue: fieldValue?.name,

--- a/src/js/components/receiving/ReceivingCheckScreen.jsx
+++ b/src/js/components/receiving/ReceivingCheckScreen.jsx
@@ -18,7 +18,7 @@ import TableRowWithSubfields from 'components/form-elements/TableRowWithSubfield
 import TextField from 'components/form-elements/TextField';
 import apiClient, { flattenRequest, parseResponse } from 'utils/apiClient';
 import { renderFormField } from 'utils/form-utils';
-import renderHandlingIcons from 'utils/product-handling-icons';
+import { getReceivingItemValue, getReceivingPayloadContainers } from 'utils/form-values-utils';
 import Translate from 'utils/Translate';
 
 
@@ -106,11 +106,7 @@ const TABLE_FIELDS = {
         attributes: {
           className: 'text-left ml-1',
           showValueTooltip: true,
-          formatValue: value => (
-            <div className="d-flex">
-              {value?.translatedName ?? value?.name}
-              {renderHandlingIcons(value?.handlingIcons)}
-            </div>),
+          formatValue: value => getReceivingItemValue(value),
         },
         getDynamicAttr: ({ fieldValue }) => ({
           tooltipValue: fieldValue?.name,
@@ -357,18 +353,7 @@ class ReceivingCheckScreen extends Component {
 
     const payload = {
       ...formValues,
-      containers: _.map(formValues.containers, container => ({
-        ...container,
-        shipmentItems: _.map(container.shipmentItems, (item) => {
-          if (!_.get(item, 'recipient.id')) {
-            return {
-              ...item, recipient: '',
-            };
-          }
-
-          return item;
-        }),
-      })),
+      containers: getReceivingPayloadContainers(formValues),
     };
 
     return apiClient.post(url, flattenRequest(payload));

--- a/src/js/utils/Select.jsx
+++ b/src/js/utils/Select.jsx
@@ -107,7 +107,7 @@ class Select extends Component {
       multi, placeholder, showLabelTooltip, value, defaultPlaceholder,
     } = this.props;
 
-    if (value?.displayNames?.default || value?.hasDisplayName) {
+    if (value?.displayNames?.default || value?.displayName) {
       return (
         <div className="p-1">
           {value?.name}

--- a/src/js/utils/Select.jsx
+++ b/src/js/utils/Select.jsx
@@ -107,11 +107,7 @@ class Select extends Component {
       multi, placeholder, showLabelTooltip, value, defaultPlaceholder,
     } = this.props;
 
-    // TODO: We should change this in the future
-    // to check only hasTranslatedName, but for now
-    // we don't have hasTranslatedName in all mappings
-    // discussion connected to OBPIH-5148
-    if (value?.translatedName || value?.hasTranslatedName) {
+    if (value?.displayNames?.default || value?.hasDisplayName) {
       return (
         <div className="p-1">
           {value?.name}
@@ -275,7 +271,7 @@ class Select extends Component {
     const isTooltipDisabled = () => {
       const { value: fieldValue } = this.props;
 
-      if (fieldValue?.translatedName || showLabelTooltip) {
+      if (fieldValue?.displayName || showLabelTooltip) {
         return false;
       }
 

--- a/src/js/utils/form-values-utils.jsx
+++ b/src/js/utils/form-values-utils.jsx
@@ -6,7 +6,7 @@ import { Tooltip } from 'react-tippy';
 import renderHandlingIcons from 'utils/product-handling-icons';
 
 export const getInvoiceDescription = (rowValue) => {
-  if (!rowValue?.orderAdjustment && rowValue?.displayNames?.default) {
+  if (!rowValue?.orderAdjustment && !rowValue.isAdjustment && rowValue?.displayNames?.default) {
     return (
       <Tooltip
         html={rowValue?.productName}

--- a/src/js/utils/form-values-utils.jsx
+++ b/src/js/utils/form-values-utils.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import _ from 'lodash';
+import { Tooltip } from 'react-tippy';
+
+import renderHandlingIcons from 'utils/product-handling-icons';
+
+export const getInvoiceDescription = (rowValue) => {
+  if (!rowValue?.orderAdjustment && rowValue?.displayNames?.default) {
+    return (
+      <Tooltip
+        html={rowValue?.productName}
+        theme="transparent"
+        delay="150"
+        duration="250"
+        hideDelay="50"
+      >
+        {rowValue.displayNames?.default}
+      </Tooltip>
+    );
+  }
+  return rowValue?.description;
+};
+
+export const getReceivingItemValue = rowValue => (
+  <div className="d-flex">
+    {rowValue?.displayNames?.default ?? rowValue?.name}
+    {renderHandlingIcons(rowValue?.handlingIcons)}
+  </div>);
+
+
+export const getReceivingPayloadContainers = formValues =>
+  _.map(formValues.containers, container => ({
+    ...container,
+    shipmentItems: _.map(container.shipmentItems, (item) => {
+      if (!_.get(item, 'recipient.id')) {
+        return _.omit({
+          ...item, recipient: '',
+        }, 'product.displayNames');
+      }
+      /** We have to omit product.displayNames, due to an error
+       *  while binding bindData(partialReceiptItem, shipmentItemMap)
+       *  it expects product.displayNames to have a setter, as we pass
+       *  product.displayNames.default: XYZ, to the update method, but it's not a
+       *  writable property.
+       *  With deprecated product.translatedName it was not the case, because
+       *  it was recognizing the transient and we didn't access product.translatedName.something
+       *  but product.translatedName directly
+       * */
+      return _.omit(item, 'product.displayNames');
+    }),
+  }));

--- a/src/js/utils/option-utils.jsx
+++ b/src/js/utils/option-utils.jsx
@@ -90,7 +90,7 @@ export const debounceProductsFetch = (waitTime, minSearchLength, locationId) =>
             handlingIcons: obj.handlingIcons,
             lotAndExpiryControl: obj.lotAndExpiryControl,
             label: `${obj.productCode} - ${obj.displayName ?? obj.name}`,
-            hasDisplayName: !!obj.displayName,
+            displayName: obj.displayName,
             color: obj.color,
             exactMatch: obj.exactMatch,
           }

--- a/src/js/utils/option-utils.jsx
+++ b/src/js/utils/option-utils.jsx
@@ -89,8 +89,8 @@ export const debounceProductsFetch = (waitTime, minSearchLength, locationId) =>
             productCode: obj.productCode,
             handlingIcons: obj.handlingIcons,
             lotAndExpiryControl: obj.lotAndExpiryControl,
-            label: `${obj.productCode} - ${obj.translatedName ?? obj.name}`,
-            hasTranslatedName: !!obj.translatedName,
+            label: `${obj.productCode} - ${obj.displayName ?? obj.name}`,
+            hasDisplayName: !!obj.displayName,
             color: obj.color,
             exactMatch: obj.exactMatch,
           }


### PR DESCRIPTION
Scope:

- invoice
- request
- receiving
- product select global refactor

Those include only changes on React side, as GSP view pages will be done in other ticket and also it was blocked by the refactor of `<format:displayName>` ticket.