### PR TITLE
OBGM-611 Item recipient shouldn't be selected by default when creating PO

### DIFF
--- a/grails-app/views/order/_orderItemForm.gsp
+++ b/grails-app/views/order/_orderItemForm.gsp
@@ -50,11 +50,9 @@
     <td class="center middle">
     </td>
     <td class="center middle">
-        <g:hiddenField id="defaultRecipient" name="defaultRecipient" value="${order?.orderedBy?.id}"/>
         <g:selectPerson
             id="recipient"
             name="recipient"
-            value="${order?.orderedBy?.id}"
             noSelection="['':'']" class="select2"
             data-placeholder="${g.message(code: 'default.selectAnOption.label', default: 'Select an Option')}"
         />

--- a/grails-app/views/purchaseOrder/_showOrderItems.gsp
+++ b/grails-app/views/purchaseOrder/_showOrderItems.gsp
@@ -594,9 +594,8 @@
           clearSource();
           $("#quantityUom").val(null).trigger('change');
 
-          // Reset recipient to default recipient
-          var defaultRecipient = $("#defaultRecipient").val();
-          $("#recipient").val(defaultRecipient).trigger("change");
+          // Reset recipient
+          $("#recipient").val("").trigger("change");
 
           // Reset estimated ready date
           $("#estimatedReadyDate-datepicker").datepicker('setDate', null);


### PR DESCRIPTION
This issue was a little bit odd. As I know previously we had set PO creator as a default recipient, but it stopped working. Now, it started working again and now we are treating it as a bug 😀

I checked how the value of the default recipient looked like in Grails 1. Despite the fact that `order?.orderedBy?.id` had a value, the value in the browser was empty, so that was the reason it didn't work.

In Grails 3 we have this value displayed correctly in the browser, so the PO creator was assigned as a default recipient. As a fix, I just removed the code that was assigned this default recipient and a little bit changed resetting the recipient in the same way as we are resetting the rest of the properties above.