### PR TITLE
OBGM-635 Fix validation for negative quantity of RecordInventory

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
@@ -1350,7 +1350,7 @@ class InventoryService implements ApplicationContextAware {
 
         try {
             // Create a new transaction
-            def transaction = new Transaction(cmd.properties)
+            Transaction transaction = new Transaction(cmd.properties)
             transaction.inventory = cmd.inventory
             transaction.comment = cmd.comment
             transaction.transactionType = TransactionType.get(Constants.PRODUCT_INVENTORY_TRANSACTION_TYPE_ID)
@@ -1373,7 +1373,7 @@ class InventoryService implements ApplicationContextAware {
                     }
 
                     // 1. Find an existing inventory item for the given lot number and product and description
-                    def inventoryItem =
+                    InventoryItem inventoryItem =
                             findInventoryItemByProductAndLotNumber(cmd.product, row.lotNumber)
 
                     // 2. If the inventory item doesn't exist, we create a new one
@@ -1399,7 +1399,7 @@ class InventoryService implements ApplicationContextAware {
                         }
                     }
                     // 3. Create a new transaction entry (even if quantity didn't change)
-                    def transactionEntry = new TransactionEntry()
+                    TransactionEntry transactionEntry = new TransactionEntry()
                     transactionEntry.properties = row.properties
                     transactionEntry.quantity = row.newQuantity
                     transactionEntry.product = inventoryItem?.product

--- a/src/main/groovy/org/pih/warehouse/inventory/RecordInventoryCommand.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/RecordInventoryCommand.groovy
@@ -13,6 +13,7 @@ import grails.validation.Validateable
 import org.apache.commons.collections.FactoryUtils
 import org.apache.commons.collections.list.LazyList
 import org.pih.warehouse.product.Product
+import org.springframework.validation.Errors
 
 class RecordInventoryCommand implements Validateable {
 
@@ -36,7 +37,7 @@ class RecordInventoryCommand implements Validateable {
         transactionDate(nullable: false)
         comment(nullable: true)
         recordInventoryRow(nullable: true)
-        recordInventoryRows(validator: { val, obj, errors ->
+        recordInventoryRows(validator: { List<RecordInventoryRowCommand> val,  RecordInventoryCommand obj,  Errors errors ->
             def errorsFound = false
             val.each { row ->
                 if (row) {
@@ -44,7 +45,7 @@ class RecordInventoryCommand implements Validateable {
                     if (!row?.validate()) {
                         errorsFound = true
                         row.errors.allErrors.each { error ->
-                            obj.errors.rejectValue('recordInventoryRows', "recordInventoryCommand.recordInventoryRows.invalid",
+                            errors.rejectValue('recordInventoryRows', "recordInventoryCommand.recordInventoryRows.invalid",
                                     [row, error.getField(), error.getRejectedValue()] as Object[],
                                     "Property [${error.getField()}] of lot number #${row?.lotNumber} with value [${error.getRejectedValue()}] is invalid.")
                         }


### PR DESCRIPTION
The problem was hard to spot, so I'll explain it:
In my opinion implementations of `validator` is different in Grails 1 and in Grails 3.

`validator` accepts up to three parameters: `value` (that we are validating), `object` (that owns this value/property), `errors`.
Instead of adding an error to `errors` (3rd parameter of `validator` closure), we were adding it to `object.errors` which in fact was the same in Grails 1 (more below with examples), but was not the same in Grails 3.

### Grails 1 screenshots:
![Screenshot from 2023-08-05 20-02-33](https://github.com/openboxes/openboxes/assets/93163821/2246ec54-ad60-4d73-b9c6-006dc92daaeb)
![Screenshot from 2023-08-05 20-02-47](https://github.com/openboxes/openboxes/assets/93163821/e051e9a7-d387-46bb-afe0-d1f73752877c)
![Screenshot from 2023-08-05 20-03-26](https://github.com/openboxes/openboxes/assets/93163821/f20b108c-5dac-4df3-9afd-d90c5f248b70)

As you can see we were always operating on the same `BeanPropertyBindingResult` of hash `16619`, so: `obj.errors` and `errors` were the same thing and also the `commandInstance.errors` in the service were still pointing to the `16619`.


### Now look, what was going on in Grails 3:
![Screenshot from 2023-08-05 20-08-27](https://github.com/openboxes/openboxes/assets/93163821/35b74fed-e6a5-40ef-b427-ca67eb8d01fd)
![Screenshot from 2023-08-05 20-08-40](https://github.com/openboxes/openboxes/assets/93163821/19e1053c-f57b-4fb2-883a-2b66e8a223a9)
![Screenshot from 2023-08-05 20-09-09](https://github.com/openboxes/openboxes/assets/93163821/43c2fd2e-2d85-404f-aafd-2fbd1d74adfe)

You can see that the `obj.errors` has initial hash of `21961` and the `errors` has `17884`. More importantly - you can see that after validating, in the controller layer the `commandInstance.errors` (which was the `obj.errors` in the validator) has changed to `17884` - so I assume at the end, the `validator` was doing something like:
```groovy
obj.errors = errors
```
so because were operating on `obj.errors`, the `errors` were "untouched" (they stored 0 errors), that's why the validation did not work, because in Grails 3, the `obj.errors` that we were assigning the error to, was at the end of validator overwritten to `errors`.


What steered me to this solution were the docs, where they tend to use the `errors` object for that (as I changed it to) instead of assigning the errors to `obj.errors`:
 
![Screenshot from 2023-08-05 20-26-54](https://github.com/openboxes/openboxes/assets/93163821/7f46f16f-f96a-4a56-a70c-5c0016851a71)
