### PR TITLE
OBPIH-5639 NullPointerException while updating product availability during product import 

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/InventorySnapshotService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventorySnapshotService.groovy
@@ -410,7 +410,7 @@ class InventorySnapshotService {
     }
 
     void updateInventorySnapshots(Product product) {
-        if (!product?.id) {
+        if (!product?.id || !product?.productCode) {
             return
         }
         def results = InventorySnapshot.executeUpdate(

--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -704,7 +704,7 @@ class ProductAvailabilityService {
     }
 
     void updateProductAvailability(Product product) {
-        if (!product?.id) {
+        if (!product?.id || !product?.productCode) {
             return
         }
         def results = ProductAvailability.executeUpdate(


### PR DESCRIPTION
Add guard condition for updateProductAvailability and updaeInventorySnapshots
prevent update query from executing if productCode on event.product object is null