### PR TITLE
OBGM-535 Fix synonyms import through edit product page

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
@@ -31,8 +31,8 @@ import org.pih.warehouse.importer.ImportDataCommand
 import org.pih.warehouse.importer.ProductSynonymExcelImporter
 import org.pih.warehouse.inventory.InventoryItem
 import org.pih.warehouse.inventory.InventoryLevel
+import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.multipart.MultipartHttpServletRequest
-import org.springframework.web.multipart.commons.CommonsMultipartFile
 
 import javax.activation.MimetypesFileTypeMap
 import java.math.RoundingMode
@@ -1141,7 +1141,7 @@ class ProductController {
         if (request.method == "POST") {
             File localFile = null
             MultipartHttpServletRequest mpr = (MultipartHttpServletRequest) request
-            CommonsMultipartFile uploadFile = (CommonsMultipartFile) mpr.getFile("file")
+            MultipartFile uploadFile = mpr.getFile("file")
 
             if (uploadFile?.empty) {
                 flash.error = "Please upload a non-empty file"


### PR DESCRIPTION
It turned out that there is some difference between `MultipartHttpServletRequest` implementation in Grails 1 and Grails 3 and this is probably why it couldn't cast this class now.

Since `CommonsMultipartFile` is an implementation of `MultipartFile` interface:
```groovy
public class CommonsMultipartFile implements MultipartFile, Serializable {
```
 we can (and should) use it as a type here, since it is even more correct in terms of [dependency inversion principle](https://stackify.com/dependency-inversion-principle/), and the error disappears and the import works correctly.

