### PR TITLE
OBGM-636 Able to adjust inventory to negative qty value 

### DIFF
--- a/grails-app/views/inventory/_inventoryAdjustment.gsp
+++ b/grails-app/views/inventory/_inventoryAdjustment.gsp
@@ -2,7 +2,6 @@
 <g:form action="saveAdjustmentTransaction">
     <div class="box">
         <h2><g:message code="inventory.adjustStock.label"/></h2>
-        <g:hiddenField name="transactionInstance.id" value="${command?.transactionInstance?.id}"/>
         <g:hiddenField name="transactionInstance.inventory.id" value="${command?.warehouseInstance?.inventory?.id}"/>
         <g:hiddenField name="transactionInstance.transactionType.id" value="${command?.transactionInstance?.transactionType?.id }"/>
         <table>

--- a/grails-app/views/inventoryItem/_adjustStock.gsp
+++ b/grails-app/views/inventoryItem/_adjustStock.gsp
@@ -1,6 +1,5 @@
 <%@ page import="org.pih.warehouse.core.ReasonCode" %>
 <div class="dialog">
-    <jqvalui:renderValidationScript for="org.pih.warehouse.inventory.AdjustStockCommand" form="adjustStockForm"/>
     <g:form name="adjustStockForm" controller="inventoryItem" action="adjustStock" autocomplete="off">
 
         <g:hiddenField name="product.id" value="${inventoryItem?.product?.id}"/>

--- a/src/main/groovy/org/pih/warehouse/inventory/AdjustStockCommand.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/AdjustStockCommand.groovy
@@ -26,7 +26,7 @@ class AdjustStockCommand implements Validateable {
 
     static constraints = {
         currentQuantity(nullable: false)
-        newQuantity(nullable: false)
+        newQuantity(nullable: false, min: 0)
         inventoryItem(nullable: false)
         location(nullable: false)
         binLocation(nullable: true)


### PR DESCRIPTION
In the ticket, I included all of the places that used the jquery validation: https://pihemr.atlassian.net/browse/OBGM-636?atlOrigin=eyJpIjoiZmMwMmUzNDM3OTAwNDFlMjgyYjVmMTUzZjQ3MzMzN2QiLCJwIjoiaiJ9

I just added the validation on min qty to the command instance, so after inputting qty lower than 0, we will see the error message (All of the error messages are visible in this way in adjusting inventory):
![image](https://github.com/openboxes/openboxes/assets/83239466/e02bfd34-dbc1-4bbc-bb50-4d62be1aa62f)
With the jquery plugin, the validation looked like that:
![image](https://github.com/openboxes/openboxes/assets/83239466/15747cb2-45e8-462e-9bb1-9b391ab6502a)

The second error in adjusting inventory (reproduction steps 2 from the ticket) was caused by data binding. When we provided the transaction id using a hidden field the transaction wasn't bound correctly. In the params, it looks like that:
![image](https://github.com/openboxes/openboxes/assets/83239466/2eb8f957-5d76-444b-a0ee-9b6c5c0ff61c)
After removing this hidden field it looks like that:
![image](https://github.com/openboxes/openboxes/assets/83239466/96f505ac-d278-4a05-9cf8-823280f28b7e)
So now, Grails is using nested values, instead of flattened.
Before removing this hidden field, we didn't have a transaction instance, and the .hasErrors method threw the error
![image](https://github.com/openboxes/openboxes/assets/83239466/5f8d7154-c26e-48c1-b7e0-9cc66c9c8919)
After fixing, we have the transaction method and the .hasErrors method is accessible.
![image](https://github.com/openboxes/openboxes/assets/83239466/3658d55b-4826-4637-8f7a-d2524b8fae6b)
