### PR TITLE
OBPIH-5222 / OBPIH-5560 Import and Export files for products with special characters

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -173,6 +173,7 @@ grails.project.dependency.resolution = {
         compile 'org.xhtmlrenderer:flying-saucer-core:9.1.15'
         compile 'org.xhtmlrenderer:flying-saucer-pdf-openpdf:9.1.15'
         compile 'com.github.librepdf:openpdf:1.2.0'
+        compile 'com.github.albfernandez:juniversalchardet:2.4.0'
     }
     plugins {
 

--- a/grails-app/controllers/org/pih/warehouse/JsonController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/JsonController.groovy
@@ -1862,7 +1862,7 @@ class JsonController {
                 }
 
                 response.setHeader("Content-disposition", "attachment; filename=\"Request-Detail-Report.csv\"")
-                render(contentType: "text/csv", text: CSVUtils.prependBOMToCSVString(sw.toString()), encoding: "UTF-8")
+                render(contentType: "text/csv", text: CSVUtils.prependBomToCsvString(sw.toString()), encoding: "UTF-8")
                 return
             }
             render([aaData: data] as JSON)

--- a/grails-app/controllers/org/pih/warehouse/JsonController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/JsonController.groovy
@@ -1862,7 +1862,7 @@ class JsonController {
                 }
 
                 response.setHeader("Content-disposition", "attachment; filename=\"Request-Detail-Report.csv\"")
-                render(contentType: "text/csv", text: CSVUtils.addBOMToCSVString(sw.toString()), encoding: "UTF-8")
+                render(contentType: "text/csv", text: CSVUtils.prependBOMToCSVString(sw.toString()), encoding: "UTF-8")
                 return
             }
             render([aaData: data] as JSON)

--- a/grails-app/controllers/org/pih/warehouse/JsonController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/JsonController.groovy
@@ -26,6 +26,7 @@ import org.pih.warehouse.core.Person
 import org.pih.warehouse.core.Tag
 import org.pih.warehouse.core.User
 import org.pih.warehouse.core.ValidationCode
+import org.pih.warehouse.importer.CSVUtils
 import org.pih.warehouse.inventory.InventoryItem
 import org.pih.warehouse.inventory.InventoryStatus
 import org.pih.warehouse.inventory.Transaction
@@ -1861,7 +1862,7 @@ class JsonController {
                 }
 
                 response.setHeader("Content-disposition", "attachment; filename=\"Request-Detail-Report.csv\"")
-                render(contentType: "text/csv", text: sw.toString(), encoding: "UTF-8")
+                render(contentType: "text/csv", text: CSVUtils.addBOMToCSVString(sw.toString()), encoding: "UTF-8")
                 return
             }
             render([aaData: data] as JSON)

