### PR TITLE
OBGM-551 Unable to Place PO

### DIFF
--- a/grails-app/services/org/pih/warehouse/order/OrderService.groovy
+++ b/grails-app/services/org/pih/warehouse/order/OrderService.groovy
@@ -458,7 +458,7 @@ class OrderService {
     boolean canApproveOrder(Order order, User userInstance) {
         if (isApprovalRequired(order)) {
             List<RoleType> defaultRoleTypes = grailsApplication.config.openboxes.purchasing.approval.defaultRoleTypes
-                    .collect { RoleType."$it" }
+                    .collect { RoleType.valueOf(it) }
             return userService.hasAnyRoles(userInstance, defaultRoleTypes)
         }
         return Boolean.TRUE

--- a/grails-app/services/org/pih/warehouse/order/OrderService.groovy
+++ b/grails-app/services/org/pih/warehouse/order/OrderService.groovy
@@ -458,6 +458,7 @@ class OrderService {
     boolean canApproveOrder(Order order, User userInstance) {
         if (isApprovalRequired(order)) {
             List<RoleType> defaultRoleTypes = grailsApplication.config.openboxes.purchasing.approval.defaultRoleTypes
+                    .collect { RoleType."$it" }
             return userService.hasAnyRoles(userInstance, defaultRoleTypes)
         }
         return Boolean.TRUE


### PR DESCRIPTION
Roles passed from the application.yaml weren't properly compared with the values from `getEffectiveRoles(user)` (it always returned `false`, so we didn't have appropriate privileges to perform actions).