### PR TITLE
OBPIH-5502 Fix accessing .isAdjusment from an undefined object at the…

### DIFF
--- a/src/js/utils/form-values-utils.jsx
+++ b/src/js/utils/form-values-utils.jsx
@@ -6,7 +6,7 @@ import { Tooltip } from 'react-tippy';
 import renderHandlingIcons from 'utils/product-handling-icons';
 
 export const getInvoiceDescription = (rowValue) => {
-  if (!rowValue?.orderAdjustment && !rowValue.isAdjustment && rowValue?.displayNames?.default) {
+  if (!rowValue?.orderAdjustment && !rowValue?.isAdjustment && rowValue?.displayNames?.default) {
     return (
       <Tooltip
         html={rowValue?.productName}


### PR DESCRIPTION
… invoice modal

Fixes after QA - the blank page was appearing when trying to filter by shipment at the invoice modal due to not having null safe operator at the `.isAdjustment` which I missed