### PR TITLE
OBGM-567 / OBGM-566 Unable to reload autopick after editing qty of pick item to 0 and styling of qty atp validation not visible

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/core/ErrorsController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/core/ErrorsController.groovy
@@ -97,12 +97,12 @@ class ErrorsController {
     def handleValidationErrors() {
         if (RequestUtil.isAjax(request)) {
             response.status = 400
-            BeanPropertyBindingResult errors = request?.exception?.cause?.errors
+            BeanPropertyBindingResult errors = request?.exception?.cause?.target?.errors ?: request?.exception?.cause?.errors
             List<String> errorMessages = errors.allErrors.collect {
                 return g.message(error: it, locale: localizationService.currentLocale)
             }
             render([errorCode: 400,
-                    errorMessage: "Validation error. " + request?.exception?.cause?.fullMessage,
+                    errorMessage: "Validation error. " + request?.exception?.cause?.target?.fullMessage ?: request?.exception?.cause?.fullMessage,
                     errorMessages: errorMessages
             ] as JSON)
             return

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -1237,7 +1237,7 @@ class StockMovementService {
                 // FIXME: Refactor this part to get rid of need to throw wrapped exception plus consider not allowing zeroing out picked stock
                 // Throw checked exception with ValidationException cause to not rollback deleted picklist while throwing unchecked exception
                 // See: https://pihemr.atlassian.net/browse/OBPIH-5318
-                throw new Exception(errorMessage, new ValidationException(errorMessage, requisitionItem.errors))
+                throw new ValidationException(errorMessage, requisitionItem.errors)
             }
         }
     }

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -1234,9 +1234,7 @@ class StockMovementService {
                         requisitionItem?.product?.productCode,
                 ].toArray(), errorMessage)
 
-                // FIXME: Refactor this part to get rid of need to throw wrapped exception plus consider not allowing zeroing out picked stock
-                // Throw checked exception with ValidationException cause to not rollback deleted picklist while throwing unchecked exception
-                // See: https://pihemr.atlassian.net/browse/OBPIH-5318
+                // FIXME: consider not allowing zeroing out picked stock
                 throw new ValidationException(errorMessage, requisitionItem.errors)
             }
         }

--- a/src/js/components/stock-movement-wizard/outbound/PackingPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/PackingPage.jsx
@@ -18,8 +18,11 @@ import SelectField from 'components/form-elements/SelectField';
 import TextField from 'components/form-elements/TextField';
 import PackingSplitLineModal from 'components/stock-movement-wizard/modals/PackingSplitLineModal';
 import AlertMessage from 'utils/AlertMessage';
