### PR TITLE
OBPIH-5471 Unable to add/edit inventory levels on new staging

### DIFF
--- a/grails-app/views/inventoryLevel/_form.gsp
+++ b/grails-app/views/inventoryLevel/_form.gsp
@@ -64,7 +64,7 @@
                         <g:hiddenField name="location.id" value="${locationInstance?.id}"/>
                         <g:select name="displayLocation.id" from="${[locationInstance]}"
                             optionKey="id" optionValue="${{format.metadata(obj:it)}}" class="chzn-select-deselect"
-                                                  value="${locationInstance.id}" disabled="${true}"/>
+                                                  value="${locationInstance?.id}" disabled="${true}"/>
                     </td>
                 </tr>
                 <tr class="prop">

--- a/grails-app/views/product/_summaryDialog.gsp
+++ b/grails-app/views/product/_summaryDialog.gsp
@@ -7,7 +7,7 @@
                     <g:if test="${productInstance?.images }">
                         <div class="nailthumb-product">
                             <g:set var="image" value="${productInstance?.images?.sort()?.first()}"/>
-                            <img src="${createLink(controller:'product', action:'renderImage', id:image.id)}" style="display:none" />
+                            <img src="${createLink(controller:'product', action:'renderImage', id:image?.id)}" style="display:none" />
                         </div>
                     </g:if>
                     <g:else>
@@ -32,7 +32,7 @@
 				<td class="right" width="1%">
 					<div id="product-status" class="title">
 						<g:if test="${productInstance?.active}">
-							<g:productStatus product="${productInstance.id}"/>
+							<g:productStatus product="${productInstance?.id}"/>
 						</g:if>
 						<g:else>
 							<span class="tag tag-danger"><g:message code="default.inactive.label"/></span>

--- a/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
@@ -1226,7 +1226,8 @@ class AddItemsPage extends Component {
                   onMouseDown={() => {
                     if (
                       _.some(values.lineItems, lineItem =>
-                        lineItem.rowSaveStatus === RowSaveStatus.PENDING)
+                        lineItem.rowSaveStatus === RowSaveStatus.PENDING &&
+                        lineItem.product)
                     ) {
                       this.showPendingSaveNotification();
                       return;

--- a/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
@@ -1226,8 +1226,7 @@ class AddItemsPage extends Component {
                   onMouseDown={() => {
                     if (
                       _.some(values.lineItems, lineItem =>
-                        lineItem.rowSaveStatus === RowSaveStatus.PENDING &&
-                        lineItem.product)
+                        lineItem.rowSaveStatus === RowSaveStatus.PENDING)
                     ) {
                       this.showPendingSaveNotification();
                       return;


### PR DESCRIPTION
The issue is not reproducible for me locally. The issue is not even (don't know why) reproducible on obstg, but is still reproducible on obdev1.
I went through the code and "potential candidates" that might cause this `NullPointerException`, but what worries me that on the obdev1 you can only see:

![Screenshot from 2023-03-20 17-25-01](https://user-images.githubusercontent.com/93163821/226404924-c6edb1d0-ef1a-4ff3-8e73-a06b9e03e2b1.png)

Whereas when I was trying to "manipulate" code a bit, to cause all possible NullPointers, I was always getting a detailed message:
![Screenshot from 2023-03-20 16-14-05](https://user-images.githubusercontent.com/93163821/226405185-e69f0417-8b60-4664-a820-0055977df6b9.png)

So I'm not really convinced if the issue is strictly connected to any of those "candidates" or to some maybe mismatching between database and code, but anyway - @mdpearson - the issue seems to have fixed itself on the obstg, if it might help you, but is still visible on the obdev1.

What I tried:

- went through the `inventoryLevel/_form.gsp` and manipulated the code a bit to cause NullPointers, e.g. in 2nd line changed the value to `null`, same in line 3rd, 11 (`productInstance: null`)
- in `InventoryLevelController` in `def dialog`:
```groovy
render(template: "form", model: [inventoryLevelInstance: inventoryLevelInstance, productInstance: productInstance])
```
I changed `inventoryLevelInstance` to `null` - it caused `NullPointerException`, but I got a detailed message why.
As for `productInstance: null` - I got an infinite spinner inside the dialog.

