### PR TITLE
OBPIH-5634 Improve manual location import to allow having locationTyp…

### DIFF
--- a/grails-app/services/org/pih/warehouse/data/LocationDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/LocationDataService.groovy
@@ -39,7 +39,11 @@ class LocationDataService {
             Location location = params.id ? Location.findById(params.id) : null
             Location parentLocation = params.parentLocation ? Location.findByName(params.parentLocation) : null
             LocationGroup locationGroup = params.locationGroup ? LocationGroup.findByName(params.locationGroup) : null
-            LocationType locationType = params.locationType ? LocationType.findByIdOrName(params.locationType, params.locationType) : null
+            String locationTypeName = LocalizationUtil.getDefaultString(params.locationType as String)
+            // TODO: Replace with a single GORM .find with Closure when in Grails 3 (available since Grails 2.0)
+            LocationType locationType = LocationType
+                    .findAllByNameLike(locationTypeName + "%")
+                    .find{ LocalizationUtil.getDefaultString(it.name) == locationTypeName}
             List<Organization> organizations = params.organization ? Organization.findAllByCodeOrName(params.organization, params.organization) : null
 
             if (params.id && !location) {


### PR DESCRIPTION
…e without pipe-delimited translation


I made a promise to Katarzyna and Manon that users won't have to import locationType with pipe-delimited translation, which might've been annoying

For the load data it worked, because it was not taking care of what is thrown in `.validateData()`, but it was validated inside import demo data method, while for manual import, we take care of what is thrown in the `.validateData()` and there I forgot to include the change I've made to: https://github.com/openboxes/openboxes/pull/4015