### PR TITLE
OBPIH-5555 Past values of ship and delivered dates are not saved in PO shipments

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -2212,6 +2212,7 @@ class StockMovementService {
         shipment.shipmentType = stockMovement.shipmentType
         shipment.driverName = stockMovement.driverName
         shipment.expectedDeliveryDate = stockMovement.expectedDeliveryDate
+        shipment.expectedShippingDate = stockMovement.dateShipped
         if (stockMovement.comments) {
             shipment.addToComments(new Comment(comment: stockMovement.comments))
         }


### PR DESCRIPTION
Past values weren't saved, because we didn't save the `expectedShippingDate`, so each request with past `expectedDeliveryDate` didn't pass the validation.