--- a/grails-app/controllers/org/pih/warehouse/api/LocationApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/LocationApiController.groovy
@@ -260,7 +260,7 @@ class LocationApiController extends BaseDomainApiController {
         def csv = "id,name,active,locationNumber,locationType,locationGroup,parentLocation,organization,streetAddress,streetAddress2,city,stateOrProvince,postalCode,country,description\n"
 
         response.setHeader("Content-disposition", "attachment; filename=\"Location_template.csv\"")
-        render(contentType: "text/csv", text: CSVUtils.addBOMToCSVString(csv.toString()), encoding: "UTF-8")
+        render(contentType: "text/csv", text: CSVUtils.prependBOMToCSVString(csv.toString()), encoding: "UTF-8")
     }
 
     def importCsv = { ImportDataCommand command ->

--- a/grails-app/controllers/org/pih/warehouse/api/LocationApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/LocationApiController.groovy
@@ -19,6 +19,7 @@ import org.pih.warehouse.core.LocationRole
 import org.pih.warehouse.core.LocationType
 import org.pih.warehouse.core.RoleType
 import org.pih.warehouse.core.User
+import org.pih.warehouse.importer.CSVUtils
 import org.pih.warehouse.importer.ImportDataCommand
 import org.pih.warehouse.inventory.InventoryLevel
 import org.pih.warehouse.product.ProductAvailability
@@ -259,7 +260,7 @@ class LocationApiController extends BaseDomainApiController {
         def csv = "id,name,active,locationNumber,locationType,locationGroup,parentLocation,organization,streetAddress,streetAddress2,city,stateOrProvince,postalCode,country,description\n"
 
         response.setHeader("Content-disposition", "attachment; filename=\"Location_template.csv\"")
-        render(contentType: "text/csv", text: csv.toString(), encoding: "UTF-8")
+        render(contentType: "text/csv", text: CSVUtils.addBOMToCSVString(csv.toString()), encoding: "UTF-8")
     }
 
     def importCsv = { ImportDataCommand command ->

--- a/grails-app/controllers/org/pih/warehouse/api/LocationApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/LocationApiController.groovy
@@ -260,7 +260,7 @@ class LocationApiController extends BaseDomainApiController {
         def csv = "id,name,active,locationNumber,locationType,locationGroup,parentLocation,organization,streetAddress,streetAddress2,city,stateOrProvince,postalCode,country,description\n"
 
         response.setHeader("Content-disposition", "attachment; filename=\"Location_template.csv\"")
-        render(contentType: "text/csv", text: CSVUtils.prependBOMToCSVString(csv.toString()), encoding: "UTF-8")
+        render(contentType: "text/csv", text: CSVUtils.prependBomToCsvString(csv.toString()), encoding: "UTF-8")
     }
 
     def importCsv = { ImportDataCommand command ->

--- a/grails-app/controllers/org/pih/warehouse/inventory/InventoryController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/inventory/InventoryController.groovy
@@ -634,7 +634,7 @@ class InventoryController {
             csv += "\n"
         }
 
-        render(contentType: "text/csv", text: CSVUtils.prependBOMToCSVString(csv))
+        render(contentType: "text/csv", text: CSVUtils.prependBomToCsvString(csv))
     }
 
     def listQuantityOnHandZero = {
@@ -798,7 +798,7 @@ class InventoryController {
             csv += (hasRoleFinance ? (totalValue ?: "") : "")
             csv += "\n"
         }
-        return CSVUtils.prependBOMToCSVString(csv)
+        return CSVUtils.prependBomToCsvString(csv)
     }
 
     def getCsvForProductMap(inventoryItems) {
@@ -849,7 +849,7 @@ class InventoryController {
             csv += (hasRoleFinance ? (totalValue ?: "") : "")
             csv += "\n"
         }
-        return CSVUtils.prependBOMToCSVString(csv)
+        return CSVUtils.prependBomToCsvString(csv)
     }
 
 

--- a/grails-app/controllers/org/pih/warehouse/inventory/InventoryController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/inventory/InventoryController.groovy
@@ -634,7 +634,7 @@ class InventoryController {
             csv += "\n"
         }
 
-        render(contentType: "text/csv", text: CSVUtils.addBOMToCSVString(csv))
+        render(contentType: "text/csv", text: CSVUtils.prependBOMToCSVString(csv))
     }
 
     def listQuantityOnHandZero = {
@@ -798,7 +798,7 @@ class InventoryController {
             csv += (hasRoleFinance ? (totalValue ?: "") : "")
             csv += "\n"
         }
-        return CSVUtils.addBOMToCSVString(csv)
+        return CSVUtils.prependBOMToCSVString(csv)
     }
 
     def getCsvForProductMap(inventoryItems) {
@@ -849,7 +849,7 @@ class InventoryController {
             csv += (hasRoleFinance ? (totalValue ?: "") : "")
             csv += "\n"
         }
-        return CSVUtils.addBOMToCSVString(csv)
+        return CSVUtils.prependBOMToCSVString(csv)
     }
 
 

--- a/grails-app/controllers/org/pih/warehouse/inventory/InventoryController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/inventory/InventoryController.groovy
@@ -22,6 +22,7 @@ import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.Tag
 import org.pih.warehouse.core.User
+import org.pih.warehouse.importer.CSVUtils
 import org.pih.warehouse.importer.InventoryExcelImporter
 import org.pih.warehouse.product.Category
 import org.pih.warehouse.product.Product
@@ -248,7 +249,7 @@ class InventoryController {
                 response.contentType = "text/csv"
                 def csv = inventoryService.exportBaselineQoH(command.products, quantityMapByDate)
                 println "export products: " + csv
-                render csv
+                render(contentType: "text/csv", text:  csv, encoding: "UTF-8")
             } else {
                 render(text: 'No products found', status: 404)
             }
@@ -633,7 +634,7 @@ class InventoryController {
             csv += "\n"
         }
 
-        render(contentType: "text/csv", text: csv)
+        render(contentType: "text/csv", text: CSVUtils.addBOMToCSVString(csv))
     }
 
     def listQuantityOnHandZero = {
@@ -797,7 +798,7 @@ class InventoryController {
             csv += (hasRoleFinance ? (totalValue ?: "") : "")
             csv += "\n"
         }
-        return csv
+        return CSVUtils.addBOMToCSVString(csv)
     }
 
     def getCsvForProductMap(inventoryItems) {
@@ -848,7 +849,7 @@ class InventoryController {
             csv += (hasRoleFinance ? (totalValue ?: "") : "")
             csv += "\n"
         }
-        return csv
+        return CSVUtils.addBOMToCSVString(csv)
     }
 
 

