### PR TITLE
OBGM-654 Add additional sort fallback condition for receiptItems sorting

### DIFF
--- a/grails-app/domain/org/pih/warehouse/receiving/Receipt.groovy
+++ b/grails-app/domain/org/pih/warehouse/receiving/Receipt.groovy
@@ -76,5 +76,16 @@ class Receipt implements Serializable, Comparable<Receipt> {
                         id <=> otherReceipt?.id
     }
 
+    List<ReceiptItem> sortReceiptItemsBySortOrder() {
+        def receiptItemsComparator = { a, b ->
+            return a.shipmentItem?.requisitionItem?.orderIndex <=> b.shipmentItem?.requisitionItem?.orderIndex ?:
+                    a.shipmentItem?.sortOrder <=> b.shipmentItem?.sortOrder ?:
+                            a?.sortOrder <=> b?.sortOrder ?:
+                                    a?.inventoryItem?.product?.name <=>  b?.inventoryItem?.product?.name
+        }
+
+        return receiptItems?.sort(receiptItemsComparator)
+    }
+
 
 }

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -1057,7 +1057,8 @@ class StockMovementService {
         List<ReceiptItem> receiptItems = shipments*.receipts*.receiptItems?.flatten()?.sort { a, b ->
             a.shipmentItem?.requisitionItem?.orderIndex <=> b.shipmentItem?.requisitionItem?.orderIndex ?:
                     a.shipmentItem?.sortOrder <=> b.shipmentItem?.sortOrder ?:
-                            a?.sortOrder <=> b?.sortOrder
+                            a?.sortOrder <=> b?.sortOrder ?:
+                                    a?.inventoryItem?.product?.name <=>  b?.inventoryItem?.product?.name
         }
         return receiptItems
     }
@@ -1067,7 +1068,8 @@ class StockMovementService {
         List<ReceiptItem> receiptItems = shipment.receipts*.receiptItems?.flatten()?.sort { a, b ->
             a.shipmentItem?.requisitionItem?.orderIndex <=> b.shipmentItem?.requisitionItem?.orderIndex ?:
                     a.shipmentItem?.sortOrder <=> b.shipmentItem?.sortOrder ?:
-                            a?.sortOrder <=> b?.sortOrder
+                            a?.sortOrder <=> b?.sortOrder ?:
+                                    a?.inventoryItem?.product?.name <=>  b?.inventoryItem?.product?.name
         }
         return receiptItems
     }

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -1054,23 +1054,13 @@ class StockMovementService {
 
     List<ReceiptItem> getRequisitionBasedStockMovementReceiptItems(def stockMovement) {
         def shipments = Shipment.findAllByRequisition(stockMovement.requisition)
-        List<ReceiptItem> receiptItems = shipments*.receipts*.receiptItems?.flatten()?.sort { a, b ->
-            a.shipmentItem?.requisitionItem?.orderIndex <=> b.shipmentItem?.requisitionItem?.orderIndex ?:
-                    a.shipmentItem?.sortOrder <=> b.shipmentItem?.sortOrder ?:
-                            a?.sortOrder <=> b?.sortOrder ?:
-                                    a?.inventoryItem?.product?.name <=>  b?.inventoryItem?.product?.name
-        }
+        List<ReceiptItem> receiptItems = shipments*.receipts?.flatten()*.sortReceiptItemsBySortOrder()?.flatten()
         return receiptItems
     }
 
     List<ReceiptItem> getShipmentBasedStockMovementReceiptItems(def stockMovement) {
         Shipment shipment = stockMovement.shipment
-        List<ReceiptItem> receiptItems = shipment.receipts*.receiptItems?.flatten()?.sort { a, b ->
-            a.shipmentItem?.requisitionItem?.orderIndex <=> b.shipmentItem?.requisitionItem?.orderIndex ?:
-                    a.shipmentItem?.sortOrder <=> b.shipmentItem?.sortOrder ?:
-                            a?.sortOrder <=> b?.sortOrder ?:
-                                    a?.inventoryItem?.product?.name <=>  b?.inventoryItem?.product?.name
-        }
+        List<ReceiptItem> receiptItems = shipment.receipts*.sortReceiptItemsBySortOrder()?.flatten()
         return receiptItems
     }
 


### PR DESCRIPTION
The issue was that there was a case where it was impossible to sort this list since all of the values specified in the comparator conditions had the same values so it resulted in a random order list each time it was generated.

 To fix this I added an additional last fallback comparator to sort by product name.