### PR TITLE
OBGM-657 Handle validation exceptions generically on product groups

### DIFF
--- a/grails-app/conf/runtime.groovy
+++ b/grails-app/conf/runtime.groovy
@@ -1073,6 +1073,12 @@ openboxes.supportLinks = [
     knowledgeBase: 'https://openboxes.helpscoutdocs.com/',
 ]
 
+openboxes.errorHandler.templateMapping = [
+        "/productGroup/save": "/productGroup/create",
+        "/productGroup/addToProductGroup": "/productGroup/create",
+        "/productGroup/update": "/productGroup/edit",
+]
+
 // Reset an instance
 
 openboxes.resettingInstance.command = "wget https://raw.githubusercontent.com/openboxes/openboxes/develop/reset-database.sh | sh"

--- a/grails-app/controllers/org/pih/warehouse/product/ProductGroupController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductGroupController.groovy
@@ -41,7 +41,7 @@ class ProductGroupController {
     def create() {
         def productGroupInstance = new ProductGroup()
         productGroupInstance.properties = params
-        return [productGroupInstance: productGroupInstance]
+        return [productGroup: productGroupInstance]
     }
 
     // @CacheFlush("selectProductFamilyCache")
@@ -56,12 +56,9 @@ class ProductGroupController {
             productGroupInstance.addToProducts(product)
         }
 
-        if (productGroupDataService.save(productGroupInstance)) {
-            flash.message = "${warehouse.message(code: 'default.created.message', args: [warehouse.message(code: 'productGroup.label', default: 'ProductGroup'), productGroupInstance.id])}"
-            redirect(action: "edit", id: productGroupInstance.id)
-        } else {
-            render(view: "create", model: [productGroupInstance: productGroupInstance])
-        }
+        productGroupDataService.save(productGroupInstance)
+        flash.message = "${warehouse.message(code: 'default.created.message', args: [warehouse.message(code: 'productGroup.label', default: 'ProductGroup'), productGroupInstance.id])}"
+        redirect(action: "edit", id: productGroupInstance.id)
     }
 
     def show() {
@@ -84,7 +81,7 @@ class ProductGroupController {
         } else {
             productGroupInstance.properties = params
             log.info "category: " + productGroupInstance?.category?.name
-            return [productGroupInstance: productGroupInstance]
+            return [productGroup: productGroupInstance]
         }
     }
 
@@ -97,7 +94,7 @@ class ProductGroupController {
                 if (productGroupInstance.version > version) {
 
                     productGroupInstance.errors.rejectValue("version", "default.optimistic.locking.failure", [warehouse.message(code: 'productGroup.label', default: 'ProductGroup')] as Object[], "Another user has updated this ProductGroup while you were editing")
-                    render(view: "edit", model: [productGroupInstance: productGroupInstance])
+                    render(view: "edit", model: [productGroup: productGroupInstance])
                     return
                 }
             }