--- a/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
@@ -782,7 +782,7 @@ class ProductController {
                     "attachment; filename=\"Products-${date.format("yyyyMMdd-hhmmss")}.csv\"")
             response.contentType = "text/csv"
             println "export products: " + csv
-            render csv
+            render(contentType: "text/csv", text: csv)
         } else {
             response.sendError(404)
         }
@@ -800,7 +800,7 @@ class ProductController {
             response.setHeader("Content-disposition",
                     "attachment; filename=\"Products-${new Date().format("yyyyMMdd-hhmmss")}.csv\"")
             response.contentType = "text/csv"
-            render csv
+            render(contentType: "text/csv", text: csv)
         } else {
             render(text: 'No products found', status: 404)
         }

--- a/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
@@ -859,7 +859,7 @@ class ProductController {
                     uploadFile?.transferTo(localFile)
                     session.localFile = localFile
                     //Detect CSV encoding
-                    String fileEncoding = CSVUtils.detectCSVCharset(localFile)
+                    String fileEncoding = CSVUtils.detectCsvCharset(localFile)
                     // Get CSV content in UTF-8 encoding
                     def csv = localFile.getText(fileEncoding)
 
@@ -907,7 +907,7 @@ class ProductController {
 
         if (params.importNow && session.localFile) {
             try {
-                String fileEncoding = CSVUtils.detectCSVCharset(session.localFile)
+                String fileEncoding = CSVUtils.detectCsvCharset(session.localFile)
                 def csv = session.localFile.getText(fileEncoding)
 
                 // Get columns

--- a/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
@@ -859,7 +859,7 @@ class ProductController {
                     uploadFile?.transferTo(localFile)
                     session.localFile = localFile
                     //Detect CSV encoding
-                    String fileEncoding = CSVUtils.detectCSVCharset(localFile) ?: "MacRoman"
+                    String fileEncoding = CSVUtils.detectCSVCharset(localFile)
                     // Get CSV content in UTF-8 encoding
                     def csv = localFile.getText(fileEncoding)
 
@@ -907,7 +907,7 @@ class ProductController {
 
         if (params.importNow && session.localFile) {
             try {
-                String fileEncoding = CSVUtils.detectCSVCharset(session.localFile) ?: "MacRoman"
+                String fileEncoding = CSVUtils.detectCSVCharset(session.localFile)
                 def csv = session.localFile.getText(fileEncoding)
 
                 // Get columns

--- a/grails-app/controllers/org/pih/warehouse/product/ProductSupplierController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductSupplierController.groovy
@@ -394,7 +394,7 @@ class ProductSupplierController {
                 response.contentType = "text/csv"
                 response.setHeader("Content-disposition",
                     "attachment; filename=\"ProductSuppliers-${new Date().format("yyyyMMdd-hhmmss")}.csv\"")
-                render dataService.generateCsv(data)
+                render(contentType: "text/csv", text: dataService.generateCsv(data))
                 response.outputStream.flush()
                 return;
         }

--- a/grails-app/controllers/org/pih/warehouse/reporting/ReportController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/reporting/ReportController.groovy
@@ -16,6 +16,7 @@ import org.grails.plugins.csv.CSVWriter
 import org.pih.warehouse.api.StockMovement
 import org.pih.warehouse.api.StockMovementItem
 import org.pih.warehouse.core.Location
+import org.pih.warehouse.importer.CSVUtils
 import org.pih.warehouse.inventory.InventoryLevel
 import org.pih.warehouse.inventory.Transaction
 import org.pih.warehouse.order.OrderItem
@@ -514,7 +515,7 @@ class ReportController {
                 }
 
                 response.setHeader("Content-disposition", "attachment; filename=\"Detailed-Order-Report-${new Date().format("MM/dd/yyyy")}.csv\"")
-                render(contentType: "text/csv", text: sw.toString(), encoding: "UTF-8")
+                render(contentType: "text/csv", text: CSVUtils.addBOMToCSVString(sw.toString()), encoding: "UTF-8")
             }
         } else if(params.downloadAction == "downloadSummaryOnOrderReport") {
             def location = Location.get(session.warehouse.id)
@@ -537,7 +538,7 @@ class ReportController {
                 data = data.sort { it.productCode }
                 csv.writeAll(data)
                 response.setHeader("Content-disposition", "attachment; filename=\"Detailed-Order-Report-${new Date().format("MM/dd/yyyy")}.csv\"")
-                render(contentType: "text/csv", text: sw.toString(), encoding: "UTF-8")
+                render(contentType: "text/csv", text: CSVUtils.addBOMToCSVString(sw.toString()), encoding: "UTF-8")
             }
         }
     }
@@ -599,7 +600,7 @@ class ReportController {
             }
 
             response.setHeader("Content-disposition", "attachment; filename=\"Inventory-by-location-${new Date().format("yyyyMMdd-hhmmss")}.csv\"")
-            render(contentType: "text/csv", text: sw.toString(), encoding: "UTF-8")
+            render(contentType: "text/csv", text: CSVUtils.addBOMToCSVString(sw.toString()), encoding: "UTF-8")
         }
 
         render(view: 'showInventoryByLocationReport', model: [command: command])

--- a/grails-app/controllers/org/pih/warehouse/reporting/ReportController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/reporting/ReportController.groovy
@@ -515,7 +515,7 @@ class ReportController {
                 }
 
                 response.setHeader("Content-disposition", "attachment; filename=\"Detailed-Order-Report-${new Date().format("MM/dd/yyyy")}.csv\"")
-                render(contentType: "text/csv", text: CSVUtils.addBOMToCSVString(sw.toString()), encoding: "UTF-8")
+                render(contentType: "text/csv", text: CSVUtils.prependBOMToCSVString(sw.toString()), encoding: "UTF-8")
             }
         } else if(params.downloadAction == "downloadSummaryOnOrderReport") {
             def location = Location.get(session.warehouse.id)
@@ -538,7 +538,7 @@ class ReportController {
                 data = data.sort { it.productCode }
                 csv.writeAll(data)
                 response.setHeader("Content-disposition", "attachment; filename=\"Detailed-Order-Report-${new Date().format("MM/dd/yyyy")}.csv\"")
-                render(contentType: "text/csv", text: CSVUtils.addBOMToCSVString(sw.toString()), encoding: "UTF-8")
+                render(contentType: "text/csv", text: CSVUtils.prependBOMToCSVString(sw.toString()), encoding: "UTF-8")
             }
         }
     }
@@ -600,7 +600,7 @@ class ReportController {
             }
 
             response.setHeader("Content-disposition", "attachment; filename=\"Inventory-by-location-${new Date().format("yyyyMMdd-hhmmss")}.csv\"")
-            render(contentType: "text/csv", text: CSVUtils.addBOMToCSVString(sw.toString()), encoding: "UTF-8")
+            render(contentType: "text/csv", text: CSVUtils.prependBOMToCSVString(sw.toString()), encoding: "UTF-8")
         }
 
         render(view: 'showInventoryByLocationReport', model: [command: command])

