### PR TITLE
OBPIH-5714 Click Next on add items page should be enabled when some line items have qtt=0 (fixes after QA)

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -1315,7 +1315,7 @@ openboxes.display.date.defaultValue = Constants.DISPLAY_DATE_DEFAULT_VALUE
 openboxes.client.notification.autohide.delay = 8000
 
 // Autosave configuration
-openboxes.client.autosave.enabled = true
+openboxes.client.autosave.enabled = false
 
 // Global megamenu configuration
 

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -1315,7 +1315,7 @@ openboxes.display.date.defaultValue = Constants.DISPLAY_DATE_DEFAULT_VALUE
 openboxes.client.notification.autohide.delay = 8000
 
 // Autosave configuration
-openboxes.client.autosave.enabled = false
+openboxes.client.autosave.enabled = true
 
 // Global megamenu configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17918,9 +17918,9 @@
       }
     },
     "react-confirm-alert": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/react-confirm-alert/-/react-confirm-alert-2.4.1.tgz",
-      "integrity": "sha512-Sc2N1paCTCS5HWEAhik2IQa9/vwSQLAoCT5uccjPH/VyTaBAkRPZPx9sUqFTy3q5VnnGwCPsoz7fnw54x79d/w=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/react-confirm-alert/-/react-confirm-alert-2.6.1.tgz",
+      "integrity": "sha512-KxlpQoR4x/ET1oFPm/IGpsqnpzP17qkkQZuaO3pw7zGZ9oP5hElPtq/1vgoikoqNHQ2tMm6Iw9HQUNLoNgXkRA=="
     },
     "react-datepicker": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "react": "16.8.6",
     "react-chartjs-2": "2.9.0",
     "react-color": "2.19.3",
-    "react-confirm-alert": "2.4.1",
+    "react-confirm-alert": "2.6.1",
     "react-datepicker": "1.7.0",
     "react-dom": "16.8.6",
     "react-dropzone": "4.3.0",

--- a/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
@@ -367,6 +367,7 @@ class AddItemsPage extends Component {
     this.saveAndTransitionToNextStep = this.saveAndTransitionToNextStep.bind(this);
     this.shouldShowAutosaveFeatureBar = this.shouldShowAutosaveFeatureBar.bind(this);
     this.shouldCreateAutosaveFeatureBar = this.shouldCreateAutosaveFeatureBar.bind(this);
+    this.didUserConfirmAlert = false;
     this.debouncedSave = _.debounce(() => {
       this.saveRequisitionItemsInCurrentStep(this.state.values.lineItems, false);
     }, 1000);
@@ -653,12 +654,19 @@ class AddItemsPage extends Component {
       buttons: [
         {
           label: this.props.translate('react.default.yes.label', 'Yes'),
-          onClick: onConfirm,
+          onClick: () => {
+            this.didUserConfirmAlert = true;
+          },
         },
         {
           label: this.props.translate('react.default.no.label', 'No'),
         },
       ],
+      afterClose: () => {
+        if (this.didUserConfirmAlert) {
+          onConfirm();
+        }
+      },
     });
   }
 
@@ -968,17 +976,17 @@ class AddItemsPage extends Component {
           return Promise.reject(new Error(this.props.translate('react.stockMovement.error.saveRequisitionItems.label', 'Could not save requisition items')));
         });
     }
-    this.setState({
+    this.setState(previousState => ({
       values: {
-        ...this.state.values,
-        lineItems: this.state.values.lineItems.map((item) => {
+        ...previousState.values,
+        lineItems: previousState.values.lineItems.map((item) => {
           if (parseInt(item.quantityRequested, 10) === 0) {
             return { ...item, disabled: true, rowSaveStatus: RowSaveStatus.SAVED };
           }
           return item;
         }),
       },
-    });
+    }));
 
     return Promise.resolve();
   }

--- a/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
@@ -442,7 +442,8 @@ class AddItemsPage extends Component {
     const lineItemsToBeUpdated = [];
     _.forEach(lineItemsWithStatus, (item) => {
       // We wouldn't update items with quantity requested < 0
-      if (!item.quantityRequested === undefined || parseInt(item.quantityRequested, 10) < 0) {
+      if ((item.quantityRequested !== 0 && !item.quantityRequested) ||
+        parseInt(item.quantityRequested, 10) < 0) {
         return; // lodash continue
       }
       const oldItem = _.find(this.state.currentLineItems, old => old.id === item.id);
@@ -609,7 +610,8 @@ class AddItemsPage extends Component {
     _.forEach(values.lineItems, (item, key) => {
       if (
         !_.isNil(item.product)
-        && (item.quantityRequested === undefined || item?.quantityRequested < 0)
+        && ((item.quantityRequested !== 0 && !item.quantityRequested)
+          || item?.quantityRequested < 0)
       ) {
         errors.lineItems[key] = { quantityRequested: 'react.stockMovement.error.enterQuantity.label' };
       }
@@ -665,6 +667,7 @@ class AddItemsPage extends Component {
       afterClose: () => {
         if (this.didUserConfirmAlert) {
           onConfirm();
+          this.didUserConfirmAlert = false;
         }
       },
     });
@@ -1011,7 +1014,7 @@ class AddItemsPage extends Component {
       }
 
       if (
-        item.product && (item.quantityRequested === undefined ||
+        item.product && ((item.quantityRequested !== 0 && !item.quantityRequested) ||
           parseInt(item.quantityRequested, 10) < 0)
       ) {
         return { ...item, rowSaveStatus: RowSaveStatus.ERROR };


### PR DESCRIPTION
I have to check `item.quantityRequested === undefined` instead of `!item.quantityRequested` because `quantityRequest` can be 0, so `!item.quantityRequested` will be true, but the main idea of checking that is just to validate the items which have empty quantity.

`if (item.id && newQty === oldQty && oldQty === 0) {
        lineItemsToBeUpdated.push(item);
        return;
      }` means that we want to send items with 0 qty which are added using stock list (before when we added items using stock list, they weren't sent to save, so items with 0 qty were visible on the next page / after save)

The issue with being unable to add new lines using arrows was caused by the asynchronous behavior of `setState`, so when I added `previousState` as an argument the issue was solved.

Additionally, I had to upgrade `react-confirm-alert` from 2.4.1 to 2.6.1, because, in the previous version, we weren't able to trigger two alerts in a row, so when we had an alert about items with 0 qty, the alert with duplicated items didn't appear, so we couldn't go forward in this case.