### PR TITLE
OBGM-545 Fix pagination for product list

### DIFF
--- a/grails-app/services/org/pih/warehouse/product/ProductService.groovy
+++ b/grails-app/services/org/pih/warehouse/product/ProductService.groovy
@@ -14,6 +14,7 @@ import grails.gorm.transactions.Transactional
 import grails.validation.ValidationException
 import groovy.xml.Namespace
 import org.hibernate.criterion.CriteriaSpecification
+import org.hibernate.criterion.Restrictions
 import org.hibernate.sql.JoinType
 import org.pih.warehouse.core.ApiException
 import org.pih.warehouse.core.Constants
@@ -330,7 +331,6 @@ class ProductService {
                 }
             }
 
-            createAlias("synonyms", "synonym", JoinType.LEFT_OUTER_JOIN)
 
             if (!includeInactive) {
                 eq("active", true)
@@ -369,6 +369,7 @@ class ProductService {
             }
             or {
                 if (params.name) {
+                    createAlias("synonyms", "synonym", JoinType.LEFT_OUTER_JOIN, Restrictions.like("synonymTypeCode", SynonymTypeCode.DISPLAY_NAME) )
                     ilike("name", "%" + params.name.replaceAll(" ", "%") + "%")
                     and {
                         ilike("synonym.name", "%" + params.name.replaceAll(" ", "%") + "%")


### PR DESCRIPTION
The problem was with a difference between joining type in Grails 1 vs Grails 3 - we were fixing this once, but the join was added in a wrong place, because we should join synonyms only if we provide `params.name`.
Additionally - the pagination was showing wrong results, because the `LEFT_JOIN` was giving us duplicate results which was then cut by the distinct. 
Why it was giving duplicate results is due to `LEFT_JOIN` being used - if a product has 4 synonyms, it was considered 4 times in the query.
A workaround for that was to add an additional criteria to the `createAlias`, which was to join by `product.id` and `synonym.product_id` AND `synonymTypeCode = SynonymTypeCode.DISPLAY_NAME` - this will remove the duplicates, because we can have only one `DISPLAY_NAME` synonym.

Fortunately we can add additional criteria in `createAlias` - since it might be difficult to find, I'm attaching a link to docs of that: https://docs.jboss.org/hibernate/orm/4.1/javadocs/org/hibernate/Criteria.html#createAlias(java.lang.String,%20java.lang.String,%20org.hibernate.sql.JoinType,%20org.hibernate.criterion.Criterion)