--- a/grails-app/controllers/org/pih/warehouse/reporting/ReportController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/reporting/ReportController.groovy
@@ -515,7 +515,7 @@ class ReportController {
                 }
 
                 response.setHeader("Content-disposition", "attachment; filename=\"Detailed-Order-Report-${new Date().format("MM/dd/yyyy")}.csv\"")
-                render(contentType: "text/csv", text: CSVUtils.prependBOMToCSVString(sw.toString()), encoding: "UTF-8")
+                render(contentType: "text/csv", text: CSVUtils.prependBomToCsvString(sw.toString()), encoding: "UTF-8")
             }
         } else if(params.downloadAction == "downloadSummaryOnOrderReport") {
             def location = Location.get(session.warehouse.id)
@@ -538,7 +538,7 @@ class ReportController {
                 data = data.sort { it.productCode }
                 csv.writeAll(data)
                 response.setHeader("Content-disposition", "attachment; filename=\"Detailed-Order-Report-${new Date().format("MM/dd/yyyy")}.csv\"")
-                render(contentType: "text/csv", text: CSVUtils.prependBOMToCSVString(sw.toString()), encoding: "UTF-8")
+                render(contentType: "text/csv", text: CSVUtils.prependBomToCsvString(sw.toString()), encoding: "UTF-8")
             }
         }
     }
