### PR TITLE
OBGM-598 Fix safely extracting ValidationException Root Cause on ErrorController and return translated errors

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/core/ErrorsController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/core/ErrorsController.groovy
@@ -11,6 +11,7 @@ package org.pih.warehouse.core
 
 import grails.converters.JSON
 import grails.core.GrailsApplication
+import org.grails.exceptions.ExceptionUtils
 import org.pih.warehouse.RequestUtil
 import org.springframework.validation.BeanPropertyBindingResult
 import util.ConfigHelper
@@ -97,12 +98,14 @@ class ErrorsController {
     def handleValidationErrors() {
         if (RequestUtil.isAjax(request)) {
             response.status = 400
-            BeanPropertyBindingResult errors = request?.exception?.cause?.target?.errors ?: request?.exception?.cause?.errors
+            Throwable exception = request.getAttribute('exception')
+            def root = ExceptionUtils.getRootCause(exception)
+            BeanPropertyBindingResult errors = root.getErrors()
             List<String> errorMessages = errors.allErrors.collect {
                 return g.message(error: it, locale: localizationService.currentLocale)
             }
             render([errorCode: 400,
-                    errorMessage: "Validation error. " + request?.exception?.cause?.target?.fullMessage ?: request?.exception?.cause?.fullMessage,
+                    errorMessage: "Validation error. " + root.fullMessage,
                     errorMessages: errorMessages
             ] as JSON)
             return


### PR DESCRIPTION
The issue that has been described in the ticket seems to be reproducible only on obdev3 (deployed app), locally everything seems to work properly fine, but the error did give me an idea of what could go wrong.

Since we were trying to extract errors in the following way 
```groovy
BeanPropertyBindingResult errors = request?.exception?.cause?.target?.errors ?: request?.exception?.cause?.errors
```
the **nullsafety** operator isn't really helping us in accessing class properties because in that case accessing a non-existing class property will throw an error either way, so that issue most likely was because the `request.exception.cause` did not contain `target` property which resulted in throwing.
By "not contain the property" I mean that it's not defined in the Exception class and not because it's value is `null`.

Looking for a way to better handle this validation exception I came across an exception handler taglib.
```gsp
<g:renderException exception="${exception}" />
```
After inspecting this taglib closure I saw how it's extracting the cause and errors and made similar changes in the code.

**RenderTagLib.groovy**
```groovy
Closure renderException = { Map attrs ->
        if (!(attrs?.exception instanceof Throwable)) {
              return
        }
        Throwable exception = (Throwable)attrs.exception
        
        Encoder htmlEncoder = codecLookup.lookupEncoder('HTML')

        def currentOut = out
        int statusCode = request.getAttribute('javax.servlet.error.status_code') as int
        currentOut << """<h1>Error ${prettyPrintStatus(statusCode)}</h1>
<dl class="error-details">
<dt>URI</dt><dd>${htmlEncoder.encode(WebUtils.getForwardURI(request) ?: request.getAttribute('javax.servlet.error.request_uri'))}</dd>
"""

        def root = ExceptionUtils.getRootCause(exception)
        currentOut << "<dt>Class</dt><dd>${root?.getClass()?.name ?: exception.getClass().name}</dd>"
        currentOut << "<dt>Message</dt><dd>${htmlEncoder.encode(exception.message)}</dd>"
        if (root != null && root != exception && root.message != exception.message) {
            currentOut << "<dt>Caused by</dt><dd>${htmlEncoder.encode(root.message)}</dd>"
        }
        currentOut << "</dl>"

        currentOut << errorsViewStackTracePrinter.prettyPrintCodeSnippet(exception)

        def trace = errorsViewStackTracePrinter.prettyPrint(exception.cause ?: exception)
        if (StringUtils.hasText(trace.trim())) {
            currentOut << "<h2>Trace</h2>"
            currentOut << '<pre class="stack">'
            currentOut << htmlEncoder.encode(trace)
            currentOut << '</pre>'
        }
    }
```

I am certain that this will fix the issue that came up on obdev3 but since I wasn't able to reproduce it locally I can't be 100% sure.