@@ -119,7 +116,7 @@ class ProductGroupController {
                 flash.message = "${warehouse.message(code: 'default.updated.message', args: [warehouse.message(code: 'productGroup.label', default: 'ProductGroup'), productGroupInstance.id])}"
                 redirect(action: "edit", id: productGroupInstance.id)
             } else {
-                render(view: "edit", model: [productGroupInstance: productGroupInstance])
+                render(view: "edit", model: [productGroup: productGroupInstance])
             }
         } else {
             flash.message = "${warehouse.message(code: 'default.not.found.message', args: [warehouse.message(code: 'productGroup.label', default: 'ProductGroup'), params.id])}"
@@ -130,9 +127,7 @@ class ProductGroupController {
 
     // @CacheFlush("selectProductFamilyCache")
     def update() {
-
         log.info "Update product group " + params
-
 
         ProductGroup productGroupInstance = productGroupDataService.get(params.id)
         if (productGroupInstance) {
@@ -141,21 +136,22 @@ class ProductGroupController {
                 if (productGroupInstance.version > version) {
 
                     productGroupInstance.errors.rejectValue("version", "default.optimistic.locking.failure", [warehouse.message(code: 'productGroup.label', default: 'ProductGroup')] as Object[], "Another user has updated this ProductGroup while you were editing")
-                    render(view: "edit", model: [productGroupInstance: productGroupInstance])
+                    render(view: "edit", model: [productGroup: productGroupInstance])
                     return
                 }
             }
             productGroupInstance.properties = params
 
-            if (!productGroupInstance.hasErrors() && productGroupDataService.save(productGroupInstance)) {
+            try {
+                productGroupDataService.save(productGroupInstance)
                 flash.message = "${warehouse.message(code: 'default.updated.message', args: [warehouse.message(code: 'productGroup.label', default: 'ProductGroup'), productGroupInstance.id])}"
                 redirect(controller: "productGroup", action: "list")
-            } else {
+            } catch (Exception e) {
                 println productGroupInstance.errors
                 // Refresh the instance from db, to avoid returning to the view productGroupInstance
                 // that is persisted in Hibernate session with the binded properties that didn't pass the validation
                 productGroupInstance.refresh()
-                render(view: "edit", model: [productGroupInstance: productGroupInstance])
+                render(view: "edit", model: [productGroup: productGroupInstance])
             }
         } else {
             flash.message = "${warehouse.message(code: 'default.not.found.message', args: [warehouse.message(code: 'productGroup.label', default: 'ProductGroup'), params.id])}"
@@ -212,7 +208,7 @@ class ProductGroupController {
 
         List<ProductGroup> productGroups = ProductGroup.findAllByCategory(productGroupInstance.category)
 
-        render(view: "create", model: [productGroupInstance: productGroupInstance, productGroups: productGroups])
+        render(view: "create", model: [productGroup: productGroupInstance, productGroups: productGroups])
     }
 
     /**

--- a/grails-app/views/productGroup/create.gsp
+++ b/grails-app/views/productGroup/create.gsp
@@ -40,28 +40,27 @@
 				${flash.message}
 			</div>
 		</g:if>
-		<g:hasErrors bean="${productGroupInstance}">
+		<g:hasErrors>
 			<div class="errors">
-				<g:renderErrors bean="${productGroupInstance}" as="list" />
+				<g:renderErrors as="list" />
 			</div>
 		</g:hasErrors>
-
 		<div class="summary">
 			<h1 class="title"><g:message code="default.create.label" args="[g.message(code: 'productGroup.label')]"/></h1>
 		</div>
 
 		<div class="buttonBar">
-			<g:link class="button" action="list">
+			<g:link class="button" controller="productGroup" action="list">
 				<img src="${resource(dir:'images/icons/silk',file:'application_view_list.png')}"/>&nbsp;
 				<warehouse:message code="default.list.label" args="[warehouse.message(code:'productGroups.label')]"/>
 			</g:link>
-			<g:link class="button" action="create">
+			<g:link class="button" controller="productGroup" action="create">
 				<img src="${resource(dir:'images/icons/silk',file:'add.png')}"/>&nbsp;
 				<warehouse:message code="default.add.label" args="[warehouse.message(code:'productGroup.label')]"/>
 			</g:link>
 		</div>
 
-		<g:form action="save" method="post">
+		<g:form controller="productGroup" action="save" method="post">
 
 				<div class="box">
 
@@ -70,24 +69,23 @@
 					<table>
 						<tbody>
 
-
 							<tr class="prop">
 								<td valign="middle" class="name"><label for="name"><warehouse:message
 											code="productGroup.name.label" default="Generic product" /></label>
 								</td>
 								<td valign="middle"
-									class="value ${hasErrors(bean: productGroupInstance, field: 'name', 'errors')}">
+									class="value ${hasErrors(bean: productGroup, field: 'name', 'errors')}">
 
-									<g:if test="${productGroups }">
+									<g:if test="${productGroups}">
 										<div>
-											<g:select name="id" from="${productGroups }"
-												optionKey="id" optionValue="name" value="${productGroupInstance?.id }" noSelection="['null':'']"/>
+											<g:select name="id" from="${productGroups}"
+												optionKey="id" optionValue="name" value="${productGroup?.id }" noSelection="['null':'']"/>
 										</div>
 									</g:if>
 									<g:else>
 										<div>
 											<g:textField name="name" class="text large"
-												value="${productGroupInstance?.name}" />
+												value="${productGroup?.name}" />
 										</div>
 									</g:else>
 
@@ -97,16 +95,16 @@
                             <tr class="prop">
                                 <td valign="middle" class="name"><label for="category"><warehouse:message
                                         code="productGroup.category.label" default="Category" /></label></td>
-                                <td valign="middle" class="value ${hasErrors(bean: productGroupInstance, field: 'category', 'errors')}">
+                                <td valign="middle" class="value ${hasErrors(bean: productGroup, field: 'category', 'errors')}">
                                     <%-- Show category if coming from Inventory Browser --%>
-                                    <g:if test="${productGroupInstance?.category }">
-                                        <format:category category="${productGroupInstance?.category }"/>
+                                    <g:if test="${productGroup?.category }">
+                                        <format:category category="${productGroup?.category }"/>
                                         <g:hiddenField id="category" name="category.id"
-                                                       value="${productGroupInstance?.category?.id }" />
+                                                       value="${productGroup?.category?.id }" />
                                     </g:if>
                                     <g:else>
                                         <g:selectCategory name="category.id" class="chzn-select" noSelection="['null':'']"
-                                                          value="${productGroupInstance?.category?.id}" />
+                                                          value="${productGroup?.category?.id}" />
                                     </g:else>
 
                                 </td>
@@ -116,21 +114,21 @@
 										code="productGroup.description.label" default="Description" /></label>
 								</td>
 								<td valign="top"
-									class="value ${hasErrors(bean: productGroupInstance, field: 'description', 'errors')}">
-									<g:textArea name="description" class="text" style="width: 100%" rows="5">${productGroupInstance?.description}</g:textArea>
+									class="value ${hasErrors(bean: productGroup, field: 'description', 'errors')}">
+									<g:textArea name="description" class="text" style="width: 100%" rows="5">${productGroup?.description}</g:textArea>
 								</td>
 							</tr>
 
 
-							<g:if test="${productGroupInstance?.products }">
+							<g:if test="${productGroup?.products }">
 								<tr class="prop">
 									<td valign="top" class="name">
 										<label for="products"><warehouse:message
 												code="productGroup.products.label" default="Products" /></label>
 									</td>
-									<td class="value ${hasErrors(bean: productGroupInstance, field: 'products', 'errors')}">
+									<td class="value ${hasErrors(bean: productGroup, field: 'products', 'errors')}">
 										<table>
-											<g:each var="product" in="${productGroupInstance?.products }" status="status">
+											<g:each var="product" in="${productGroup?.products }" status="status">
 												<tr class="${status%2?'even':'odd' }">
 													<td class="middle" width="1%">
 														<g:checkBox id="productId" name="product.id" value="${product?.id }"/>
@@ -174,7 +172,7 @@
 										<g:submitButton name="create" class="button"
 											value="${warehouse.message(code: 'default.button.create.label', default: 'Create')}" />
 
-										<g:link action="list" class="button">
+										<g:link controller="productGroup" action="list" class="button">
 											${warehouse.message(code: 'default.button.cancel.label', default: 'Cancel')}
 										</g:link>
 

--- a/grails-app/views/productGroup/edit.gsp
+++ b/grails-app/views/productGroup/edit.gsp
@@ -20,15 +20,15 @@
 				${flash.message}
 			</div>
 		</g:if>
-		<g:hasErrors bean="${productGroupInstance}">
+		<g:hasErrors>
 			<div class="errors">
-				<g:renderErrors bean="${productGroupInstance}" as="list" />
+				<g:renderErrors as="list" />
 			</div>
 		</g:hasErrors>
 
         <div class="summary">
 			<h1 class="title">
-				${productGroupInstance?.name}
+				${productGroup?.name}
 			</h1>
         </div>
 
@@ -51,8 +51,8 @@
                 </ul>
                 <div id="product-group-tab">
 					<g:form method="post" action="update">
-						<g:hiddenField name="id" value="${productGroupInstance?.id}" />
-						<g:hiddenField name="version" value="${productGroupInstance?.version}" />
+						<g:hiddenField name="id" value="${productGroup?.id}" />
+						<g:hiddenField name="version" value="${productGroup?.version}" />
 						<div class="box">
 							<h2><warehouse:message code="productGroup.label" default="Product group"/></h2>
 							<table>
@@ -62,9 +62,9 @@
 													code="productGroup.name.label" default="Name" /></label>
 										</td>
 										<td valign="top"
-											class="value ${hasErrors(bean: productGroupInstance, field: 'name', 'errors')}">
+											class="value ${hasErrors(bean: productGroup, field: 'name', 'errors')}">
 											<g:textField name="name" class="text large" size="100"
-												value="${productGroupInstance?.name}" />
+												value="${productGroup?.name}" />
 										</td>
 									</tr>
 
@@ -74,7 +74,7 @@
 													code="productGroup.category.label" default="Category" /></label></td>
 										<td valign="top" class="value">
 											<g:selectCategory name="category.id" class="chzn-select-deselect" noSelection="['null':'']"
-															  value="${productGroupInstance?.category?.id}" />
+															  value="${productGroup?.category?.id}" />
 
 										</td>
 									</tr>
@@ -83,8 +83,8 @@
 												code="productGroup.description.label" default="Description" /></label>
 										</td>
 										<td valign="top"
-											class="value ${hasErrors(bean: productGroupInstance, field: 'description', 'errors')}">
-											<g:textArea name="description" class="text" style="width: 100%" rows="5">${productGroupInstance?.description}</g:textArea>
+											class="value ${hasErrors(bean: productGroup, field: 'description', 'errors')}">
+											<g:textArea name="description" class="text" style="width: 100%" rows="5">${productGroup?.description}</g:textArea>
 										</td>
 									</tr>
 
@@ -108,13 +108,13 @@
 				<div id="product-group-products-tab">
 					<div class="box">
 						<h2><warehouse:message code="productGroup.products.label" default="Products"/></h2>
-						<g:render template="products" model="[productGroup: productGroupInstance, products: productGroupInstance?.products, isProductFamily: false]"/>
+						<g:render template="/productGroup/products" model="[productGroup: productGroup, products: productGroup?.products, isProductFamily: false]"/>
 					</div>
 				</div>
 				<div id="product-group-siblings-tab">
 					<div class="box">
 						<h2><warehouse:message code="productGroup.products.label" default="Products"/></h2>
-						<g:render template="products" model="[productGroup: productGroupInstance, products: productGroupInstance?.siblings, isProductFamily: true]"/>
+						<g:render template="/productGroup/products" model="[productGroup: productGroup, products: productGroup?.siblings, isProductFamily: true]"/>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
For the moment I am pushing and documenting everything that I was able to investigate about handling errors more generically for forms on GSP views, but unfortunately, I don't feel strongly about following this conversation, but let me explain everything in order.

## Investigation
At first, when I picked up this ticket I started browsing through many different public repositories in order to try to find any examples of other projects implementing at least a similar "Generic error handling" system for GSP views, but I wasn't successful in my search and noticed that most of the project handle errors separately or the most common approach is to render that generic error view like we already have
```groovy
render(view: "/error")
``` 
One thing that put me on the right path is the grails [documentation](https://guides.grails.org/grails3/command-objects-and-forms/guide/index.html) which describes how to properly handle form data. 
There was an example similar to many of our cases like:
```groovy

def save(Player player) {
    if (player == null) {
        render status: HttpStatus.NOT_FOUND
        return
    }

    if (player.hasErrors()) {
        respond player.errors, view: 'create'
        return
    }
}
```
If there are validation errors we return a  _response_ which takes in a **bean** and a **view** attribute _(besides many other attribuets)_ and renders the view, and to get errors from this bean we can render them using the grails tags
```gsp

<g:hasErrors bean="${player}">
    <div class="errors">
        <g:renderErrors bean="${player} as="list" />
    </div>
</g:hasErrors>
```
As you can see, in the GPS we are assigning bean as `player` even though we have not given it such an alias on the response 
`respond player.errors, view: 'create'`.
Grails is smart enough to find all of the beans that are provided in the view and to access it we need to call the object by its domain/class name _(in this case the Domain name is Player so we assign the beans as player)_.
If we want to include errors from all of the beans, we can omit the bean and just render
```gsp

<g:hasErrors>
    <div class="errors">
        <g:renderErrors as="list" />
    </div>
</g:hasErrors>
```
That way it will access all of the available beans and render all of the errors.
### My implementation
So after finding out that grails will take care of all of the errors in a more or less generic way, without me specifying the bean I thought that maybe I should move this logic to the global `ErrorsContorler` `handleValidationErrors()`.
The one challenge was to figure out how to render the appropriate GSP template view for each error, so for the time being I specified an action/error mapping variable that defines the relation to which view to render for each action which throws an exception 
https://github.com/openboxes/openboxes/blob/ddb403d7bbbe1c0c4795ad6f843eb6f0eb9d1069/grails-app/conf/runtime.groovy#L1076-L1080

So given we have an exception thrown on `ProductGroupController` `save,` in the error handler we extract this information from the request forwardURI
```groovy
def path = request.forwardURI - request.contextPath
def engine = groovyPagesTemplateEngine
```
which returns a `/productGroup/save`, which then we match with the errorMapper 
```groovy
Map templateMapping = grailsApplication.config.openboxes. error handler.templateMapping
def viewPath = templateMapping[path] ?: path
```
which returns a path to the view which we want to render `/productGroup/create`

then we check if such a view exists in the project 
```groovy
if (engine.getResourceForUri("${viewPath}.gsp").exists() || engine.getResourceForUri("/grails-app/views/${viewPath}.gsp").exists()) {
    respond errors.target, view: viewPath
    return
}
```
If it does exist then we render that view otherwise we render the generic error page
```groovy
render(view: "/error")
```

## The problem with this approach
One of the problems that I noticed was, in the case of the productGroup edit, when an exception was thrown and it was handled by this implementation of the generic error handler, it failed on lazyInitialization since inside of the `edit.gsp` we are accessing some associations _(product and siblings)_ lazily.
Since the exception was thrown before, it ended the session and we can't access them. 
A solution to that would be to eagerly fetch those _products_ and _siblings_ but we already discussed this in previous PR's and I think that it would be a little annoying to do everywhere and this is something that should be handled by the ORM.

Another problem is that sometimes we have a bit more complicated models that need to be passed to the view. In the case of the `productGroup/create` we only need the productGroup instance, but then there are sometimes more complicated models that are being passed down like
```groovy
render(template: 'products', model: [productGroup: productGroup, products: isProductFamily ? productGroup?.siblings : productGroup?.products])
```
And it would be pretty hard to handle this generically since `response errors.taget, view: viewPath` will have access only to the bean in which the validation was thrown.

In conclusion, I will leave this PR on `Draft` and we will probably discuss this on the tech huddle, maybe after discussing this with other developers something will click and I'll be able to finish it, but at the moment I will leave this PR and will go with a solution which is using the `try/catch` to catch the error and return the appropriate view and errors manually
