### PR TITLE
OBPIH-5662 Unable to delete internal locations on GSP

### DIFF
--- a/grails-app/services/org/pih/warehouse/core/LocationService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/LocationService.groovy
@@ -703,13 +703,11 @@ class LocationService {
         if (parentLocation) {
             existingLocation.parentLocation = null
             parentLocation.removeFromLocations(existingLocation)
-            parentLocation.save()
         }
         Location zone = existingLocation.zone
         if (zone) {
             existingLocation.zone = null
             zone.removeFromLocations(existingLocation)
-            zone.save()
         }
         existingLocation.delete(flush: true)
     }


### PR DESCRIPTION
The issue was most probably caused by the OSIV (OpenSessionInView filter). If you are interested in detalis - you can find an explanation of my research in the ticket.