### PR TITLE
OBPIH-5699 Exclude items which have bin location from the reorder report

### DIFF
--- a/grails-app/services/org/pih/warehouse/core/DashboardService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/DashboardService.groovy
@@ -565,7 +565,7 @@ class DashboardService {
 
             // If an inventoryLevel does have a bin location,
             // or minQuantity and reorderQuantity not set, the item should not appear in the report
-            if (inventoryLevel?.binLocation || (!minQuantity && !reorderQuantity)) {
+            if (inventoryLevel?.internalLocation || (!minQuantity && !reorderQuantity)) {
                 return false
             }
 


### PR DESCRIPTION
The reason why it wasn't working was that a deprecated property was used there:
https://github.com/openboxes/openboxes/blob/33b93dcf20c46c073d13b6335350400b7778e4c8/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy#L62-L63

instead of:
https://github.com/openboxes/openboxes/blob/33b93dcf20c46c073d13b6335350400b7778e4c8/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy#L23-L24
which is currently set when editing the inventoryLevel: https://github.com/openboxes/openboxes/blob/33b93dcf20c46c073d13b6335350400b7778e4c8/grails-app/views/inventoryLevel/_form.gsp#L69-L71