### PR TITLE
OBGM-543 Fix bug in inventory by location report causing html elements to be rendered on csv

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/reporting/ReportController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/reporting/ReportController.groovy
@@ -608,6 +608,7 @@ class ReportController {
             }
             response.setHeader("Content-disposition", "attachment; filename=\"Inventory-by-location-${new Date().format("yyyyMMdd-hhmmss")}.csv\"")
             render(contentType: "text/csv", text: CSVUtils.prependBomToCsvString(sw.toString()), encoding: "UTF-8")
+            return
         }
 
         render(view: 'showInventoryByLocationReport', model: [command: command])


### PR DESCRIPTION
Since inventory by location report method did not return after rendering csv file it also additionally rendered html report which was appended to the csv file