### PR TITLE
OBGM-577 Change product supplier identifier format to be the same as on develop branch

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -315,7 +315,7 @@ openboxes:
         product:
             format: "LLNN"
         productSupplier:
-            format: "LLNN"
+            format: "NNNN"
             prefix:
                 enabled: true
         receipt:


### PR DESCRIPTION
I didn't notice it at first but after QA Katarzyna pointed out that the format of generated identifier for product source didn't match the one that is on `develop` branch so I compared both branches and in fact there was a difference in formats
https://github.com/openboxes/openboxes/blob/1e77b282da20c34b75ebec47b896e3528dae095e/src/groovy/org/pih/warehouse/core/Constants.groovy#L121
Based on commits I did not see any reasoning behind changing the format on `feature/upgrade-to-grails-3.3.10` so I assume it was probably a mistake