### PR TITLE
OBGM-670 Unable to assign to user "No access" role

### DIFF
--- a/grails-app/services/org/pih/warehouse/core/UserService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/UserService.groovy
@@ -36,16 +36,20 @@ class UserService {
 
         def userInstance = User.get(userId)
 
+        if (params.roles) {
+            userInstance.roles = Role.findAllByIdInList(params.list("roles"))
+            params.remove("roles")
+        }
+
         // Password in the db is different from the one specified
         // so the user must have changed the password.  We need
         // to compare the password with confirm password before
         // setting the new password in the database
+        userInstance.properties = params
         if (params.changePassword && userInstance.password != params.password) {
-            userInstance.properties = params
             userInstance.password = params?.password?.encodeAsPassword()
             userInstance.passwordConfirm = params?.passwordConfirm?.encodeAsPassword()
         } else {
-            userInstance.properties = params
             // Needed to bypass the password == passwordConfirm validation
             userInstance.passwordConfirm = userInstance.password
         }
@@ -71,7 +75,7 @@ class UserService {
 
             // Check to make sure the roles are dirty
             def currentRoles = new HashSet(userInstance?.roles)
-            def updatedRoles = Role.findAllByIdInList(params.list("roles"))
+            def updatedRoles = params.roles ? Role.findAllByIdInList(params.list("roles")) : []
             def isRolesDirty = !ListUtils.isEqualList(updatedRoles, currentRoles)
             log.info "User update: ${updatedRoles} vs ${currentRoles}: isDirty=${isRolesDirty}, canEditRoles=${canEditRoles}"
             if (isRolesDirty && !canEditRoles) {


### PR DESCRIPTION
It was interesting that in the debugger roles were bound correctly, but during saving the error with mismatching type was thrown. When I added "no access" to the roles and evaluated the user's role after binding everything looked good. When I let the debugger go line after the save method I saw that one error was visible.

👇 This part of the code tried to bind the roles with appropriate mapping to the Role object, but the "no access" had a "null" value and it could not be fetched, so I bound the roles manually. Grails 1 looks like he didn't have a problem with just skipping the "null"
```
userInstance.properties = params
```
I also moved the `updatedRoles` higher in the function to avoid fetching the roles twice.