### PR TITLE
OBPIH-5626 Make download options and exit button always enabled

### DIFF
--- a/src/js/components/stock-movement-wizard/outbound/SendMovementPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/SendMovementPage.jsx
@@ -848,7 +848,6 @@ class SendMovementPage extends Component {
                             {...document}
                             key={idx}
                             onClick={() => this.saveValues(values)}
-                            disabled={invalid}
                           />);
                         },
                       )}
@@ -875,7 +874,6 @@ class SendMovementPage extends Component {
                   :
                     <button
                       type="button"
-                      disabled={invalid}
                       onClick={() => {
                         window.location = '/openboxes/stockMovement/list?direction=OUTBOUND';
                       }}


### PR DESCRIPTION
We decided to make the download options and exit button always enabled at send request page for both requesting and fulfilling location