### PR TITLE
OBGM-622 Previous and Next Refresh not filled with value on transaction report

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/reporting/ReportController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/reporting/ReportController.groovy
@@ -279,7 +279,7 @@ class ReportController {
         command.location = Location.get(session.warehouse.id)
         command.rootCategory = productService.getRootCategory()
 
-        def triggers = quartzScheduler.getTriggersOfJob(new JobKey("org.pih.warehouse.jobs.RefreshTransactionFactJob"))
+        def triggers = quartzScheduler.getTriggersOfJob(new JobKey("org.pih.warehouse.jobs.RefreshTransactionFactJob", "GRAILS_JOBS"))
         def previousFireTime = triggers*.previousFireTime.max()
         def nextFireTime = triggers*.nextFireTime.max()
         def locationKey = LocationDimension.findByLocationId(command?.location?.id)

--- a/grails-app/controllers/org/pih/warehouse/reporting/ReportController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/reporting/ReportController.groovy
@@ -12,6 +12,7 @@ package org.pih.warehouse.reporting
 import grails.converters.JSON
 import grails.gorm.transactions.Transactional
 import grails.plugins.csv.CSVWriter
+import grails.plugins.quartz.GrailsJobClassConstants
 import org.apache.commons.lang.StringEscapeUtils
 import org.pih.warehouse.api.StockMovement
 import org.pih.warehouse.api.StockMovementItem
@@ -279,7 +280,7 @@ class ReportController {
         command.location = Location.get(session.warehouse.id)
         command.rootCategory = productService.getRootCategory()
 
-        def triggers = quartzScheduler.getTriggersOfJob(new JobKey("org.pih.warehouse.jobs.RefreshTransactionFactJob", "GRAILS_JOBS"))
+        def triggers = quartzScheduler.getTriggersOfJob(new JobKey("org.pih.warehouse.jobs.RefreshTransactionFactJob", GrailsJobClassConstants.DEFAULT_GROUP))
         def previousFireTime = triggers*.previousFireTime.max()
         def nextFireTime = triggers*.nextFireTime.max()
         def locationKey = LocationDimension.findByLocationId(command?.location?.id)


### PR DESCRIPTION
The `triggers` variable didn't contain any triggers after calling the `getTriggersOfJob` method. As I checked `JobKey` created a key with the `DEFAULT` group:
![image](https://github.com/openboxes/openboxes/assets/83239466/4e206602-76c3-4d24-9df0-d137f306e225)
In the `quartzScheduler` I found that `RefreshTransactionFactJob` belongs to the `GRAILS_JOBS` group. After adding this second parameter, the triggers were correctly found.
![image](https://github.com/openboxes/openboxes/assets/83239466/d8f24a31-efdb-4167-bb23-d5d875017d3f)
