### PR TITLE
OBPIH-5641 Invalid content of error message in outbound workflow

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -2510,6 +2510,9 @@ shipmentItem.inventoryItem.label=Inventory Item
 shipmentItem.binLocation.label=Bin Location
 shipmentItem.quantity.cannotExceedAvailableQuantity=Shipping quantity ({0}) cannot exceed quantity available ({1}) \
   for product code ''{2}'' and lot number ''{3}'' at origin ''{4}'' bin ''{5}''.
+shipmentItem.quantity.pickNotValid=The pick for product code(s) ({0}) is no longer valid. \
+  This can occur if a stock count, transfer, or recall has been performed on the product since the initial pick was generated. \
+  To address this issue, edit the pick to select a new lot or reduce the pick quantity and add a reason code.
 shipmentItem.shipment.required=Shipment item must be assigned a shipment
 shipmentItem.inventoryItem.required=Shipment item must be assigned an inventory item
 shipmentItem.quantityShipped.label=Shipped

--- a/grails-app/services/org/pih/warehouse/shipping/ShipmentService.groovy
+++ b/grails-app/services/org/pih/warehouse/shipping/ShipmentService.groovy
@@ -740,14 +740,9 @@ class ShipmentService {
                 String errorMessage = "The pick for product code(s) ${shipmentItem.product.productCode} is no longer valid. " +
                         "This can occur if a stock count, transfer, or recall has been performed on the product since the initial pick was generated. " +
                         "To address this issue, edit the pick to select a new lot or reduce the pick quantity and add a reason code."
-                shipmentItem.errors.rejectValue("quantity", "shipmentItem.quantity.cannotExceedAvailableQuantity",
+                shipmentItem.errors.rejectValue("quantity", "shipmentItem.quantity.pickNotValid",
                         [
-                                shipmentItem.quantity + " " + shipmentItem?.product?.unitOfMeasure,
-                                quantityAvailableWithPicked + " " + shipmentItem?.product?.unitOfMeasure,
                                 shipmentItem?.product?.productCode,
-                                shipmentItem?.inventoryItem?.lotNumber,
-                                origin.name,
-                                shipmentItem?.binLocation?.name ?: 'Default'
                         ].toArray(), errorMessage)
                 throw new ValidationException("Shipment item is invalid", shipmentItem.errors)
             }


### PR DESCRIPTION
The reason why it was working before was that we were taking `defaultMessage` > `translatedMessage`, and as you can see, I changed the code of the message, because it was a copy paste from the outbound return validation message.
Why it is appearing just now, is because after my refactor of `ErrorsController`, we now take `translatedMessage` > `defaultMessage`, which is the correct way to handle messages.
