### PR TITLE
OBPIH-5640 Fix the NullPointerException in the afterView filter

### DIFF
--- a/grails-app/conf/UtilFilters.groovy
+++ b/grails-app/conf/UtilFilters.groovy
@@ -22,11 +22,16 @@ class UtilFilters {
                 request._timeBeforeRequest = System.currentTimeMillis()
             }
 
-            after = {
+            after = { Map model ->
                 request._timeAfterRequest = System.currentTimeMillis()
             }
 
-            afterView = {
+            afterView = { Exception e ->
+
+                if (e) {
+                    log.info("Request for (${controllerName}/${actionName}) failed with an uncaught exception: ${e.message}")
+                    return
+                }
 
                 if (actionName == "logout") {
                     return
@@ -35,8 +40,9 @@ class UtilFilters {
                     session?._showTime = params.showTime == "on"
                 }
                 if (session._showTime) {
-                    def actionDuration = request?._timeAfterRequest - request?._timeBeforeRequest
-                    def viewDuration = System.currentTimeMillis() - request?._timeAfterRequest
+                    def actionDuration = (request?._timeAfterRequest && request?._timeBeforeRequest) ?
+                            (request?._timeAfterRequest - request?._timeBeforeRequest) : null
+                    def viewDuration = request?._timeAfterRequest ? (System.currentTimeMillis() - request?._timeAfterRequest) : null
 
                     request?.actionDuration = actionDuration
                     request?.viewDuration = viewDuration


### PR DESCRIPTION
NullPointer in the afterView filter - the problem occured, because of not handled exception thrown from the `LocationApiController`:
```groovy
render([data: location] as JSON)
```
unfortunately if we get any marshaller exception, the `render` is already sent to the response, so we get the status 200, so I don't know if there is any option to handle that, because the exception occurs not with `[data: location] as JSON`, but when the `render([data: location] as JSON)` is called...
When we do not handle the error, the `UtilFilters` doesn't run the `after` closure, so we don't assign:
```groovy
request._timeAfterRequest = System.currentTimeMillis()
```
but it goes straight to the `afterView` having `request._timeAfterRequest` as `null`.
So the `NullPointerException` was about:
`Cannot invoke minus() method on null object` when calculating:
```groovy
def actionDuration = request?._timeAfterRequest - request?._timeBeforeRequest
```

According to Grails' [docs](http://docs.grails.org/3.0.0.M1/guide/single.html#filters), we can access an exception in the `afterView` closure, so I added that and I log it whenever it occurs, and return.

The funny part is that when I do this:
```groovy
def read = {
        Location location = Location.get(params.id)
        try {
          render([data: location] as JSON)
        } catch (Exception e) {
          println(e)
        }
 }
```
instead of this:
```groovy
def read = {
        Location location = Location.get(params.id)
        render([data: location] as JSON)
}
```
even though I don't do anything special in the `catch`, it then properly triggers the `after` closure in the `UtilFilters`

So summing up - the stocklist issue was not itself causing the `NullPointerException`, but thanks to that, we know what is causing it - the part I don't know how we should deal with is how to prevent the `render` returning the response with `200` status if it fails.