@@ -600,7 +600,7 @@ class ReportController {
             }
 
             response.setHeader("Content-disposition", "attachment; filename=\"Inventory-by-location-${new Date().format("yyyyMMdd-hhmmss")}.csv\"")
-            render(contentType: "text/csv", text: CSVUtils.prependBOMToCSVString(sw.toString()), encoding: "UTF-8")
+            render(contentType: "text/csv", text: CSVUtils.prependBomToCsvString(sw.toString()), encoding: "UTF-8")
         }
 
         render(view: 'showInventoryByLocationReport', model: [command: command])

--- a/grails-app/controllers/org/pih/warehouse/requisition/RequisitionController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/requisition/RequisitionController.groovy
@@ -18,6 +18,7 @@ import org.pih.warehouse.api.AvailableItem
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.Person
 import org.pih.warehouse.core.User
+import org.pih.warehouse.importer.CSVUtils
 import org.pih.warehouse.picklist.Picklist
 import org.pih.warehouse.picklist.PicklistItem
 import org.pih.warehouse.product.Product
@@ -627,7 +628,7 @@ class RequisitionController {
             response.contentType = "text/csv"
             def csv = dataService.exportRequisitions(requisitions)
             println "export requisitions: " + csv
-            render csv
+            render(contentType: "text/csv", text: csv, encoding: "UTF-8")
         } else {
             render(text: 'No requisitions found', status: 404)
         }
@@ -643,7 +644,7 @@ class RequisitionController {
             response.contentType = "text/csv"
             def csv = dataService.exportRequisitionItems(requisitions)
             println "export requisitions: " + csv
-            render csv
+            render(contentType: "text/csv", text: csv, encoding: "UTF-8")
         } else {
             render(text: 'No requisitions found', status: 404)
         }
@@ -659,7 +660,7 @@ class RequisitionController {
             response.contentType = "text/csv"
             def csv = dataService.exportRequisitions(requisitions)
             println "export requisitions: " + csv
-            render csv
+            render(contentType: "text/csv", text: csv, encoding: "UTF-8")
         } else {
             render(text: 'No requisitions found', status: 404)
         }

--- a/grails-app/services/org/pih/warehouse/data/DataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/DataService.groovy
@@ -18,6 +18,7 @@ import org.pih.warehouse.core.ProductPrice
 import org.pih.warehouse.core.UnitOfMeasure
 import org.pih.warehouse.core.UnitOfMeasureClass
 import org.pih.warehouse.core.UnitOfMeasureType
+import org.pih.warehouse.importer.CSVUtils
 import org.pih.warehouse.importer.ImportDataCommand
 import org.pih.warehouse.importer.InventoryLevelExcelImporter
 import org.pih.warehouse.inventory.Inventory
@@ -525,7 +526,7 @@ class DataService {
                     unitOfMeasure     : inventoryLevel?.product?.unitOfMeasure ?: "EA"
             ]
         }
-        return csv.writer.toString()
+        return CSVUtils.addBOMToCSVString(csv.writer.toString())
     }
 
 
@@ -612,7 +613,7 @@ class DataService {
             ]
             csvWriter << row
         }
-        return sw.toString()
+        return CSVUtils.addBOMToCSVString(sw.toString())
     }
 
     String exportRequisitionItems(requisitions) {
@@ -668,7 +669,7 @@ class DataService {
                 csvWriter << row
             }
         }
-        return sw.toString()
+        return CSVUtils.addBOMToCSVString(sw.toString())
     }
 
     def transformObjects(List objects, List includeFields) {
@@ -730,7 +731,7 @@ class DataService {
                 sw.append("\n")
             }
         }
-        return sw.toString()
+        return CSVUtils.addBOMToCSVString(sw.toString())
     }
 
 }

--- a/grails-app/services/org/pih/warehouse/data/DataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/DataService.groovy
@@ -526,7 +526,7 @@ class DataService {
                     unitOfMeasure     : inventoryLevel?.product?.unitOfMeasure ?: "EA"
             ]
         }
-        return CSVUtils.addBOMToCSVString(csv.writer.toString())
+        return CSVUtils.prependBOMToCSVString(csv.writer.toString())
     }
 
 
@@ -613,7 +613,7 @@ class DataService {
             ]
             csvWriter << row
         }
-        return CSVUtils.addBOMToCSVString(sw.toString())
+        return CSVUtils.prependBOMToCSVString(sw.toString())
     }
 
     String exportRequisitionItems(requisitions) {
@@ -669,7 +669,7 @@ class DataService {
                 csvWriter << row
             }
         }
