### PR TITLE
OBPIH-5621 Fix circular reference for the location JSON marshaller

### DIFF
--- a/grails-app/conf/UtilFilters.groovy
+++ b/grails-app/conf/UtilFilters.groovy
@@ -22,11 +22,16 @@ class UtilFilters {
                 request._timeBeforeRequest = System.currentTimeMillis()
             }
 
-            after = {
+            after = { Map model ->
                 request._timeAfterRequest = System.currentTimeMillis()
             }
 
-            afterView = {
+            afterView = { Exception e ->
+
+                if (e) {
+                    log.info("Request for (${controllerName}/${actionName}) failed with an uncaught exception: ${e.message}")
+                    return
+                }
 
                 if (actionName == "logout") {
                     return
@@ -35,8 +40,9 @@ class UtilFilters {
                     session?._showTime = params.showTime == "on"
                 }
                 if (session._showTime) {
-                    def actionDuration = request?._timeAfterRequest - request?._timeBeforeRequest
-                    def viewDuration = System.currentTimeMillis() - request?._timeAfterRequest
+                    def actionDuration = (request?._timeAfterRequest && request?._timeBeforeRequest) ?
+                            (request?._timeAfterRequest - request?._timeBeforeRequest) : null
+                    def viewDuration = request?._timeAfterRequest ? (System.currentTimeMillis() - request?._timeAfterRequest) : null
 
                     request?.actionDuration = actionDuration
                     request?.viewDuration = viewDuration

--- a/grails-app/conf/UtilFilters.groovy
+++ b/grails-app/conf/UtilFilters.groovy
@@ -22,16 +22,11 @@ class UtilFilters {
                 request._timeBeforeRequest = System.currentTimeMillis()
             }
 
-            after = { Map model ->
+            after = {
                 request._timeAfterRequest = System.currentTimeMillis()
             }
 
-            afterView = { Exception e ->
-
-                if (e) {
-                    log.info("Request for (${controllerName}/${actionName}) failed with an uncaught exception: ${e.message}")
-                    return
-                }
+            afterView = {
 
                 if (actionName == "logout") {
                     return
@@ -40,9 +35,8 @@ class UtilFilters {
                     session?._showTime = params.showTime == "on"
                 }
                 if (session._showTime) {
-                    def actionDuration = (request?._timeAfterRequest && request?._timeBeforeRequest) ?
-                            (request?._timeAfterRequest - request?._timeBeforeRequest) : null
-                    def viewDuration = request?._timeAfterRequest ? (System.currentTimeMillis() - request?._timeAfterRequest) : null
+                    def actionDuration = request?._timeAfterRequest - request?._timeBeforeRequest
+                    def viewDuration = System.currentTimeMillis() - request?._timeAfterRequest
 
                     request?.actionDuration = actionDuration
                     request?.viewDuration = viewDuration

--- a/grails-app/domain/org/pih/warehouse/core/Location.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Location.groovy
@@ -335,6 +335,17 @@ class Location implements Comparable<Location>, java.io.Serializable {
         return active ? LocationStatus.ENABLED : LocationStatus.DISABLED
     }
 
+    Map toBaseJson() {
+        return [
+                id: id,
+                name: name,
+                locationNumber: locationNumber,
+                active: active,
+                locationType: locationType,
+                locationTypeCode: locationType?.locationTypeCode?.name(),
+        ]
+    }
+
     Map toJson() {
         return [
                 id                         : id,
@@ -363,14 +374,7 @@ class Location implements Comparable<Location>, java.io.Serializable {
     }
 
     Map toJson(locationTypeCode) {
-        def json = [
-                id: id,
-                name: name,
-                locationNumber: locationNumber,
-                active: active,
-                locationType: locationType,
-                locationTypeCode: locationType?.locationTypeCode?.name(),
-        ]
+        Map json = toBaseJson()
         switch (locationTypeCode) {
             case LocationTypeCode.INTERNAL:
             case LocationTypeCode.BIN_LOCATION:

--- a/grails-app/domain/org/pih/warehouse/core/Location.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Location.groovy
@@ -362,41 +362,25 @@ class Location implements Comparable<Location>, java.io.Serializable {
         ]
     }
 
-    Map toJson(LocationTypeCode locationTypeCode) {
+    Map toJson(locationTypeCode) {
+        def json = [
+                id: id,
+                name: name,
+                locationNumber: locationNumber,
+                active: active,
+                locationType: locationType,
+                locationTypeCode: locationType?.locationTypeCode?.name(),
+        ]
         switch (locationTypeCode) {
-            case LocationTypeCode.DEPOT:
-                return [
-                        id: id,
-                        name: name,
-                        locationNumber: locationNumber,
-                        locationType: locationType,
-                        locationTypeCode: locationType?.locationTypeCode?.name(),
-                        active: active
-                ]
             case LocationTypeCode.INTERNAL:
             case LocationTypeCode.BIN_LOCATION:
-                return [
-                        id: id,
-                        name: name,
-                        locationNumber: locationNumber,
-                        locationType: locationType?.name,
-                        locationTypeCode: locationType?.locationTypeCode?.name(),
+               json += [
                         zoneId: zone?.id,
                         zoneName: zone?.name,
                         active: active
                 ]
-            case LocationTypeCode.ZONE:
-                return [
-                        id: id,
-                        name: name,
-                        locationNumber: locationNumber,
-                        locationType: locationType?.name,
-                        locationTypeCode: locationType?.locationTypeCode?.name(),
-                        active: active
-                ]
-            default:
-                return toJson()
         }
+        return json
     }
 
     static Map toJson(Location location) {


### PR DESCRIPTION
1. Circular reference for the location JSON marshaller - it was happening if an organization had a defaultLocation and this location's locationTypeCode was NOT: `DEPOT`, `INTERNAL`, `BIN_LOCATION`, `ZONE` - if it was e.g. `SUPPLIER`, we were falling back to `toJson()` method, which was referencing again the organization, and the organization was again referencing the location.

Organization.groovy
```groovy
Map toJson() { 
   return [
      ...
     defaultLocation: Location.toJson(defaultLocation),
     ...
  ]
}
```

`Location.groovy`:
```groovy
static Map toJson(Location location) {
  return location ? location.toJson(location?.locationType?.locationTypeCode) : null
}
```
...
```groovy
Map toJson(LocationTypeCode locationTypeCode) {
  switch(locationTypeCode) {
    ...
    default:
      return toJson()
  }
}
```
...
```groovy
Map toJson() {
        return [
                ...
                organization               : organization,
                ...
        ]
}
```
I also had to remove type checking from `toJson(LocationTypeCode locationTypeCode)` to `toJson(locationTypeCode)`, because if the `locationTypeCode` is `null`, it doesn't even evaluate this method, but immedietaly returns `null`, so it doesn't return the `defaultLocation`, but returns `defaultLocation: null`.
I also removed calling by default: `toJson()`, because it basically caused the circular reference.

