### PR TITLE
OBGM-410 Unable to receive inbound returns

### DIFF
--- a/grails-app/services/org/pih/warehouse/shipping/ShipmentService.groovy
+++ b/grails-app/services/org/pih/warehouse/shipping/ShipmentService.groovy
@@ -1155,7 +1155,7 @@ class ShipmentService {
         }
 
         Holders.grailsApplication.mainContext.publishEvent(new ShipmentStatusTransitionEvent(shipmentInstance, ShipmentStatusCode.SHIPPED))
-
+        shipmentInstance.save(flush: true)
     }
 
 


### PR DESCRIPTION
The reason for being unable to receive inbound returns was that, the `shipmentStatusCode` wasn't saved, so during clicking on the `receive` button our shipment still has `PENDING` status. I've added `.save(flush: true)` after the `publishEvent` and after that change, the status is changed to `SHIPPED` and it works fine. I tried it without `flush: true` but it doesn't work. I am a little bit curious if there is a better way for handling that save, maybe we can do something with saving within this published event?