-        return CSVUtils.addBOMToCSVString(sw.toString())
+        return CSVUtils.prependBOMToCSVString(sw.toString())
     }
 
     def transformObjects(List objects, List includeFields) {
@@ -731,7 +731,7 @@ class DataService {
                 sw.append("\n")
             }
         }
-        return CSVUtils.addBOMToCSVString(sw.toString())
+        return CSVUtils.prependBOMToCSVString(sw.toString())
     }
 
 }

--- a/grails-app/services/org/pih/warehouse/data/DataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/DataService.groovy
@@ -526,7 +526,7 @@ class DataService {
                     unitOfMeasure     : inventoryLevel?.product?.unitOfMeasure ?: "EA"
             ]
         }
-        return CSVUtils.prependBOMToCSVString(csv.writer.toString())
+        return CSVUtils.prependBomToCsvString(csv.writer.toString())
     }
 
 
@@ -613,7 +613,7 @@ class DataService {
             ]
             csvWriter << row
         }
-        return CSVUtils.prependBOMToCSVString(sw.toString())
+        return CSVUtils.prependBomToCsvString(sw.toString())
     }
 
     String exportRequisitionItems(requisitions) {
@@ -669,7 +669,7 @@ class DataService {
                 csvWriter << row
             }
         }
-        return CSVUtils.prependBOMToCSVString(sw.toString())
+        return CSVUtils.prependBomToCsvString(sw.toString())
     }
 
     def transformObjects(List objects, List includeFields) {
@@ -731,7 +731,7 @@ class DataService {
                 sw.append("\n")
             }
         }
-        return CSVUtils.prependBOMToCSVString(sw.toString())
+        return CSVUtils.prependBomToCsvString(sw.toString())
     }
 
 }

--- a/src/groovy/org/pih/warehouse/importer/CSVUtils.groovy
+++ b/src/groovy/org/pih/warehouse/importer/CSVUtils.groovy
@@ -179,15 +179,20 @@ class CSVUtils {
         return Constants.DEFAULT_COLUMN_SEPARATOR;
     }
 
-    static String addBOMToCSVString(String csvString) {
+    static String prependBOMToCSVString(String csvString) {
         return '\uFEFF' + csvString
     }
+
+    static String stripBOMIfPresent(String csvString) {
+        return csvString.replace("\uFEFF", "")
+    }
+
 
     static String detectCSVCharset(File file) {
         def detector = new UniversalDetector(null)
         byte[] fileBytes = file.bytes
         detector.handleData(fileBytes, 0, fileBytes.length - 1);
         detector.dataEnd();
-        return detector.getDetectedCharset();
+        return detector.getDetectedCharset() ?: 'MacRoman';
     }
 }

--- a/src/groovy/org/pih/warehouse/importer/CSVUtils.groovy
+++ b/src/groovy/org/pih/warehouse/importer/CSVUtils.groovy
@@ -12,6 +12,7 @@ package org.pih.warehouse.importer
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVPrinter
 import org.apache.commons.lang.StringUtils
+import org.mozilla.universalchardet.UniversalDetector
 import org.grails.plugins.csv.CSVMapReader
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.util.LocalizationUtil
@@ -180,5 +181,13 @@ class CSVUtils {
 
     static String addBOMToCSVString(String csvString) {
         return '\uFEFF' + csvString
+    }
+
+    static String detectCSVCharset(File file) {
+        def detector = new UniversalDetector(null)
+        byte[] fileBytes = file.bytes
+        detector.handleData(fileBytes, 0, fileBytes.length - 1);
+        detector.dataEnd();
+        return detector.getDetectedCharset();
     }
 }

--- a/src/groovy/org/pih/warehouse/importer/CSVUtils.groovy
+++ b/src/groovy/org/pih/warehouse/importer/CSVUtils.groovy
@@ -177,4 +177,8 @@ class CSVUtils {
         }
         return Constants.DEFAULT_COLUMN_SEPARATOR;
     }
+
+    static String addBOMToCSVString(String csvString) {
+        return '\uFEFF' + csvString
+    }
 }

--- a/src/groovy/org/pih/warehouse/importer/CSVUtils.groovy
+++ b/src/groovy/org/pih/warehouse/importer/CSVUtils.groovy
@@ -179,17 +179,17 @@ class CSVUtils {
         return Constants.DEFAULT_COLUMN_SEPARATOR;
     }
 
