### PR TITLE
OBGM-648 Unable to edit Package size from other to each in product source import 

### DIFF
--- a/grails-app/services/org/pih/warehouse/data/ProductSupplierDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSupplierDataService.groovy
@@ -202,6 +202,7 @@ class ProductSupplierDataService {
                 defaultProductPackage.productPrice = productPrice
             } else if (price && defaultProductPackage.productPrice) {
                 defaultProductPackage.productPrice.price = price
+                defaultProductPackage.lastUpdated = new Date()
             }
         }
 


### PR DESCRIPTION
When we were updating package size through import and we had previously added package and product price we were just updating our default product package like that:
`defaultProductPackage.productPrice.price = price`
So, the save action was performed only on `ProductPrice` object, because the reference didn't change. Our default product package is this one with the newest `lastUpdated`. So after this kind of update, the `lastUpdated` wasn't triggered and after update, we saw the same package size as we had before import.
As a solution, I decided to update the `lastUpdated` property manually.