### PR TITLE
OBGM-625 Fix transaction required exception when deleting a user

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/user/UserController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/user/UserController.groovy
@@ -17,6 +17,7 @@ import org.pih.warehouse.core.MailService
 import org.pih.warehouse.core.Role
 import org.pih.warehouse.core.RoleType
 import org.pih.warehouse.core.User
+import org.pih.warehouse.core.UserDataService
 
 import javax.imageio.ImageIO as IIO
 import javax.swing.*
@@ -34,6 +35,7 @@ class UserController {
     def locationService
     def localizationService
     LocationRoleDataService locationRoleDataService
+    UserDataService userGormService
 
     /**
      * Show index page - just a redirect to the list page.
@@ -332,14 +334,14 @@ class UserController {
 
         log.info("params " + params)
 
-        def userInstance = User.get(params.id)
+        User userInstance = userGormService.get(params.id)
         if (userInstance) {
             if (userInstance?.id == session?.user?.id) {
                 flash.message = "${warehouse.message(code: 'default.cannot.delete.self.message', args: [warehouse.message(code: 'user.label'), params.id])}"
                 redirect(action: "edit", id: params.id)
             } else {
                 try {
-                    userInstance.delete(flush: true)
+                    userGormService.delete(userInstance.id)
                     flash.message = "${warehouse.message(code: 'default.deleted.message', args: [warehouse.message(code: 'user.label'), params.id])}"
                     redirect(action: "list")
                 }

--- a/grails-app/services/org/pih/warehouse/core/UserDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/UserDataService.groovy
@@ -1,0 +1,12 @@
+package org.pih.warehouse.core
+
+import grails.gorm.services.Service
+
+@Service(value = User, name = "userGormService")
+interface UserDataService {
+    void delete(String id)
+
+    User save(User user)
+
+    User get(String id)
+}


### PR DESCRIPTION
It was meant to be a bigger issue due to a weird error Katarzyna has attached to the ticket. Since it was 5 SP I tried to reproduce the same issue what she had in the browser console, but I couldn't reproduce this particular issue. I think that this straight forward change is a clue to the problem and the error Katarzyna had, was a one time accident.

After the change a user is deleted properly and if it can't be deleted, we get an information that "User could not be deleted".