### PR TITLE
OBGM-619 Include out of stock checkbox not working on inventory browser 

### DIFF
--- a/src/main/groovy/org/pih/warehouse/inventory/InventoryCommand.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/InventoryCommand.groovy
@@ -31,11 +31,11 @@ class InventoryCommand implements Validateable {
     List searchResults = []
 
     // indicates whether to display hidden products
-    def showHiddenProducts = Boolean.FALSE
+    Boolean showHiddenProducts = Boolean.FALSE
     // indicates whether unsupported products for the warehouse should be included
-    def showUnsupportedProducts = Boolean.FALSE
+    Boolean showUnsupportedProducts = Boolean.FALSE
     // indicates whether non-inventory products for the warehouse should be included
-    def showNonInventoryProducts = Boolean.FALSE
+    Boolean showNonInventoryProducts = Boolean.FALSE
     // indicates whether out of stock products for the warehouse should be included
     Boolean showOutOfStockProducts = Boolean.FALSE
 

--- a/src/main/groovy/org/pih/warehouse/inventory/InventoryCommand.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/InventoryCommand.groovy
@@ -37,7 +37,7 @@ class InventoryCommand implements Validateable {
     // indicates whether non-inventory products for the warehouse should be included
     def showNonInventoryProducts = Boolean.FALSE
     // indicates whether out of stock products for the warehouse should be included
-    def showOutOfStockProducts = Boolean.FALSE
+    Boolean showOutOfStockProducts = Boolean.FALSE
 
     // all of the resulting ProductCommands above, organized by Category
     Boolean searchPerformed = Boolean.FALSE


### PR DESCRIPTION
The `showOutOfStockProducts` was not bound correctly, it is explained here: https://stackoverflow.com/questions/60990362/grails-command-object-not-binding-to-def-type

Part of the documentation linked in question above:
> Properties which are not bindable by default are those related to transient fields, dynamically typed properties and static properties.