### PR TITLE
OBGM-560 Fix association between transaction and shipment while rollbacking and fix refresh product availability when deleting outbound return

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -482,6 +482,8 @@ openboxes:
         refreshProductAvailabilityJob:
             enabled: true
             cronExpression: "0 0 0/2 * * ?" # every two hours
+            delayStart: true
+            delayInMilliseconds: 5000
 
         # Refresh transaction fact table
         refreshTransactionFactJob:

--- a/grails-app/domain/org/pih/warehouse/order/Order.groovy
+++ b/grails-app/domain/org/pih/warehouse/order/Order.groovy
@@ -21,31 +21,37 @@ import org.pih.warehouse.shipping.ShipmentStatusCode
 
 class Order implements Serializable {
 
-    def beforeInsert = {
+    def beforeInsert() {
         createdBy = AuthService.currentUser
     }
 
-    def beforeUpdate = {
+    def beforeUpdate() {
         updatedBy = AuthService.currentUser
     }
 
-    def publishRefreshEvent = {
+    def publishRefreshEvent() {
         if (isPurchaseOrder) {
             Holders.grailsApplication.mainContext.publishEvent(new RefreshOrderSummaryEvent(this))
         }
     }
 
-    def publishRefreshEvenBeforeDelete = {
+    def publishRefreshEvenBeforeDelete() {
         if (isPurchaseOrder) {
             Holders.grailsApplication.mainContext.publishEvent(new RefreshOrderSummaryEvent(this, true))
         }
     }
 
-    def afterInsert = publishRefreshEvent
+    def afterInsert() {
+        publishRefreshEvent()
+    }
 
-    def afterUpdate = publishRefreshEvent
+    def afterUpdate() {
+        publishRefreshEvent()
+    }
 
-    def beforeDelete = publishRefreshEvenBeforeDelete
+    def beforeDelete() {
+        publishRefreshEvenBeforeDelete()
+    }
 
     String id
     OrderStatus status = OrderStatus.PENDING

--- a/grails-app/domain/org/pih/warehouse/picklist/PicklistItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/picklist/PicklistItem.groovy
@@ -18,15 +18,21 @@ import org.pih.warehouse.requisition.RequisitionItem
 
 class PicklistItem implements Serializable {
 
-    def publishRefreshEvent = {
+    def publishRefreshEvent() {
         Holders.grailsApplication.mainContext.publishEvent(new RefreshProductAvailabilityEvent(this))
     }
 
-    def afterInsert = publishRefreshEvent
+    def afterInsert() {
+        publishRefreshEvent()
+    }
 
-    def afterUpdate = publishRefreshEvent
+    def afterUpdate() {
+        publishRefreshEvent()
+    }
 
-    def afterDelete = publishRefreshEvent
+    def afterDelete() {
+        publishRefreshEvent()
+    }
 
     String id
     RequisitionItem requisitionItem

--- a/grails-app/services/org/pih/warehouse/shipping/ShipmentService.groovy
+++ b/grails-app/services/org/pih/warehouse/shipping/ShipmentService.groovy
@@ -956,7 +956,7 @@ class ShipmentService {
             if (saveParent) {
                 shipment.save(flush: true)
             }
-            shipmentItem.delete(flush: true)
+            shipmentItem.delete()
         }
     }
 

--- a/grails-app/services/org/pih/warehouse/shipping/ShipmentService.groovy
+++ b/grails-app/services/org/pih/warehouse/shipping/ShipmentService.groovy
@@ -956,7 +956,7 @@ class ShipmentService {
             if (saveParent) {
                 shipment.save(flush: true)
             }
-            shipmentItem.delete()
+            shipmentItem.delete(flush: true)
         }
     }
 
@@ -1499,6 +1499,7 @@ class ShipmentService {
             debitTransaction.transactionDate = shipmentInstance.getActualShippingDate()
             debitTransaction.requisition = shipmentInstance.requisition
             debitTransaction.transactionNumber = identifierService.generateTransactionIdentifier()
+            debitTransaction.outgoingShipment = shipmentInstance
 
             addTransactionEntries(debitTransaction, shipmentInstance)
 


### PR DESCRIPTION
As this ticket drove me nuts, a little description (as always :smile: ):

**1. rollback problem** - we have a bidirectional relationship between `Transaction` and `Shipment`. The problem there was that we were not assigning `outgoingShipment` to the `Transaction` instance, we were only doing it for one direction, so for shipment like:
```groovy
shipmentInstance.addToOutgoingTransactions(debitTransaction)
```
For correct bidirectional relationships, we have to add it for both sides.
Grails is that clever, that when doing `addToOutgoingTransactions`, it was automatically assigning the `outgoingShipment` for the `debitTransaction` also, but it was not persisted. In grails 1 it was working due to OSIV, that was catching those "dirty" changes and here, it doesn't work, because we saved the `debitTransaction` a few lines above.

What also fixed the issue was removing this:
```groovy
 if (!debitTransaction.save()) {
       log.info "debit transaction errors " + debitTransaction.errors
       throw new ValidationException("An error occurred while saving ${debitTransaction?.transactionType?.transactionCode} transaction", debitTransaction.errors)
}
```
because then, the `debitTransaction` was saved at the end of the session and the `outgoingShipment` set by the:
```groovy
shipmentInstance.addToOutgoingTransactions(debitTransaction)
```
was caught.

We could either change it to `validate()` and let Grails do the work with associations, but I think the path I went with assigning it explicitly is a more proper solution.


**2. quantity available not updating when deleting the shipment:**

This drove me nuts.... since we were refreshing product availability asynchronously and the session that was deleting picklist items was not yet flushed and the `productAvailabilityService` was creating its own session and transaction, it didn't know "what is going on" in the first session, that is deleting the entities.... so it was thinking that picklist item is still in the DB (because the deletion was still in batch in first session)....
After long debugging it turned out, that we have missing properties for product availability jobs, which was the delay.....
Adding the delay, fixed the issue, because the first session "managed" to finish and to be flushed before the second session (from the job) initialized.