### PR TITLE
OBGM-419 Update node plugin to, among other things, build cleanly on remote agents

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ plugins {
     id 'com.gorylenko.gradle-git-properties' version '2.2.4'
 
     // enable `npmInstall` and `npm_run_*` targets, and the `node` block below
-    id 'com.moowork.node' version '1.3.1'
+    id 'com.github.node-gradle.node' version '1.5.3'
 
     // resolve a Windows-specific build issue
     id 'com.virgo47.ClasspathJar' version '1.0.0'
@@ -348,7 +348,7 @@ node {
     distBaseUrl = 'https://nodejs.org/dist'
     download = true
     npmVersion = '6.14.18'
-    version = '14.21.2'
+    version = '14.21.3'
 }
 
 processResources {


### PR DESCRIPTION
Minor tweak to support remote agents on the new Bamboo server, since the old one seems dead