### PR TITLE
OBGM-627 Unable to go forward/backward on Address page in location configuration 

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -198,6 +198,7 @@ grails:
     databinding:
         dateFormats:
             - 'MM/dd/yyyy'
+        convertEmptyStringsToNull: false
 endpoints:
     jmx:
         unique-names: true

--- a/src/js/api/urls.js
+++ b/src/js/api/urls.js
@@ -54,6 +54,7 @@ export const USERS_OPTIONS = `${API}/users`;
 export const LOCATION_API = `${API}/locations`;
 export const LOCATION_TYPES = `${LOCATION_API}/locationTypes`;
 export const LOCATION_TEMPLATE = `${CONTEXT_PATH}${LOCATION_API}/template`;
+export const LOCATION = id => `${LOCATION_API}/${id}`;
 
 // ORDER
 export const ORDER = `${CONTEXT_PATH}/order`;

--- a/src/js/components/locations-configuration/LocationAddress.jsx
+++ b/src/js/components/locations-configuration/LocationAddress.jsx
@@ -9,8 +9,9 @@ import { withRouter } from 'react-router-dom';
 import Alert from 'react-s-alert';
 
 import { hideSpinner, showSpinner } from 'actions';
+import { LOCATION } from 'api/urls';
 import TextField from 'components/form-elements/TextField';
-import apiClient, { flattenRequest } from 'utils/apiClient';
+import apiClient, { mapToEmptyString } from 'utils/apiClient';
 import { renderFormField } from 'utils/form-utils';
 import Translate, { translateWithDefaultMessage } from 'utils/Translate';
 
@@ -99,14 +100,14 @@ class LocationAddress extends Component {
   }
 
   saveAddressOfLocation(values, callback) {
-    const valuesAsAddressObject = {
-      address: {
-        ...values,
-      },
-    };
     this.props.showSpinner();
-    const locationUrl = `/api/locations/${this.state.locationId}`;
-    apiClient.post(locationUrl, flattenRequest(valuesAsAddressObject))
+    const payload = mapToEmptyString(values, [null]);
+    // If field was edited it is undefined and we need to send empty string
+    // to remove it from location. If it is null, there is no need to send it, because
+    // it will be null be default
+    // We can't send empty address, because address.address is not nullable field
+    const addressPayload = !_.isEmpty(payload) ? { address: payload } : {};
+    apiClient.post(LOCATION(this.state.locationId), addressPayload)
       .then(() => {
         this.props.hideSpinner();
         callback({

--- a/src/js/utils/apiClient.jsx
+++ b/src/js/utils/apiClient.jsx
@@ -8,6 +8,7 @@ import { confirmAlert } from 'react-confirm-alert';
 import notification from 'components/Layout/notifications/notification';
 import LoginModal from 'components/LoginModal';
 import NotificationType from 'consts/notificationTypes';
+import { object } from 'prop-types';
 
 export const justRejectRequestError = (error) => Promise.reject(error);
 
@@ -142,6 +143,15 @@ export const mapToEmptyString = (values, valuesToSkip = []) => Object.keys(value
     if (values[curr] in valuesToSkip) {
       return acc;
     }
+
+    if (_.isPlainObject(values[curr])) {
+      const nestedObject = mapToEmptyString(values[curr], valuesToSkip);
+      return {
+        ...acc,
+        nestedObject,
+      };
+    }
+
     if (values[curr]) {
       return {
         ...acc,

--- a/src/js/utils/apiClient.jsx
+++ b/src/js/utils/apiClient.jsx
@@ -137,6 +137,23 @@ export const handleValidationErrors = (setState) => (error) => {
   return handleError(error);
 };
 
+export const mapToEmptyString = (values, valuesToSkip = []) => Object.keys(values)
+  .reduce((acc, curr) => {
+    if (values[curr] in valuesToSkip) {
+      return acc;
+    }
+    if (values[curr]) {
+      return {
+        ...acc,
+        [curr]: values[curr],
+      };
+    }
+    return {
+      ...acc,
+      [curr]: '',
+    };
+  }, {});
+
 apiClient.interceptors.response.use(handleSuccess, handleError);
 apiClient.interceptors.request.use(urlInterceptor, justRejectRequestError);
 


### PR DESCRIPTION
In this ticket, I found two issues that needed fixing. First was connected to `flattenRequest` function, which we used to flatten our request before being sent (In Grails 1). Apart from flattening, this function removed properties that were null.
I logged results for empty properties in the address with `flattenRequest` and without it. The results were as follows:
![image](https://github.com/openboxes/openboxes/assets/83239466/e7cac85a-52ee-49f3-a3df-644c2c2f2526)
So, removing empty properties solved saving addresses and moving forward and backward without addresses.
After fixing it, I was thinking about the case when we want to delete the address and going forward and backward - removing inputted address and going backward didn't send the changes we made, because we removed it in the solution described above. So, I had to check again what's the difference between Grails 1 and Grails 3 ... And I noticed that when we didn't input the address we sent an empty address object, but when we added an address and then removed it, we sent an object like this:
[Screenshot from Grails 1]
![image](https://github.com/openboxes/openboxes/assets/83239466/302501a0-f347-4544-a9f7-7ef300f6ac14)
So I did the same payload as we had in Grails 1 and noticed that the validation is also thrown after removing the address. After searching for this behavior I found a difference in config. Grails 3 didn't allow us to bind empty strings, because he converts empty strings to null, and then the validation fails on `nullable: false` in `Address` domains constraints. 
![image](https://github.com/openboxes/openboxes/assets/83239466/cb1d6eec-c7a8-445f-85ff-fcbb403c8b55)
And below that, I found a setting that leaves the empty string as an empty string, not a null.
![image](https://github.com/openboxes/openboxes/assets/83239466/4d96530a-e5e7-40d6-816e-91351a6cc3f8)
In Grails 1, it wasn't converted to null, so this change can potentially fix some similar issues. In GitHub, I found that someone noticed this change between Grails 3.1.9 and 3.3.1.

There is some information about it:
[GitHub issue with this change]
https://github.com/grails/grails-core/issues/10846
[Similar problem in stackOverflow]
https://stackoverflow.com/questions/24207822/why-are-empty-strings-converted-to-null-passing-to-the-constructor-of-the-domain
[Docs with this information about nullable]
https://grails.github.io/legacy-grails-doc/3.1.10/ref/Constraints/nullable.html