### PR TITLE
OBGM-620 UI issue in Fr locale: where tabs on PO add items are displayed on the same page

### DIFF
--- a/grails-app/views/purchaseOrder/_showOrderItems.gsp
+++ b/grails-app/views/purchaseOrder/_showOrderItems.gsp
@@ -509,7 +509,7 @@
                * TODO here, we may need to elsewhere -- should we escape all
                * TODO localized strings? Further discussion at OBGM-343.
                */
-              if ($("#validationCode").val() == 'WARN' && !confirm(htmlDecode("${g.message(code: 'orderItem.warningSupplier.label')}"))) {
+              if ($("#validationCode").val() == 'WARN' && !confirm(htmlDecode(`${g.message(code: 'orderItem.warningSupplier.label')}`))) {
                 return false
               } else {
                 $.ajax({


### PR DESCRIPTION
This issue was caused by the quotation marks used in languages other than English. In the confirmation dialog in English, we used single quotation marks
![image](https://github.com/openboxes/openboxes/assets/83239466/c45960e5-e34c-46bb-ae40-1ffbaa326803)
But In the French language, we were using both - single quotation marks and standard quotation marks:
![image](https://github.com/openboxes/openboxes/assets/83239466/327d4af5-7492-40fd-9b28-84de31bf82b1)
So changing it to backticks fixed this issue
