### PR TITLE
OBGM-574 Disable allow_update_outside_transaction Hibernate setting

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -209,7 +209,7 @@ slf4j.detectLoggerNameMismatch: true
 
 ---
 hibernate:
-    allow_update_outside_transaction: true
+    allow_update_outside_transaction: false
     cache:
         queries: false
         provider_class: org.hibernate.cache.EhCacheProvider


### PR DESCRIPTION
I know I could've deleted this setting at all, but I prefer to leave it with the `false` flag, because figuring out what Hibernate settings for an exact version are enabled/disabled by default, is a pain in the neck, so it will provide a better readability and understanding, what is enabled/disabled