-    static String prependBOMToCSVString(String csvString) {
+    static String prependBomToCsvString(String csvString) {
         return '\uFEFF' + csvString
     }
 
-    static String stripBOMIfPresent(String csvString) {
+    static String stripBomIfPresent(String csvString) {
         return csvString.replace("\uFEFF", "")
     }
 
 
-    static String detectCSVCharset(File file) {
-        def detector = new UniversalDetector(null)
+    static String detectCsvCharset(File file) {
+        def detector = new UniversalDetector()
         byte[] fileBytes = file.bytes
         detector.handleData(fileBytes, 0, fileBytes.length - 1);
         detector.dataEnd();

--- a/src/groovy/util/ReportUtil.groovy
+++ b/src/groovy/util/ReportUtil.groovy
@@ -2,6 +2,7 @@ package util
 
 import org.apache.commons.lang.StringEscapeUtils
 import org.pih.warehouse.core.Constants
+import org.pih.warehouse.importer.CSVUtils
 
 class ReportUtil {
 
@@ -38,7 +39,7 @@ class ReportUtil {
             csv += "\n"
         }
 
-        return csv
+        return CSVUtils.addBOMToCSVString(csv)
     }
 
 
@@ -59,7 +60,7 @@ class ReportUtil {
                 sb.append(System.lineSeparator())
             }
         }
-        return sb.toString()
+        return CSVUtils.addBOMToCSVString(sb.toString())
     }
 
 
@@ -73,7 +74,7 @@ class ReportUtil {
                 csv += csvRow(entry)
             }
         }
-        return csv
+        return CSVUtils.addBOMToCSVString(csv)
     }
 
 

--- a/src/groovy/util/ReportUtil.groovy
+++ b/src/groovy/util/ReportUtil.groovy
@@ -39,7 +39,7 @@ class ReportUtil {
             csv += "\n"
         }
 
-        return CSVUtils.addBOMToCSVString(csv)
+        return CSVUtils.prependBOMToCSVString(csv)
     }
 
 
@@ -60,7 +60,7 @@ class ReportUtil {
                 sb.append(System.lineSeparator())
             }
         }
-        return CSVUtils.addBOMToCSVString(sb.toString())
+        return CSVUtils.prependBOMToCSVString(sb.toString())
     }
 
 
@@ -74,7 +74,7 @@ class ReportUtil {
                 csv += csvRow(entry)
             }
         }
-        return CSVUtils.addBOMToCSVString(csv)
+        return CSVUtils.prependBOMToCSVString(csv)
     }
 
 

--- a/src/groovy/util/ReportUtil.groovy
+++ b/src/groovy/util/ReportUtil.groovy
@@ -39,7 +39,7 @@ class ReportUtil {
             csv += "\n"
         }
 
-        return CSVUtils.prependBOMToCSVString(csv)
+        return CSVUtils.prependBomToCsvString(csv)
     }
 
 
@@ -60,7 +60,7 @@ class ReportUtil {
                 sb.append(System.lineSeparator())
             }
         }
-        return CSVUtils.prependBOMToCSVString(sb.toString())
+        return CSVUtils.prependBomToCsvString(sb.toString())
     }
 
 
@@ -74,7 +74,7 @@ class ReportUtil {
                 csv += csvRow(entry)
             }
         }
-        return CSVUtils.prependBOMToCSVString(csv)
+        return CSVUtils.prependBomToCsvString(csv)
     }
 
 

--- a/test/integration/org/pih/warehouse/product/ProductServiceIntegrationTests.groovy
+++ b/test/integration/org/pih/warehouse/product/ProductServiceIntegrationTests.groovy
@@ -8,6 +8,7 @@ import org.pih.warehouse.core.Role
 import org.pih.warehouse.core.RoleType
 import org.pih.warehouse.core.Tag
 import org.pih.warehouse.core.User
