### PR TITLE
OBGM-536 Pagination not visible on inventory browser 

### DIFF
--- a/grails-app/views/inventory/_filters.gsp
+++ b/grails-app/views/inventory/_filters.gsp
@@ -1,7 +1,6 @@
 <div class="filters" >
 	<g:form method="GET" controller="inventory" action="browse">
 		<g:hiddenField name="max" value="${params.max?:10 }"/>
-		<g:hiddenField name="location" value="${session.warehouse.id}"/>
 		<div class="box">
 			<h2><warehouse:message code="inventory.filterByProduct.label"/></h2>
 			<div class="filter-list-item">

--- a/grails-app/views/inventory/_filters.gsp
+++ b/grails-app/views/inventory/_filters.gsp
@@ -1,7 +1,7 @@
 <div class="filters" >
 	<g:form method="GET" controller="inventory" action="browse">
 		<g:hiddenField name="max" value="${params.max?:10 }"/>
-		<g:hiddenField name="location.id" value="${session.warehouse.id}"/>
+		<g:hiddenField name="location" value="${session.warehouse.id}"/>
 		<div class="box">
 			<h2><warehouse:message code="inventory.filterByProduct.label"/></h2>
 			<div class="filter-list-item">

--- a/grails-app/views/inventory/browse.gsp
+++ b/grails-app/views/inventory/browse.gsp
@@ -1,4 +1,5 @@
-<%@ page import="org.pih.warehouse.PagedResultList; org.pih.warehouse.core.Location" %>
+<%@ page import="org.pih.warehouse.PagedResultList" %>
+<%@ page import="org.pih.warehouse.core.Location" %>
 <%@ page import="org.pih.warehouse.product.Product" %>
 <html>
     <head>

--- a/grails-app/views/inventory/browse.gsp
+++ b/grails-app/views/inventory/browse.gsp
@@ -1,4 +1,4 @@
-<%@ page import="org.pih.warehouse.core.Location" %>
+<%@ page import="org.pih.warehouse.PagedResultList; org.pih.warehouse.core.Location" %>
 <%@ page import="org.pih.warehouse.product.Product" %>
 <html>
     <head>
@@ -151,7 +151,7 @@
 
 								</form>
 							</div>
-							<g:if test="${commandInstance?.searchResults instanceof grails.orm.PagedResultList}">
+							<g:if test="${commandInstance?.searchResults instanceof PagedResultList}">
 								<div class="paginateButtons">
 
 									<g:paginate total="${commandInstance?.searchResults?.totalCount}"


### PR DESCRIPTION
Pagination was not visible because `commandInstance?.searchResults instanceof grails.orm.PagedResultList` was false - PagedResultList is an instance of `org.pih.warehouse.PagedResultList`.

After fixing the issue described above I noticed that there is an error after changing the page with filters applied. In the URL we had two similar params: `location.id=...` and `location=[id: ...]`. This second one wasn't visible after changing the page with filters. I saw that the command instance assigned location to its property when there was just `location.id` passed. After passing the `location=[id: ...]` command used this one parameter to get the location property and after that error with an invalid constructor of the Location class was thrown. I removed the `.id` from the location param, so `location=[id: ...]` got overridden and the command assign an appropriate location to its property.