### PR TITLE
OBPIH-5556 Fix error message when trying to edit/delete line that had…

### DIFF
--- a/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
@@ -437,7 +437,7 @@ class AddItemsPage extends Component {
     const lineItemsToBeUpdated = [];
     _.forEach(lineItemsWithStatus, (item) => {
       // We wouldn't update items with quantity requested <= 0
-      if (parseInt(item.quantityRequested, 10) <= 0) {
+      if (!item.quantityRequested || parseInt(item.quantityRequested, 10) <= 0) {
         return; // lodash continue
       }
       const oldItem = _.find(this.state.currentLineItems, old => old.id === item.id);


### PR DESCRIPTION
… empty quantity requested before

The issue was difficult to spot at first sight, because it was working for freshly added items, but the explanation after finding the issue is pretty simple:

We were sending item with `quantityRequested: ""` to the backend in `lineItems` and it was "deleting" that item.
The reason behind that is that:
```javascript
parseInt(item.quantityRequested, 10) <= 0
``` 
in case when `quantityRequested` is equal to `""` was evaluating to `NaN` and `NaN <= 0` was resulting in `false`, so we were "accepting" that item instead of returning, like in case negative quantities.

Why it was working for brand new items is that we were calling this:
```javascript
const lineItemsToBeAdded = _.filter(lineItems, item =>
      !item.statusCode &&
      parseInt(item.quantityRequested, 10) > 0 &&
      item.product);
```
so we had "reversed" statement (> 0, not <= 0), so `NaN` was never > than 0.



