### PR TITLE
OBPIH-5560 Can't import products with special characters

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -173,6 +173,7 @@ grails.project.dependency.resolution = {
         compile 'org.xhtmlrenderer:flying-saucer-core:9.1.15'
         compile 'org.xhtmlrenderer:flying-saucer-pdf-openpdf:9.1.15'
         compile 'com.github.librepdf:openpdf:1.2.0'
+        compile 'com.github.albfernandez:juniversalchardet:2.4.0'
     }
     plugins {
 

--- a/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
@@ -24,13 +24,13 @@ import org.pih.warehouse.core.Synonym
 import org.pih.warehouse.core.Tag
 import org.pih.warehouse.core.UploadService
 import org.pih.warehouse.core.User
+import org.pih.warehouse.importer.CSVUtils
 import org.pih.warehouse.importer.ImportDataCommand
 import org.pih.warehouse.importer.ProductSynonymExcelImporter
 import org.pih.warehouse.inventory.InventoryItem
 import org.pih.warehouse.inventory.InventoryLevel
 import org.springframework.web.multipart.MultipartHttpServletRequest
 import org.springframework.web.multipart.commons.CommonsMultipartFile
-import org.springframework.web.servlet.support.RequestContextUtils as RCU
 
 import javax.activation.MimetypesFileTypeMap
 import java.math.RoundingMode
@@ -858,9 +858,11 @@ class ProductController {
                     localFile = uploadService.createLocalFile(uploadFile.originalFilename)
                     uploadFile?.transferTo(localFile)
                     session.localFile = localFile
+                    //Detect CSV encoding
+                    String fileEncoding = CSVUtils.detectCSVCharset(localFile) ?: "MacRoman"
+                    // Get CSV content in UTF-8 encoding
+                    def csv = localFile.getText(fileEncoding)
 
-                    // Get CSV content
-                    def csv = localFile.getText()
                     columns = productService.getColumns(csv)
                     println "CSV " + csv
 

--- a/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
@@ -907,7 +907,8 @@ class ProductController {
 
         if (params.importNow && session.localFile) {
             try {
-                def csv = session.localFile.getText()
+                String fileEncoding = CSVUtils.detectCSVCharset(session.localFile) ?: "MacRoman"
+                def csv = session.localFile.getText(fileEncoding)
 
                 // Get columns
                 columns = productService.getColumns(csv)

--- a/src/groovy/org/pih/warehouse/importer/CSVUtils.groovy
+++ b/src/groovy/org/pih/warehouse/importer/CSVUtils.groovy
@@ -12,6 +12,7 @@ package org.pih.warehouse.importer
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVPrinter
 import org.apache.commons.lang.StringUtils
+import org.mozilla.universalchardet.UniversalDetector
 import org.pih.warehouse.util.LocalizationUtil
 
 import java.text.DecimalFormat
@@ -148,5 +149,13 @@ class CSVUtils {
      */
     static CSVPrinter getCSVPrinter() {
         return new CSVPrinter(new StringBuilder(), CSVFormat.DEFAULT)
+    }
+
+    static String detectCSVCharset(File file) {
+        def detector = new UniversalDetector(null)
+        byte[] fileBytes = file.bytes
+        detector.handleData(fileBytes, 0, fileBytes.length - 1);
+        detector.dataEnd();
+        return detector.getDetectedCharset();
     }
 }


### PR DESCRIPTION
In this PR I fixed importing products with special characters. The main problem was that files from Windows / MacOS have different encodings, so the char codes used in this encodings had different meaning in UTF-8.
To solve this problem I created a function `detectCSVCharset` which takes file as an argument an return its encoding (It have to be a file, because most of the information about encoding is in [file signature](https://profilbaru.com/article/List_of_file_signatures). It is possible to guess the encoding basing only on file content, but it will have lower accuracy). The library which I used for guessing the encoding has two main encoding which we need (Windows-1252, UTF-8), but encoding for MacOS is missing here. ([List of all available encodings](https://github.com/albfernandez/juniversalchardet/blob/main/src/main/java/org/mozilla/universalchardet/Constants.java)). In case when the encoding is not recognized the function for detecting returns `null`. It means that it can be Mac encoding, so I am using this encoding it in this case. This detected encoding is passed as an argument in `getText()` method. Because of that imported products with a different encoding will be saved in database and showed in the import preview correctly. 