### PR TITLE
OBPIH-5621 Fix filter selects on the stocklist list page

### DIFF
--- a/src/js/utils/Select.jsx
+++ b/src/js/utils/Select.jsx
@@ -172,19 +172,20 @@ class Select extends Component {
 
   mapOptions(values) {
     return (_.map(values, (value) => {
+      const newValue = value;
       if (typeof value === 'string') {
         return { value, label: value };
       }
       if (value.options) {
-        return { ...value, options: this.mapOptions(value.options) };
+        newValue.options = this.mapOptions(value.options);
       }
       if (value && this.props.labelKey && !value.label) {
-        return { ...value, label: value[this.props.labelKey] };
+        newValue.label = value[this.props.labelKey];
       }
       if (value && this.props.valueKey && !value.value) {
-        return { ...value, value: value[this.props.valueKey] };
+        newValue.value = value[this.props.valueKey];
       }
-      return value;
+      return newValue;
     }));
   }
 


### PR DESCRIPTION
What was missing is `value` key in the object, so one idea would be just to map locations and add `value` key to them, but I wanted to dive into that issue deeper to fix the real cause of that bug.

It seems to have been broken here: https://github.com/openboxes/openboxes/commit/bba8150660ef56c2a202a04d0e4a2e158ece30fc#diff-bce166e150c0e5f362f0b1054d7d07b5446f360a5b1fac77a9ccb84d005e737bR166-R239 by doing the refactor of `mapOptions` function.

Before the refactor it was not returning, so it was adding both `label` and `value` if the following `if` statements were truthy:
```javascript
let option = value;

if (typeof value === 'string') {
  return { value, label: value };
}

if (value && attributes.valueKey && !option.value) {
  option = { ...option, value: option[attributes.valueKey] };
}

if (value && attributes.labelKey && !option.label) {
  option = { ...option, label: option[attributes.labelKey] };
}
```
so if 2nd and 3rd if was truthy, we were adding to the object both `label` and `value` keys, while after the refactor:
```javascript
if (typeof value === 'string') {
  return { value, label: value };
}
if (value.options) {
  return { ...value, options: this.mapOptions(value.options) };
}
if (value && this.props.labelKey && !value.label) {
  return { ...value, label: value[this.props.labelKey] };
}
if (value && this.props.valueKey && !value.value) {
  return { ...value, value: value[this.props.valueKey] };
}
return value;
```
after any of those ifs were executed, we were **returning** and not going to another if, so we have never assigned `value` key to the object which is necessary for the `Select` to work properly.
