### PR TITLE
OBGM-650 Unable to import dates in product source preference import 

### DIFF
--- a/grails-app/services/org/pih/warehouse/data/ProductSupplierPreferenceDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSupplierPreferenceDataService.groovy
@@ -30,16 +30,10 @@ class ProductSupplierPreferenceDataService {
             def supplierCode = params.supplierCode
             def organizationCode = params.organizationCode
             def preferenceTypeName = params.preferenceTypeName
-            Date validityStartDate, validityEndDate
-            if (params.validityStartDate.isNumber()) {
-                validityStartDate = CSVUtils.parseDateFromExcel(params.validityStartDate as Integer)
-                validityEndDate = CSVUtils.parseDateFromExcel(params.validityEndDate as Integer)
-                params.validityStartDate = validityStartDate.format("MM/dd/yyyy")
-                params.validityEndDate = validityEndDate.format("MM/dd/yyyy")
-            } else {
-                validityStartDate = Date.from(params.validityStartDate)
-                validityEndDate = Date.from(params.validityEndDate)
-            }
+            params.validityStartDate = params.validityStartDate?.isNumber() ?
+                    CSVUtils.getDateFromExcel(params.validityStartDate as Integer) : params.validityStartDate
+            params.validityEndDate = params.validityEndDate?.isNumber() ?
+                    CSVUtils.getDateFromExcel(params.validityEndDate as Integer) : params.validityEndDate
 
             if (!supplierCode) {
                 command.errors.reject("Row ${index + 1}: Product source code is required")
@@ -59,19 +53,20 @@ class ProductSupplierPreferenceDataService {
                 command.errors.reject("Row ${index + 1}: Preference Type with name: ${preferenceTypeName} does not exist")
             }
 
-            if (validityStartDate) {
+            def dateFormat = new SimpleDateFormat("MM/dd/yyyy")
+            if (params.validityStartDate) {
                 try {
-                    validityStartDate.format("MM/dd/yyyy")
+                    dateFormat.parse(params.validityStartDate)
                 } catch (Exception e) {
-                    command.errors.reject("Row ${index + 1}: Validity start date ${validityStartDate} is invalid")
+                    command.errors.reject("Row ${index + 1}: Validity start date ${params.validityStartDate} is invalid")
                 }
             }
 
-            if (validityEndDate) {
+            if (params.validityEndDate) {
                 try {
-                    validityEndDate.format("MM/dd/yyyy")
+                    dateFormat.parse(params.validityEndDate)
                 } catch (Exception e) {
-                    command.errors.reject("Row ${index + 1}: Validity end date ${validityEndDate} is invalid")
+                    command.errors.reject("Row ${index + 1}: Validity end date ${params.validityEndDate} is invalid")
                 }
             }
         }

--- a/grails-app/services/org/pih/warehouse/data/ProductSupplierPreferenceDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSupplierPreferenceDataService.groovy
@@ -12,7 +12,6 @@ package org.pih.warehouse.data
 import grails.gorm.transactions.Transactional
 import org.pih.warehouse.core.Organization
 import org.pih.warehouse.core.PreferenceType
-import org.pih.warehouse.importer.CSVUtils
 import org.pih.warehouse.importer.ImportDataCommand
 import org.pih.warehouse.product.ProductSupplier
 import org.pih.warehouse.product.ProductSupplierPreference
@@ -27,13 +26,11 @@ class ProductSupplierPreferenceDataService {
         log.info "Validate data " + command.filename
         command.data.eachWithIndex { params, index ->
 
-            def supplierCode = params.supplierCode
-            def organizationCode = params.organizationCode
-            def preferenceTypeName = params.preferenceTypeName
-            params.validityStartDate = params.validityStartDate?.isNumber() ?
-                    CSVUtils.parseExcelDate(params.validityStartDate as Integer) : params.validityStartDate
-            params.validityEndDate = params.validityEndDate?.isNumber() ?
-                    CSVUtils.parseExcelDate(params.validityEndDate as Integer) : params.validityEndDate
+            String supplierCode = params.supplierCode
+            String organizationCode = params.organizationCode
+            String preferenceTypeName = params.preferenceTypeName
+            Date validityStartDate = params.validityStartDate
+            Date validityEndDate = params.validityEndDate
 
             if (!supplierCode) {
                 command.errors.reject("Row ${index + 1}: Product source code is required")
@@ -53,18 +50,18 @@ class ProductSupplierPreferenceDataService {
                 command.errors.reject("Row ${index + 1}: Preference Type with name: ${preferenceTypeName} does not exist")
             }
 
-            def dateFormat = new SimpleDateFormat("MM/dd/yyyy")
-            if (params.validityStartDate) {
+            String dateFormat = "MM/dd/yyyy"
+            if (validityStartDate) {
                 try {
-                    dateFormat.parse(params.validityStartDate)
+                    params.validityStartDate = validityStartDate.format(dateFormat)
                 } catch (Exception e) {
                     command.errors.reject("Row ${index + 1}: Validity start date ${params.validityStartDate} is invalid")
                 }
             }
 
-            if (params.validityEndDate) {
+            if (validityEndDate) {
                 try {
-                    dateFormat.parse(params.validityEndDate)
+                    params.validityEndDate = validityEndDate.format(dateFormat)
                 } catch (Exception e) {
                     command.errors.reject("Row ${index + 1}: Validity end date ${params.validityEndDate} is invalid")
                 }

--- a/grails-app/services/org/pih/warehouse/data/ProductSupplierPreferenceDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSupplierPreferenceDataService.groovy
@@ -24,13 +24,14 @@ class ProductSupplierPreferenceDataService {
 
     Boolean validate(ImportDataCommand command) {
         log.info "Validate data " + command.filename
+        String dateFormat = "MM/dd/yyyy"
         command.data.eachWithIndex { params, index ->
 
             String supplierCode = params.supplierCode
             String organizationCode = params.organizationCode
             String preferenceTypeName = params.preferenceTypeName
-            Date validityStartDate = params.validityStartDate
-            Date validityEndDate = params.validityEndDate
+            params.validityStartDate = params?.validityStartDate?.format(dateFormat)
+            params.validityEndDate = params?.validityEndDate?.format(dateFormat)
 
             if (!supplierCode) {
                 command.errors.reject("Row ${index + 1}: Product source code is required")
@@ -48,23 +49,6 @@ class ProductSupplierPreferenceDataService {
                 command.errors.reject("Row ${index + 1}: Preference Type is required")
             } else if (!PreferenceType.findByName(preferenceTypeName)) {
                 command.errors.reject("Row ${index + 1}: Preference Type with name: ${preferenceTypeName} does not exist")
-            }
-
-            String dateFormat = "MM/dd/yyyy"
-            if (validityStartDate) {
-                try {
-                    params.validityStartDate = validityStartDate.format(dateFormat)
-                } catch (Exception e) {
-                    command.errors.reject("Row ${index + 1}: Validity start date ${params.validityStartDate} is invalid")
-                }
-            }
-
-            if (validityEndDate) {
-                try {
-                    params.validityEndDate = validityEndDate.format(dateFormat)
-                } catch (Exception e) {
-                    command.errors.reject("Row ${index + 1}: Validity end date ${params.validityEndDate} is invalid")
-                }
             }
         }
     }

--- a/grails-app/services/org/pih/warehouse/data/ProductSupplierPreferenceDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSupplierPreferenceDataService.groovy
@@ -31,9 +31,9 @@ class ProductSupplierPreferenceDataService {
             def organizationCode = params.organizationCode
             def preferenceTypeName = params.preferenceTypeName
             params.validityStartDate = params.validityStartDate?.isNumber() ?
-                    CSVUtils.getDateFromExcel(params.validityStartDate as Integer) : params.validityStartDate
+                    CSVUtils.parseExcelDate(params.validityStartDate as Integer) : params.validityStartDate
             params.validityEndDate = params.validityEndDate?.isNumber() ?
-                    CSVUtils.getDateFromExcel(params.validityEndDate as Integer) : params.validityEndDate
+                    CSVUtils.parseExcelDate(params.validityEndDate as Integer) : params.validityEndDate
 
             if (!supplierCode) {
                 command.errors.reject("Row ${index + 1}: Product source code is required")

--- a/grails-app/services/org/pih/warehouse/data/ProductSupplierPreferenceDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSupplierPreferenceDataService.groovy
@@ -12,6 +12,7 @@ package org.pih.warehouse.data
 import grails.gorm.transactions.Transactional
 import org.pih.warehouse.core.Organization
 import org.pih.warehouse.core.PreferenceType
+import org.pih.warehouse.importer.CSVUtils
 import org.pih.warehouse.importer.ImportDataCommand
 import org.pih.warehouse.product.ProductSupplier
 import org.pih.warehouse.product.ProductSupplierPreference
@@ -29,8 +30,16 @@ class ProductSupplierPreferenceDataService {
             def supplierCode = params.supplierCode
             def organizationCode = params.organizationCode
             def preferenceTypeName = params.preferenceTypeName
-            def validityStartDate = params.validityStartDate
-            def validityEndDate = params.validityEndDate
+            Date validityStartDate, validityEndDate
+            if (params.validityStartDate.isNumber()) {
+                validityStartDate = CSVUtils.parseDateFromExcel(params.validityStartDate as Integer)
+                validityEndDate = CSVUtils.parseDateFromExcel(params.validityEndDate as Integer)
+                params.validityStartDate = validityStartDate.format("MM/dd/yyyy")
+                params.validityEndDate = validityEndDate.format("MM/dd/yyyy")
+            } else {
+                validityStartDate = Date.from(params.validityStartDate)
+                validityEndDate = Date.from(params.validityEndDate)
+            }
 
             if (!supplierCode) {
                 command.errors.reject("Row ${index + 1}: Product source code is required")
@@ -50,10 +59,9 @@ class ProductSupplierPreferenceDataService {
                 command.errors.reject("Row ${index + 1}: Preference Type with name: ${preferenceTypeName} does not exist")
             }
 
-            def dateFormat = new SimpleDateFormat("MM/dd/yyyy")
             if (validityStartDate) {
                 try {
-                    dateFormat.parse(validityStartDate)
+                    validityStartDate.format("MM/dd/yyyy")
                 } catch (Exception e) {
                     command.errors.reject("Row ${index + 1}: Validity start date ${validityStartDate} is invalid")
                 }
@@ -61,7 +69,7 @@ class ProductSupplierPreferenceDataService {
 
             if (validityEndDate) {
                 try {
-                    dateFormat.parse(validityEndDate)
+                    validityEndDate.format("MM/dd/yyyy")
                 } catch (Exception e) {
                     command.errors.reject("Row ${index + 1}: Validity end date ${validityEndDate} is invalid")
                 }

--- a/grails-app/services/org/pih/warehouse/data/ProductSupplierPreferenceDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSupplierPreferenceDataService.groovy
@@ -15,7 +15,6 @@ import org.pih.warehouse.core.PreferenceType
 import org.pih.warehouse.importer.ImportDataCommand
 import org.pih.warehouse.product.ProductSupplier
 import org.pih.warehouse.product.ProductSupplierPreference
-import java.text.SimpleDateFormat
 
 @Transactional
 class ProductSupplierPreferenceDataService {
@@ -24,14 +23,11 @@ class ProductSupplierPreferenceDataService {
 
     Boolean validate(ImportDataCommand command) {
         log.info "Validate data " + command.filename
-        String dateFormat = "MM/dd/yyyy"
         command.data.eachWithIndex { params, index ->
 
             String supplierCode = params.supplierCode
             String organizationCode = params.organizationCode
             String preferenceTypeName = params.preferenceTypeName
-            params.validityStartDate = params?.validityStartDate?.format(dateFormat)
-            params.validityEndDate = params?.validityEndDate?.format(dateFormat)
 
             if (!supplierCode) {
                 command.errors.reject("Row ${index + 1}: Product source code is required")
@@ -66,12 +62,12 @@ class ProductSupplierPreferenceDataService {
 
     def createOrUpdate(Map params) {
 
-        def supplierCode = params.supplierCode
-        def organizationCode = params.organizationCode
-        def preferenceTypeName = params.preferenceTypeName
-        def validityStartDate = params.validityStartDate
-        def validityEndDate = params.validityEndDate
-        def preferenceComments = params.preferenceComments
+        String supplierCode = params.supplierCode
+        String organizationCode = params.organizationCode
+        String preferenceTypeName = params.preferenceTypeName
+        Date validityStartDate = params.validityStartDate
+        Date validityEndDate = params.validityEndDate
+        String preferenceComments = params.preferenceComments
 
         ProductSupplier productSupplier = ProductSupplier.findByCode(supplierCode)
         Organization organization = null
@@ -80,17 +76,13 @@ class ProductSupplierPreferenceDataService {
         }
         PreferenceType preferenceType = PreferenceType.findByName(preferenceTypeName)
 
-        def dateFormat = new SimpleDateFormat("MM/dd/yyyy")
-        Date parsedValidityStartDate = validityStartDate ? dateFormat.parse(validityStartDate) : null
-        Date parsedValidityEndDate = validityEndDate ? dateFormat.parse(validityEndDate) : null
-
         ProductSupplierPreference existingPreference = ProductSupplierPreference
                 .findByProductSupplierAndDestinationParty(productSupplier, organization)
 
         if (existingPreference) {
             existingPreference.preferenceType = preferenceType
-            existingPreference.validityStartDate = parsedValidityStartDate
-            existingPreference.validityEndDate = parsedValidityEndDate
+            existingPreference.validityStartDate = validityStartDate
+            existingPreference.validityEndDate = validityEndDate
             existingPreference.comments = preferenceComments
             return existingPreference
         } else {
@@ -98,8 +90,8 @@ class ProductSupplierPreferenceDataService {
             newPreference.productSupplier = productSupplier
             newPreference.destinationParty = organization
             newPreference.preferenceType = preferenceType
-            newPreference.validityStartDate = parsedValidityStartDate
-            newPreference.validityEndDate = parsedValidityEndDate
+            newPreference.validityStartDate = validityStartDate
+            newPreference.validityEndDate = validityEndDate
             newPreference.comments = preferenceComments
             return newPreference
         }

--- a/src/main/groovy/org/pih/warehouse/importer/CSVUtils.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/CSVUtils.groovy
@@ -201,8 +201,10 @@ class CSVUtils {
         return detector.getDetectedCharset() ?: 'MacRoman';
     }
 
-    static Date parseDateFromExcel(Integer daysNumber) {
-        Date startDate = Date.parse("MM/dd/yyyy", "01/01/1900")
-        return startDate + daysNumber - 2
+    static String getDateFromExcel(Integer daysNumber) {
+        String dateFormat = "MM/dd/yyyy"
+        Date startDate = Date.parse(dateFormat, "01/01/1900")
+        Date convertedDate = startDate + daysNumber - 2
+        return convertedDate.format(dateFormat)
     }
 }

--- a/src/main/groovy/org/pih/warehouse/importer/CSVUtils.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/CSVUtils.groovy
@@ -200,4 +200,9 @@ class CSVUtils {
         detector.dataEnd();
         return detector.getDetectedCharset() ?: 'MacRoman';
     }
+
+    static Date parseDateFromExcel(Integer daysNumber) {
+        Date startDate = Date.parse("MM/dd/yyyy", "01/01/1900")
+        return startDate + daysNumber - 2
+    }
 }

--- a/src/main/groovy/org/pih/warehouse/importer/CSVUtils.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/CSVUtils.groovy
@@ -201,7 +201,7 @@ class CSVUtils {
         return detector.getDetectedCharset() ?: 'MacRoman';
     }
 
-    static String getDateFromExcel(Integer daysNumber) {
+    static String parseExcelDate(Integer daysNumber) {
         String dateFormat = "MM/dd/yyyy"
         Date startDate = Date.parse(dateFormat, "01/01/1900")
         Date convertedDate = startDate + daysNumber - 2

--- a/src/main/groovy/org/pih/warehouse/importer/CSVUtils.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/CSVUtils.groovy
@@ -200,11 +200,4 @@ class CSVUtils {
         detector.dataEnd();
         return detector.getDetectedCharset() ?: 'MacRoman';
     }
-
-    static String parseExcelDate(Integer daysNumber) {
-        String dateFormat = "MM/dd/yyyy"
-        Date startDate = Date.parse(dateFormat, "01/01/1900")
-        Date convertedDate = startDate + daysNumber - 2
-        return convertedDate.format(dateFormat)
-    }
 }

--- a/src/main/groovy/org/pih/warehouse/importer/ProductSupplierPreferenceImporter.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/ProductSupplierPreferenceImporter.groovy
@@ -34,8 +34,8 @@ class ProductSupplierPreferenceImporter extends AbstractExcelImporter {
             organizationCode     : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
             organizationName     : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
             preferenceTypeName   : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
-            validityStartDate    : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
-            validityEndDate      : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
+            validityStartDate    : ([expectedType: ExpectedPropertyType.DateJavaType, defaultValue: null]),
+            validityEndDate      : ([expectedType: ExpectedPropertyType.DateJavaType, defaultValue: null]),
             preferenceComments   : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
     ]
 

--- a/src/main/groovy/org/pih/warehouse/importer/ProductSupplierPreferenceImporter.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/ProductSupplierPreferenceImporter.groovy
@@ -34,8 +34,8 @@ class ProductSupplierPreferenceImporter extends AbstractExcelImporter {
             organizationCode     : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
             organizationName     : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
             preferenceTypeName   : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
-            validityStartDate    : ([expectedType: ExpectedPropertyType.DateType, defaultValue: null]),
-            validityEndDate      : ([expectedType: ExpectedPropertyType.DateType, defaultValue: null]),
+            validityStartDate    : ([expectedType: ExpectedPropertyType.DateJavaType, defaultValue: null]),
+            validityEndDate      : ([expectedType: ExpectedPropertyType.DateJavaType, defaultValue: null]),
             preferenceComments   : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
     ]
 

--- a/src/main/groovy/org/pih/warehouse/importer/ProductSupplierPreferenceImporter.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/ProductSupplierPreferenceImporter.groovy
@@ -34,8 +34,8 @@ class ProductSupplierPreferenceImporter extends AbstractExcelImporter {
             organizationCode     : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
             organizationName     : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
             preferenceTypeName   : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
-            validityStartDate    : ([expectedType: ExpectedPropertyType.DateJavaType, defaultValue: null]),
-            validityEndDate      : ([expectedType: ExpectedPropertyType.DateJavaType, defaultValue: null]),
+            validityStartDate    : ([expectedType: ExpectedPropertyType.DateType, defaultValue: null]),
+            validityEndDate      : ([expectedType: ExpectedPropertyType.DateType, defaultValue: null]),
             preferenceComments   : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
     ]
 


### PR DESCRIPTION
This issue was caused by importing dates as Excel dates, not as a string. It leads to different dates in the table and in the message above the table. It's visible on the screenshot that Katarzyna pasted to the ticket:
![image](https://github.com/openboxes/openboxes/assets/83239466/5579a6bc-a1cb-4977-9612-2ffc56ef13ea)
This number is visible instead of the normal date, because of the method that Excel uses to store his dates - it is a number of days counted from 1st January of the 1900 year.

Here is an explanation of how it works:
https://community.fabric.microsoft.com/t5/Desktop/Convert-a-date-value-like-42917-to-date/m-p/559598

So, I created a function `getDateFromExcel` which converts days to normal dates. In this function, I had to subtract two days from the result, because of the Excel oddity. 
The first day to subtract is because of that, Excel counts 01/01/1900 as a first day, but we are counting this day as a day 0. 
The second day is a result of the "Lap year problem": https://en.wikipedia.org/wiki/Leap_year_problem