### PR TITLE
OBGM-623 Unable to unselect use default settings for locations 

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/core/LocationController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/core/LocationController.groovy
@@ -83,16 +83,12 @@ class LocationController {
                 throw new IllegalArgumentException("The organization ${selectedOrganization?.name} is inactive, you can't assign it to the location")
             }
             // If none supported activities are chosen, assign "None"
-            // [""].empty would evaluate to false, so we want to filter out falsy values with findAll{it}
-            List supportedActivities = params.list("supportedActivities").findAll{ it }
-            if (locationInstance?.id && supportedActivities?.empty) {
-                params.supportedActivities = [ActivityCode.NONE.id]
-            }
-
-            // Map supportedActivities to mark it as dirty for save,
+            // [""].empty would evaluate to false, so we want to filter out falsy values with findAll{ it }
+            // In other case map supportedActivities to mark it as dirty for save,
             // supportedActivities cannot be empty to avoid overriding ActivityCode.NONE
-            if (locationInstance?.id && !supportedActivities?.empty) {
-                params.supportedActivities = params.list("supportedActivities")
+            List supportedActivities = params.list("supportedActivities").findAll{ it }
+            if (locationInstance?.id) {
+                params.supportedActivities = supportedActivities?.empty ? [ActivityCode.NONE.id] : supportedActivities
             }
 
             locationInstance.properties = params

--- a/grails-app/controllers/org/pih/warehouse/core/LocationController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/core/LocationController.groovy
@@ -88,6 +88,13 @@ class LocationController {
             if (locationInstance?.id && supportedActivities?.empty) {
                 params.supportedActivities = [ActivityCode.NONE.id]
             }
+
+            // Map supportedActivities to mark it as dirty for save,
+            // supportedActivities cannot be empty to avoid overriding ActivityCode.NONE
+            if (locationInstance?.id && !supportedActivities?.empty) {
+                params.supportedActivities = params.list("supportedActivities")
+            }
+
             locationInstance.properties = params
 
             if (!locationInstance.id && !locationInstance.organization) {


### PR DESCRIPTION
In Grails 1 `supportedActivities` before saving was LinkedHashSet and after saving it was PersistentSet.
In Grails 3 it was HashSet and after saving it hasn't changed. Grails didn't notice that `supportedActivities` has changed and it wasn't marked as dirty. One solution could be just marking it as dirty or doing this trick with params. As I saw we did something similar to this so I decided to follow this approach.