### PR TITLE
OBGM-520 Fix export product supplier missing data

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/product/ProductSupplierController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductSupplierController.groovy
@@ -306,9 +306,6 @@ class ProductSupplierController {
         }
         else {
             productSuppliers = ProductSupplier.createCriteria().list {
-                createAlias('supplier', 'supplier', JoinType.LEFT_OUTER_JOIN)
-                createAlias('manufacturer', 'manufacturer', JoinType.LEFT_OUTER_JOIN)
-                createAlias('contractPrice', 'contractPrice', JoinType.LEFT_OUTER_JOIN)
                 resultTransformer(CriteriaSpecification.ALIAS_TO_ENTITY_MAP)
                 projections {
                     property("active", "active")
@@ -320,13 +317,19 @@ class ProductSupplierController {
                         property("name", "productName")
                     }
                     property("productCode", "legacyProductCode")
-                    property("supplier.name", "supplier.name")
+                    supplier(JoinType.LEFT_OUTER_JOIN.joinTypeValue) {
+                        property("name", "supplier.name")
+                    }
                     property("supplierCode", "supplierCode")
-                    property("manufacturer.name", "manufacturer.name")
+                    manufacturer(JoinType.LEFT_OUTER_JOIN.joinTypeValue) {
+                        property("name", "manufacturer.name")
+                    }
                     property("manufacturerCode", "manufacturerCode")
                     property("minOrderQuantity", "minOrderQuantity")
-                    property("contractPrice.price", "contractPrice.price")
-                    property("contractPrice.toDate", "contractPrice.toDate")
+                    contractPrice(JoinType.LEFT_OUTER_JOIN.joinTypeValue) {
+                        property("price", "contractPrice.price")
+                        property("toDate", "contractPrice.toDate")
+                    }
                     property("ratingTypeCode", "ratingTypeCode")
                     property("dateCreated", "dateCreated")
                     property("lastUpdated", "lastUpdated")

--- a/grails-app/controllers/org/pih/warehouse/product/ProductSupplierController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductSupplierController.groovy
@@ -12,6 +12,7 @@ package org.pih.warehouse.product
 import grails.validation.ValidationException
 import org.hibernate.FetchMode
 import org.hibernate.criterion.CriteriaSpecification
+import org.hibernate.sql.JoinType
 import org.pih.warehouse.core.EntityTypeCode
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.PreferenceType
@@ -305,6 +306,9 @@ class ProductSupplierController {
         }
         else {
             productSuppliers = ProductSupplier.createCriteria().list {
+                createAlias('supplier', 'supplier', JoinType.LEFT_OUTER_JOIN)
+                createAlias('manufacturer', 'manufacturer', JoinType.LEFT_OUTER_JOIN)
+                createAlias('contractPrice', 'contractPrice', JoinType.LEFT_OUTER_JOIN)
                 resultTransformer(CriteriaSpecification.ALIAS_TO_ENTITY_MAP)
                 projections {
                     property("active", "active")
@@ -316,19 +320,13 @@ class ProductSupplierController {
                         property("name", "productName")
                     }
                     property("productCode", "legacyProductCode")
-                    supplier {
-                        property("name", "supplier.name")
-                    }
+                    property("supplier.name", "supplier.name")
                     property("supplierCode", "supplierCode")
-                    manufacturer {
-                        property("name", "manufacturer.name")
-                    }
+                    property("manufacturer.name", "manufacturer.name")
                     property("manufacturerCode", "manufacturerCode")
                     property("minOrderQuantity", "minOrderQuantity")
-                    contractPrice {
-                        property("price", "contractPrice.price")
-                        property("toDate", "contractPrice.toDate")
-                    }
+                    property("contractPrice.price", "contractPrice.price")
+                    property("contractPrice.toDate", "contractPrice.toDate")
                     property("ratingTypeCode", "ratingTypeCode")
                     property("dateCreated", "dateCreated")
                     property("lastUpdated", "lastUpdated")

--- a/grails-app/services/org/pih/warehouse/data/DataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/DataService.groovy
@@ -688,7 +688,7 @@ class DataService {
         includeFields.each { fieldName, element ->
             def value = null
             if (element instanceof LinkedHashMap) {
-                value = element.property.tokenize('.').inject(object) { v, k -> v?."$k" }
+                value = object.get(element.property) ?: element.property.tokenize('.').inject(object) { v, k -> v?."$k" }
                 if (element.defaultValue && element.dateFormat && !value) {
                     value = element.defaultValue.format(element.dateFormat)
                 } else if (element.dateFormat && value) {
@@ -698,7 +698,7 @@ class DataService {
                 }
                 properties[fieldName] = value ?: ""
             } else {
-                value = element.tokenize('.').inject(object) { v, k -> v?."$k" }
+                value = object.get(element) ?: element.tokenize('.').inject(object) { v, k -> v?."$k" }
                 properties[fieldName] = value ?: ""
             }
         }

--- a/grails-app/services/org/pih/warehouse/data/DataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/DataService.groovy
@@ -698,6 +698,8 @@ class DataService {
                 }
                 properties[fieldName] = value ?: ""
             } else {
+                // to access object value by key we must use the object.get(key) instead of object[key]
+                // because using the object[key] will throw an error when trying to export data using the batch controller
                 value = object.get(element) ?: element.tokenize('.').inject(object) { v, k -> v?."$k" }
                 properties[fieldName] = value ?: ""
             }

--- a/grails-app/views/batch/_uploadFileForm.gsp
+++ b/grails-app/views/batch/_uploadFileForm.gsp
@@ -174,12 +174,12 @@
                                 </label>
                             </td>
                             <td>
-                                <g:link controller="productSupplier" action="export" params="[format:'xls']">
+                                <g:link controller="batch" action="downloadTemplate" params="[template:'ProductSuppliers.xls']">
                                     <warehouse:message code="default.download.label" args="[g.message(code:'default.template.label')]"/>
                                 </g:link>
                             </td>
                             <td>
-                                <g:link controller="batch" action="downloadExcel" params="[type:'ProductSupplier']">
+                                 <g:link controller="productSupplier" action="export" params="[format:'xls']">
                                     <warehouse:message code="default.download.label" args="[g.message(code:'default.data.label')]"/>
                                 </g:link>
                             </td>

--- a/grails-app/views/batch/_uploadFileForm.gsp
+++ b/grails-app/views/batch/_uploadFileForm.gsp
@@ -174,7 +174,7 @@
                                 </label>
                             </td>
                             <td>
-                                <g:link controller="batch" action="downloadTemplate" params="[template:'ProductSuppliers.xls']">
+                                <g:link controller="productSupplier" action="export" params="[format:'xls']">
                                     <warehouse:message code="default.download.label" args="[g.message(code:'default.template.label')]"/>
                                 </g:link>
                             </td>


### PR DESCRIPTION
The core issue of this product supplier export bug was that some of the data was missing.
After debugging the code I figured out that the data that was missing involved records which had empty **supplier**, **manufacturer** or **contractPrice**. If you look at the previous criteria query you can see that all three of these attributes were specified as nested values in projections, like:
```
  supplier {
      property("name", "supplier.name")
  }
  manufacturer {
      property("name", "manufacturer.name")
  }
  contractPrice {
      property("price", "contractPrice.price")
      property("toDate", "contractPrice.toDate")
  }
```
so apparently when we want to access a nested value of a `null` attribute in a projection it ignores the whole record instead of returning a `null` for just this _attribute_.

Thank to @alannadolny for reminding me of the fact that criteria by default use the INNER JOIN
This is something that was discussed under the [product synonym issue](https://pihemr.atlassian.net/browse/OBGM-453?focusedCommentId=143166).
So a solution to this problem was to just do an appropriate association join on all of these three associations.

Interesting/ANNOYING thing I discovered while playing around with aliases and projections is,
given we have such a criteria
```groovy
ProductSupplier.createCriteria().list {
    property("name", "productName")
    property("productCode", "legacyProductCode")
    supplier {
        property("name", "supplier.name")
    }
}
```
to access `supplier.name` we have to do it the "nested object way" like presented above and accessing it like 
`property("supplier.name", "supplier.name")` will not work, but when we use aliases we can't use the "nested object way" and instead we have to access it the other way around :angry:
```groovy
ProductSupplier.createCriteria().list {
    createAlias('supplier', 'supplier', JoinType.LEFT_OUTER_JOIN)
    property("name", "productName")
    property("productCode", "legacyProductCode")
    property("supplier.name", "supplier.name")
}
```
this was way too confusing to understand why it works like that and the documentation wasn't of any help :disappointed:

The other issue that needed to be fixed was value-to-column mapping.
In our project we are achieving this by using `dataService.transformObjects` which takes the data and based on the PROPERTIES defined on the domain we map the keys to columns.
The problem there was that when mapping for example `supplier.name` it is trying to look for and map value like
```
[
  supplier: [ name: "example supplier name" ],
  ...
]
```
while our data object has a map of
```
[
  "supplier.name": "example supplier name"
]
```
so to fix this issue first we need to check for the flatten string key and then by nested attributes.
This is something that was previously implemented in the transformObject method but was removed due to the issue causing the document to crash because accessing non existing key https://github.com/openboxes/openboxes/pull/3520/files#diff-7982e9da0f9a55ec78c024b8d80f7a2095faabd97c9b47ad56fbc87de8040f21R693-R706
To prevent this bug from happening we need to use `object.get(key)` instead of `object[key]`. The former will return null if such a key doe snot exist and the latter will throw an expectation 