### PR TITLE
OBGM-586 Fix user reference that caused header of stocklist not editable

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/requisition/RequisitionTemplateController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/requisition/RequisitionTemplateController.groovy
@@ -14,6 +14,7 @@ import org.apache.commons.lang.StringEscapeUtils
 import grails.plugins.csv.CSVWriter
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.product.Product
+import org.pih.warehouse.auth.AuthService
 
 @Transactional
 class RequisitionTemplateController {
@@ -22,7 +23,6 @@ class RequisitionTemplateController {
     def inventoryService
     def productService
     def userService
-
     static allowedMethods = [save: "POST", update: "POST"]
 
     def index() {
@@ -137,7 +137,7 @@ class RequisitionTemplateController {
             }
             requisition.properties = params
             requisition.lastUpdated = new Date()
-            requisition.updatedBy = session.user
+            requisition.updatedBy = AuthService.currentUser
 
             if (!requisition.hasErrors() && requisition.save(flush: true)) {
                 flash.message = "${warehouse.message(code: 'default.updated.message', args: [warehouse.message(code: 'requisition.label', default: 'Requisition'), params.id])}"


### PR DESCRIPTION
The problem was difficult to identify, because random errors were thrown at the end of the session - sometimes regarding the template, sometimes regarding the `isUserAdmin` etc functions, so that led me to the point, that something must be wrong with the user.

The error I was getting the most times:
![Screenshot from 2023-08-01 14-26-19](https://github.com/openboxes/openboxes/assets/93163821/75c31eb3-ab8a-4506-aaef-fb217305aa3f)


The problem is that when we bind the properties to `requisition`, we also bind users instances here like `createdBy`, `requestedBy`, `updatedBy`.

When assigning the `requisition.updatedBy = session.user`, we were trying to assign a User object of identifier that is already known for this session (read the error message).
So in fact we were having two "different" (the same) objects with the same ID in the same session, which Hibernate doesn't allow.
Look at the numbers of the User object:

1. The `createdBy`, `updatedBy`, `requestedBy` after binding (23141):
![Screenshot from 2023-08-01 14-22-32](https://github.com/openboxes/openboxes/assets/93163821/6561ae85-c0af-4b86-9801-b36a648c8bfc)
2. `session.user` (22004):
![Screenshot from 2023-08-01 14-23-27](https://github.com/openboxes/openboxes/assets/93163821/0362b800-0f7c-497f-ab30-d1dd17f657e1)

3. `AuthService.currentUser` (23141):
![Screenshot from 2023-08-01 14-24-13](https://github.com/openboxes/openboxes/assets/93163821/20588aa0-551c-4451-83e9-b2c704a63e3a)


So you can see that `AuthService` is "compatible" with the session boundary, but the `session.*` itself, seems to be "deprecated" and it "lives" in its own session boundary.

