### PR TITLE
OBGM-658 Fix requested by filter that missed records due to join type…

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -14,6 +14,7 @@ import grails.gorm.transactions.Transactional
 import grails.validation.ValidationException
 import org.grails.web.json.JSONObject
 import org.hibernate.ObjectNotFoundException
+import org.hibernate.sql.JoinType
 import org.pih.warehouse.PagedResultList
 import org.pih.warehouse.api.AvailableItem
 import org.pih.warehouse.api.AvailableItemStatus
@@ -405,7 +406,7 @@ class StockMovementService {
             }
             if (criteria.requestedBy) {
                 or {
-                    requisition {
+                    requisition(JoinType.LEFT_OUTER_JOIN.joinTypeValue) {
                         eq("requestedBy", criteria?.requestedBy)
                     }
                     and {


### PR DESCRIPTION
… of requisition

It was missing results when creating e.g. inbound returns, because those don't have requisition and due to the `inner join` that is made by default in `createCriteria` in Grails 3, those inbound returns were missing on the inbound list.