### PR TITLE
OBGM-458 Fix products list query to be able to access browse inventor…

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -889,7 +889,7 @@ class ProductAvailabilityService {
                 if (!command.showOutOfStockProducts) {
 
                     // SUM(product availability.quantity_on_hand) > 0
-                    def quantityGreaterThanZero = Subqueries.lt(0, aggregatedQuantityQuery)
+                    def quantityGreaterThanZero = Subqueries.lt(0L, aggregatedQuantityQuery)
                     // productType in (:searchableProductTypes)
                     def inSearchableProductTypes = Restrictions.in("productType", searchableProductTypes)
                     // productType in (:searchableNoStockProductTypes)


### PR DESCRIPTION
…y page

After deep debugging of the product list query, it seems like one of the subqueries is expecting to compare `Long` instead of `Integer` (it might be due to a newer version of hibernate). Changing from `0` to `0L` in this one place seems to be fixing the issue and I am able to access the browser inventory page.

We can compare `long` to `int` without any inconsistency, so this small change should be enough.
A few examples:
![Screenshot from 2023-06-15 17-03-53](https://github.com/openboxes/openboxes/assets/93163821/a0ed1da4-1de9-4cca-9834-690521278f8a)
https://stackoverflow.com/questions/11143253/is-it-ok-to-compare-an-int-and-a-long-in-java