+import org.pih.warehouse.importer.CSVUtils
 import testutils.DbHelper
 
 class ProductServiceIntegrationTests extends GroovyTestCase {
@@ -327,7 +328,7 @@ class ProductServiceIntegrationTests extends GroovyTestCase {
 
 		// FIXME Export code appends column delimiter for every column (even the last)
 		def expectedHeader = Constants.EXPORT_PRODUCT_COLUMNS.join(",").replace("\n", "") + ","
-		def actualHeader = lines[0].replace("\uFEFF", "")
+		def actualHeader = CSVUtils.stripBOMIfPresent(lines[0])
 		assertNotNull lines
 		assertEquals expectedHeader, actualHeader
 	}
@@ -340,7 +341,7 @@ class ProductServiceIntegrationTests extends GroovyTestCase {
 		def lines = csv.split(/[\r\n]/)
 
 		// Remove quotes
-		def columns = lines[0].replaceAll("\"|\uFEFF", "").split(",")
+		def columns = CSVUtils.stripBOMIfPresent(lines[0]).replaceAll("\"", "").split(",")
 		println columns
 		columns.eachWithIndex { String entry, int i ->
 			assertEquals Constants.EXPORT_PRODUCT_COLUMNS[i], entry

--- a/test/integration/org/pih/warehouse/product/ProductServiceIntegrationTests.groovy
+++ b/test/integration/org/pih/warehouse/product/ProductServiceIntegrationTests.groovy
@@ -328,7 +328,7 @@ class ProductServiceIntegrationTests extends GroovyTestCase {
 
 		// FIXME Export code appends column delimiter for every column (even the last)
 		def expectedHeader = Constants.EXPORT_PRODUCT_COLUMNS.join(",").replace("\n", "") + ","
-		def actualHeader = CSVUtils.stripBOMIfPresent(lines[0])
+		def actualHeader = CSVUtils.stripBomIfPresent(lines[0])
 		assertNotNull lines
 		assertEquals expectedHeader, actualHeader
 	}
@@ -341,7 +341,7 @@ class ProductServiceIntegrationTests extends GroovyTestCase {
 		def lines = csv.split(/[\r\n]/)
 
 		// Remove quotes
-		def columns = CSVUtils.stripBOMIfPresent(lines[0]).replaceAll("\"", "").split(",")
+		def columns = CSVUtils.stripBomIfPresent(lines[0]).replaceAll("\"", "").split(",")
 		println columns
 		columns.eachWithIndex { String entry, int i ->
 			assertEquals Constants.EXPORT_PRODUCT_COLUMNS[i], entry

--- a/test/integration/org/pih/warehouse/product/ProductServiceIntegrationTests.groovy
+++ b/test/integration/org/pih/warehouse/product/ProductServiceIntegrationTests.groovy
@@ -327,7 +327,7 @@ class ProductServiceIntegrationTests extends GroovyTestCase {
 
 		// FIXME Export code appends column delimiter for every column (even the last)
 		def expectedHeader = Constants.EXPORT_PRODUCT_COLUMNS.join(",").replace("\n", "") + ","
-		def actualHeader = lines[0]
+		def actualHeader = lines[0].replace("\uFEFF", "")
 		assertNotNull lines
 		assertEquals expectedHeader, actualHeader
 	}
@@ -340,7 +340,7 @@ class ProductServiceIntegrationTests extends GroovyTestCase {
 		def lines = csv.split(/[\r\n]/)
 
 		// Remove quotes
-		def columns = lines[0].replaceAll("\"", "").split(",")
+		def columns = lines[0].replaceAll("\"|\uFEFF", "").split(",")
 		println columns
 		columns.eachWithIndex { String entry, int i ->
 			assertEquals Constants.EXPORT_PRODUCT_COLUMNS[i], entry


### PR DESCRIPTION
There is solution for two tickets - OBPIH-5222 and OBPIH-5560

OBPIH-5222:
For this ticket I added a BOM to exporting files to allow users on Windows and Mac open files with special characters without problems with displaying them.

OBPIH-5560:
In this PR I fixed importing products with special characters. The main problem was that files from Windows / MacOS have different encodings, so the char codes used in this encodings had different meaning in UTF-8.
To solve this problem I created a function `detectCSVCharset` which takes file as an argument an return its encoding (It have to be a file, because most of the information about encoding is in [file signature](https://profilbaru.com/article/List_of_file_signatures). It is possible to guess the encoding basing only on file content, but it will have lower accuracy). The library which I used for guessing the encoding has two main encoding which we need (Windows-1252, UTF-8), but encoding for MacOS is missing here. ([List of all available encodings](https://github.com/albfernandez/juniversalchardet/blob/main/src/main/java/org/mozilla/universalchardet/Constants.java)). In case when the encoding is not recognized the function for detecting returns `null`. It means that it can be Mac encoding, so I am using this encoding it in this case. This detected encoding is passed as an argument in `getText()` method. Because of that imported products with a different encoding will be saved in database and showed in the import preview correctly. 