### PR TITLE
OBGM-549 Unpacked packing unit not visible on Packing list on SM view page 

### DIFF
--- a/grails-app/views/stockMovement/_packingList.gsp
+++ b/grails-app/views/stockMovement/_packingList.gsp
@@ -43,7 +43,7 @@
         </tr>
         <g:if test="${shipmentInstance?.shipmentItems}">
             <g:set var="count" value="${0 }"/>
-            <g:set var="previousContainer"/>
+            <g:set var="previousContainer" value=""/>
             <g:each var="shipmentItem" in="${shipmentInstance.sortShipmentItemsBySortOrder()}" status="i">
                 <g:set var="rowspan" value="${shipmentItemsByContainer[shipmentItem?.container]?.size() }"/>
                 <g:set var="newContainer" value="${previousContainer != shipmentItem?.container }"/>


### PR DESCRIPTION
In Grails 1 `<g:set var="previousContainer"/>` set value of `previousContainer` to empty string:
![image](https://github.com/openboxes/openboxes/assets/83239466/eda52a73-4954-4411-8c59-14cda6fafad2)
In Grails 3 value of `previousContainer` is null.
![Untitled](https://github.com/openboxes/openboxes/assets/83239466/f20b71c0-ece9-4bd9-920e-fb4b250e0772)
So, `previousContainer != shipmentItem?.container` was evaluated to false at the beginning, because it was `null != null`. It should be true to display `unpacked` (in Grails 1 it was `'' != null`)