### PR TITLE
OBPIH-5379 Add logic to force browser not to cache css file when it changes

### DIFF
--- a/grails-app/views/layouts/custom.gsp
+++ b/grails-app/views/layouts/custom.gsp
@@ -47,7 +47,7 @@
     <jqval:resources />
     <jqvalui:resources />
 
-    <link rel="stylesheet" href="${resource(dir:'css',file:'openboxes.css')}" type="text/css" media="all" />
+    <link rel="stylesheet" href="${resource(dir:'css',file:'openboxes.css')}?v=1" type="text/css" media="all" />
     <link rel="stylesheet" href="${resource(dir:'css',file:'loading.css')}" type="text/css" media="all" />
 
     <!-- jquery validation messages -->


### PR DESCRIPTION
Due to many problems with Tomcat configuration and creating production environment on my local machine, I didn't wanna spend much more time on this ticket, but here are my thoughts after research and investigation of the issue:
### Randomness of the browser
The issue with `openboxes.css` being cached by the browser is not always reproducible - I had times when I could reproduce it 10 times in a row, but there were also times, when the new version of CSS file was always re-fetched.
Fortunately those "10 times in a row" when I could reproduce the issue led me to some thoughts.

### What happens if the file is loaded from cache

![Screenshot from 2023-04-04 11-13-15](https://user-images.githubusercontent.com/93163821/229798151-7602eb24-89f4-4ac0-8857-3688254f778e.png)

next to the response status we can see **(from disk cache)** which means that the file is cached and was not fetched from the server (so that could mean, that we might have an old version of the file).
If the file is re-fetched, we can either see only 200 status.

### What didn't work
I tried some stuff from the resources plugin, but none of those didn't change any behavior in loading css files:
```groovy
grails.resources.adhoc.patterns = ['/css/**']
grails.resources.adhoc.includes = ['**/*.css']
grails.resources.adhoc.options = [cacheSeconds: 0]
```
Removing what we have now:
```groovy
/* Grails resources plugin */
grails.resources.adhoc.includes = []
grails.resources.adhoc.excludes = ["*"]
```
also didn't seem to have any effect.


### What could work, but I didn't now how to achieve that
What could work is somehow setting the `Cache-Control` to `no-cache` or `must-revalidate` for the response header, but I don't know if we can access it, if we don't return the `.css` file from the controller, but in the html file via:
```html
<link rel="stylesheet" href="${resource(dir:'css',file:'openboxes.css')}" type="text/css" media="all" />
```
I manipulated this by marking the Chrome's checkbox "Disable cache", but I know we mustn't expect the user to be using that or to remember to use Ctrl+shift+r:
![Screenshot from 2023-04-04 14-35-50](https://user-images.githubusercontent.com/93163821/229800221-516fe3f7-40c8-438e-b0c0-e83684769985.png)
and you can see that the file was re-fetched.

### The easiest "tricky" solution
The easiest solution that many people recommend and which I did is just by simply adding a query param `?v=1` to the css' href which we just should change (increment) each time we modify the `openboxes.css` - this way the browser "wouldn't know" the file, and it would refetch it from the server whenever the "version" changes.
![Screenshot from 2023-04-04 15-04-41](https://user-images.githubusercontent.com/93163821/229800937-0e7c1243-acc1-420e-a7fd-8160f3f2247d.png)

#### Pros of that solution:

- we don't have to spend more time on researching some deprecated plugins' docs and finding a solution via config
- it's as simple as just adding a query param to the href
#### Cons of that solution:

- each time the `.css` file is modified, we have to remember to increment the version in the `custom.gsp` file

### Additional "lazy" suggestion to the solution from above
If we want to avoid having to remember about incrementing the version of the file each time we modify it, we can also do something like this:
```html
<link rel="stylesheet" href="${resource(dir:'css',file:'openboxes.css')}?v=${System.currentTimeMillis()}" type="text/css" media="all" />
```
this way the version would be always different and the file would not be cached, but always refetched, but the obvious weakness of that suggestion is that the file would NEVER be cached and it would refetched for every single GSP redirect - for the first version it would be only refetched it the version (and the file) changed, so actually the user would only refetch the css file once per release. 
But I have to admit, that I haven't spotted any performance issues due to always loading the css file using the version with `System.currentTimeMillis()`.

Let me know what you think and if you maybe have any suggestions of how to handle that in a different way or at least if you prefer to remember about changing the version "manually" (as it is in the PR currently) or to make it via `System.currentTimeMillis()`, so the dev wouldn't have to remember about incrementing the version.