### PR TITLE
OBPIH-5324 Track unsaved changes when falling online to offline (fixes after QA)

### DIFF
--- a/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
@@ -429,7 +429,7 @@ class AddItemsPage extends Component {
         key => key !== 'product',
       );
 
-      if (newQty === oldQty) {
+      if (newQty === oldQty && newRecipient === oldRecipient) {
         this.setState(prev => ({
           values: {
             ...prev.values,

--- a/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
@@ -514,11 +514,13 @@ class AddItemsPage extends Component {
     this.setState({
       values: {
         ...this.state.values,
-        lineItems: this.props.savedStockMovement.lineItems,
+        lineItems: this.props.savedStockMovement.lineItems
+          .map(item => ({ ...item, rowSaveStatus: RowSaveStatus.PENDING })),
       },
       totalCount: this.props.savedStockMovement.lineItems.length,
       isDraftAvailable: false,
     });
+    this.saveRequisitionItemsInCurrentStep(this.props.savedStockMovement.lineItems, true);
     this.props.hideSpinner();
   }
 


### PR DESCRIPTION
Fix for incorrect coloring after editing recipient: 
When we set the quantity to positive number, the line will be autosaved. After changing to negative number, we don't trigger autosave, because there is no need for sending this line, I just set the `rowSaveStatus` to `ERROR`. When we fix the number to the same quantity as we had previously it will become green, because it is actually saved number. Within this activity I didn't take changing recipient into account, so when we changed only recipient (leaving quantity as it is) we mapped line to `SAVED`.
Fix for saving lines after clicking on available draft:
It's just triggering function for saving, and mapping all of the not saved lines to `SAVING`. The new edited / added lines will become colors connected to their statuses.