### PR TITLE
OBPIH-5685 Fix inactive product validation for items added not from a…

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/api/ProductApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/ProductApiController.groovy
@@ -134,7 +134,8 @@ class ProductApiController extends BaseDomainApiController {
                     minExpirationDate: v.findAll { it.inventoryItem.expirationDate != null }.collect {
                         it.inventoryItem?.expirationDate
                     }.min()?.format("MM/dd/yyyy"),
-                    color: v[0].inventoryItem.product.color
+                    color: v[0].inventoryItem.product.color,
+                    active: v[0].inventoryItem.product?.active
                 ]
             }
 

--- a/grails-app/services/org/pih/warehouse/product/ProductService.groovy
+++ b/grails-app/services/org/pih/warehouse/product/ProductService.groovy
@@ -1309,7 +1309,8 @@ class ProductService {
         def query = """
             select distinct
             product.id, 
-            product.name, 
+            product.name,
+            product.active,
             product.product_code as productCode, 
             product.cold_chain as coldChain, 
             product.controlled_substance as controlledSubstance, 

--- a/src/groovy/org/pih/warehouse/product/ProductSearchDto.groovy
+++ b/src/groovy/org/pih/warehouse/product/ProductSearchDto.groovy
@@ -6,6 +6,8 @@ class ProductSearchDto {
 
     String id
 
+    Boolean active
+
     String name
 
     String displayName
@@ -44,6 +46,7 @@ class ProductSearchDto {
         [
                 id                 : id,
                 productCode        : productCode,
+                active             : active,
                 name               : name,
                 displayName        : displayName,
                 color              : productColor,

--- a/src/js/utils/option-utils.jsx
+++ b/src/js/utils/option-utils.jsx
@@ -112,6 +112,7 @@ export const debounceProductsFetch = (waitTime, minSearchLength, locationId) =>
             displayName: obj.displayName,
             color: obj.color,
             exactMatch: obj.exactMatch,
+            active: obj.active,
           }
         ))))
         .catch(() => callback([]));


### PR DESCRIPTION
… stocklist

For the `stockMovementItems` endpoint, there was property `product.active`, so it was working for items from stocklist, but I forgot to check it for regular items (added through debounceProductFetch), where there was not `product.active`, so the validation always occured, when it shouldn't, because it was reading `product.active` which was `undefined` as falsy value, so as it would be an inactive product. The reason for that was that for `ProductSearchDto` we didn't have `active` property returned.