### PR TITLE
OBGM-616 Fix OrderItems price history criteria query to include orderItems with null suppliers

### DIFF
--- a/grails-app/services/org/pih/warehouse/order/OrderService.groovy
+++ b/grails-app/services/org/pih/warehouse/order/OrderService.groovy
@@ -1132,11 +1132,11 @@ class OrderService {
                     property("productCode", "productCode")
                     property("name", "productName")
                 }
-                productSupplier {
+                productSupplier(JoinType.LEFT_OUTER_JOIN.joinTypeValue) {
                     property("code", "sourceCode")
                     property("supplierCode", "supplierCode")
                     property("manufacturerCode", "manufacturerCode")
-                    manufacturer {
+                    manufacturer(JoinType.LEFT_OUTER_JOIN.joinTypeValue) {
                         property("name", "manufacturerName")
                     }
                 }


### PR DESCRIPTION
I have added a LEFT OUTER join on **productSupliers** and **manufacturer** because these fields can be `null` unlike **product** and **order** which are required based on constraints.
Pointing this out for anyone wondering why I didn't add the left joins on those other fields