### PR TITLE
OBGM-539 No longer able to download certificate of donation from send page of outbound and requests

### DIFF
--- a/grails-app/services/org/pih/warehouse/core/DocumentService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/DocumentService.groovy
@@ -1150,7 +1150,7 @@ class DocumentService {
             row.getCell(CELL_INDEX++).setCellStyle(tableHeaderLeftStyle)
 
             def totalPrice = 0
-            def previousContainer = "", initialRowIndex = 0, finalRowIndex = 0
+            def previousContainer = ""
             shipmentInstance.sortShipmentItemsBySortOrder().each { itemInstance ->
 
                 CELL_INDEX = 0
@@ -1162,12 +1162,6 @@ class DocumentService {
 
                 row.createCell(CELL_INDEX).setCellValue(row.getRowNum() - 6)
                 row.getCell(CELL_INDEX++).setCellStyle(tableDataCenterStyle)
-
-                if (row.getRowNum() > 16) {
-                    sheet.addMergedRegion(CellRangeAddress.valueOf("A${initialRowIndex + 1}:A${finalRowIndex + 1}"))
-                }
-                initialRowIndex = row.getRowNum()
-                finalRowIndex = row.getRowNum()
 
                 row.createCell(CELL_INDEX).setCellValue(itemInstance?.inventoryItem?.product?.productCode)
                 row.getCell(CELL_INDEX++).setCellStyle(tableDataLeftStyle)


### PR DESCRIPTION
Validation of merging regions in xls has changed. In the new version number of merging cells has to be higher than 1:
![Untitled](https://github.com/openboxes/openboxes/assets/83239466/a4a2bc03-998a-4492-8b34-bfc361a8dfea)
Meanwhile, in Grails 1 the only validation that is being checked is:
![image](https://github.com/openboxes/openboxes/assets/83239466/96ec775e-b859-4cc7-8909-9c7d2b044b22)
So, I removed the `initialRowIndex` and `finalRowIndex` variables. In the begging, both of them have 0 as a value. Later in each iteration, we assigned `row.getRowNum()` to both of them, so they have the same value every time.
When the number of cells was greater than 16, this part of the code was triggered:
`sheet.addMergedRegion(CellRangeAddress.valueOf("A${initialRowIndex + 1}:A${finalRowIndex + 1}"))`
So, because of the fact, that `initialRowIndex` and `finalRowIndex` are equal, we are doing sth like this:
`sheet.addMergedRegion(CellRangeAddress.valueOf("A17:A17"))`
`sheet.addMergedRegion(CellRangeAddress.valueOf("A18:A18"))`
`sheet.addMergedRegion(CellRangeAddress.valueOf("A19:A19"))`
and so on.
So we were always trying to merge only one cell and the validation didn't pass.
