### PR TITLE
OBGM-610 Fix creating an internal location

### DIFF
--- a/grails-app/taglib/org/pih/warehouse/SelectTagLib.groovy
+++ b/grails-app/taglib/org/pih/warehouse/SelectTagLib.groovy
@@ -445,12 +445,9 @@ class SelectTagLib {
     }
 
     def selectZoneLocationByLocation = { attrs, body ->
-        def location = Location.get(attrs.id)
+        Location location = Location.get(attrs.id)
 
-        if (location) {
-            attrs.from = locationService.getZones(location)
-        }
-
+        attrs.from = location ? locationService.getZones(location) : []
         attrs["class"] = "chzn-select-deselect"
         attrs["noSelection"] = ["null": ""]
         attrs.optionKey = 'id'

--- a/grails-app/views/location/edit.gsp
+++ b/grails-app/views/location/edit.gsp
@@ -138,7 +138,6 @@
                                                 id="${locationInstance?.parentLocation?.id}"
                                                 value="${locationInstance?.zone?.id}"
                                                 noSelection="['null': '']"
-                                                from="[]"
                                                 class="chzn-select-deselect"/>
                                     </td>
                                 </tr>

--- a/grails-app/views/location/edit.gsp
+++ b/grails-app/views/location/edit.gsp
@@ -138,6 +138,7 @@
                                                 id="${locationInstance?.parentLocation?.id}"
                                                 value="${locationInstance?.zone?.id}"
                                                 noSelection="['null': '']"
+                                                from="[]"
                                                 class="chzn-select-deselect"/>
                                     </td>
                                 </tr>


### PR DESCRIPTION
The `selectZoneLocationByLocation` is defined like this:
```groovy
def selectZoneLocationByLocation = { attrs, body ->
        def location = Location.get(attrs.id)

        if (location) {
            attrs.from = locationService.getZones(location)
        }

        attrs["class"] = "chzn-select-deselect"
        attrs["noSelection"] = ["null": ""]
        attrs.optionKey = 'id'
        attrs.optionValue = 'name'

        out << g.select(attrs)
    }
```
so we were only assigning `from` param if `location` is not falsy.

From the Grails 3 docs we can see that `from` param is required for `g:select`: 
![Screenshot from 2023-07-27 15-35-38](https://github.com/openboxes/openboxes/assets/93163821/6dbd4a3b-6ac2-461f-833c-665d09286617)
and that the implementation of the select has this if statement (2nd from the top):

![Screenshot from 2023-07-27 15-36-11](https://github.com/openboxes/openboxes/assets/93163821/dd20ec6d-1e2c-447c-b052-2316de0551c9)

which I couldn't find in the implementation in Grails 1. It's weird, because Grails 1 docs also say, that `from` param is required.
![Screenshot from 2023-07-27 15-38-41](https://github.com/openboxes/openboxes/assets/93163821/a029140d-426e-4119-acf6-15e83281710f)