-import apiClient, {
+import {
+  apiClientCustomResponseHandler as apiClient,
   flattenRequest,
+  handleSuccess,
+  handleValidationErrors,
   stringUrlInterceptor,
 } from 'utils/apiClient';
 import { renderFormField } from 'utils/form-utils';
@@ -211,11 +214,14 @@ class PackingPage extends Component {
     this.saveSplitLines = this.saveSplitLines.bind(this);
     this.isRowLoaded = this.isRowLoaded.bind(this);
     this.loadMoreRows = this.loadMoreRows.bind(this);
+    this.setState = this.setState.bind(this);
 
     this.debouncedPeopleFetch =
       debouncePeopleFetch(this.props.debounceTime, this.props.minSearchLength);
 
     this.props.showSpinner();
+
+    apiClient.interceptors.response.use(handleSuccess, handleValidationErrors(this.setState));
   }
 
   componentDidMount() {

--- a/src/js/components/stock-movement-wizard/outbound/PickPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/PickPage.jsx
@@ -22,6 +22,7 @@ import AlertMessage from 'utils/AlertMessage';
 import apiClient, {
   parseResponse,
   stringUrlInterceptor,
+  handleError, handleSuccess,
 } from 'utils/apiClient';
 import { renderFormField } from 'utils/form-utils';
 import { formatProductDisplayName, matchesProductCodeOrName } from 'utils/form-values-utils';
@@ -221,6 +222,10 @@ class PickPage extends Component {
     this.isRowLoaded = this.isRowLoaded.bind(this);
     this.loadMoreRows = this.loadMoreRows.bind(this);
     this.recreatePicklist = this.recreatePicklist.bind(this);
+    this.handleValidationErrors = this.handleValidationErrors.bind(this);
+
+    apiClient.interceptors.response.use(handleSuccess, this.handleValidationErrors);
+
   }
 
   componentDidMount() {
@@ -427,6 +432,18 @@ class PickPage extends Component {
   validatePicklist() {
     const url = `/api/stockMovements/${this.state.values.stockMovementId}/validatePicklist`;
     return apiClient.get(url);
+  }
+
+  // eslint-disable-next-line react/sort-comp
+  handleValidationErrors(error) {
+    if (error.response.status === 400) {
+      const alertMessage = _.join(_.get(error, 'response.data.errorMessages', ''), ' ');
+      this.setState({ alertMessage, showAlert: true });
+
+      return Promise.reject(error);
+    }
+
+    return handleError(error);
   }
 
   validateReasonCodes(lineItems) {

--- a/src/js/components/stock-movement-wizard/outbound/SendMovementPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/SendMovementPage.jsx
@@ -20,11 +20,16 @@ import LabelField from 'components/form-elements/LabelField';
 import SelectField from 'components/form-elements/SelectField';
 import TextField from 'components/form-elements/TextField';
 import AlertMessage from 'utils/AlertMessage';
-import apiClient, { handleError, stringUrlInterceptor } from 'utils/apiClient';
+import {
+  apiClientCustomResponseHandler as apiClient,
+  handleError,
+  handleSuccess,
+  handleValidationErrors,
+  stringUrlInterceptor,
+} from 'utils/apiClient';
 import { renderFormField } from 'utils/form-utils';
 import { formatProductDisplayName } from 'utils/form-values-utils';
 import { debounceLocationsFetch } from 'utils/option-utils';
-import renderHandlingIcons from 'utils/product-handling-icons';
 import Translate, { translateWithDefaultMessage } from 'utils/Translate';
 import splitTranslation from 'utils/translation-utils';
 
@@ -285,9 +290,12 @@ class SendMovementPage extends Component {
     this.loadMoreRows = this.loadMoreRows.bind(this);
     this.toggleDropdown = this.toggleDropdown.bind(this);
     this.validate = this.validate.bind(this);
+    this.setState = this.setState.bind(this);
 
     this.debouncedLocationsFetch =
       debounceLocationsFetch(this.props.debounceTime, this.props.minSearchLength);
+
+    apiClient.interceptors.response.use(handleSuccess, handleValidationErrors(this.setState));
   }
 
   componentDidMount() {

--- a/src/js/utils/apiClient.jsx
+++ b/src/js/utils/apiClient.jsx
@@ -9,7 +9,7 @@ import notification from 'components/Layout/notifications/notification';
 import LoginModal from 'components/LoginModal';
 import NotificationType from 'consts/notificationTypes';
 
-const justRejectRequestError = (error) => Promise.reject(error);
+export const justRejectRequestError = (error) => Promise.reject(error);
 
 const apiClient = axios.create({});
 
@@ -107,7 +107,7 @@ export const handleError = (error) => {
 // TODO: This is temporary cleaner. Once migration is complete it should be removed
 const cleanUrlFromContextPath = (url) => url.replace('/openboxes', '');
 
-const urlInterceptor = (config) => {
+export const urlInterceptor = (config) => {
   const contextPath = window.CONTEXT_PATH;
   const cleanedUrl = _.trimStart(config.url ? cleanUrlFromContextPath(config.url) : '', '/');
 

--- a/src/js/utils/apiClient.jsx
+++ b/src/js/utils/apiClient.jsx
@@ -12,6 +12,7 @@ import NotificationType from 'consts/notificationTypes';
 export const justRejectRequestError = (error) => Promise.reject(error);
 
 const apiClient = axios.create({});
+export const apiClientCustomResponseHandler = axios.create({});
 
 export function parseResponse(data) {
   if (_.isArray(data)) {
@@ -125,7 +126,23 @@ export const stringUrlInterceptor = (url) => {
   return config.url;
 };
 
+export const handleValidationErrors = (setState) => (error) => {
+  if (error.response.status === 400) {
+    const alertMessage = _.join(_.get(error, 'response.data.errorMessages', ''), ' ');
+    setState({ alertMessage, showAlert: true });
+
+    return Promise.reject(error);
+  }
+
+  return handleError(error);
+};
+
 apiClient.interceptors.response.use(handleSuccess, handleError);
 apiClient.interceptors.request.use(urlInterceptor, justRejectRequestError);
+
+apiClientCustomResponseHandler.interceptors.request.use(
+  urlInterceptor,
+  justRejectRequestError,
+);
 
 export default apiClient;


### PR DESCRIPTION
OBGM-566:
The previous handling of our messages in "red boxes" were deleted, so I reverted it, but I did it in a more reusable way - I created a new `apiClient` (we cannot override previously set `interceptor` behavior, adding new one results in showing popup error and the 'red box'). Within `apiClient.js` I override the behavior while getting a response but let us use custom behavior for a response. Additionally, I made the `handleValidationErrors` curried function to pass the `setState` for each component that needs the content of the message to be set.
OBGM-567:
The first thing was that the interceptor behavior wasn't overridden, so we didn't get the error messages in the 'red boxes'. The second thing was a change in Exception, we didn't have errors and fullMessage in the same place in the exception object as we had before. This change should fix other problems with messages caused by the appropriate handling ValidationException.

I also unwrapped ValidationException from Exception, because the content of the fullMessage and errors were in a different properties because of that. (errors and fullMessage weren't in the same place as without wrapping it).

And I found that fix made before:
`// Throw checked exception with ValidationException cause to not rollback deleted picklist while throwing unchecked exception`
won't work because of the change in handling exceptions in transactions. **Previously checked exception not caused a rollback, but unchecked caused. Withing the GORM 6+ version this behavior was changed and all of the exceptions causing a rollback for now.**
It can be found in the documentation (http://docs.grails.org/latest/guide/services.html#declarativeTransactions)
> Version Grails 3.2.0 was the first version to use GORM 6 by default. Checked exceptions did not roll back transactions before GORM 6. Only a method that threw a runtime exception (i.e. one that extends RuntimeException) rollbacked a transaction. 

Referring to that, @kchelstowski was right in saying that rollbacks didn't work in Grails 1 - but it was caused only because of the handling of different types of exceptions (checked / unchecked).
He recorded a video showing the rollback didn't work (grails 1, as you can see the item is saved in the DB):
https://www.loom.com/share/b4c53546dada42d19b74b39d282cabf4?sid=879e5441-575b-4a9c-9a7a-5a9b9c4f53ea
And there is a video showing that it is not saved in the DB (grails 3):
https://www.loom.com/share/09884a401f2349d4b174426175a2a25e?sid=16caaa84-59e5-4991-8dfe-977d1a82004d
