### PR TITLE
OBGM-637 Error message when try to create attribute without input Code

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/product/AttributeController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/AttributeController.groovy
@@ -89,7 +89,7 @@ class AttributeController {
             flash.message = "${warehouse.message(code: 'default.saved.message', args: [warehouse.message(code: 'attribute.label', default: 'Attribute'), attributeInstance.id])}"
             redirect(action: "edit", id: attributeInstance.id)
         } else {
-            render(view: (params.id ? "edit" : "create"), model: [attributeInstance: attributeInstance])
+            render(view: "edit", model: [attributeInstance: attributeInstance])
         }
     }
 

--- a/grails-app/domain/org/pih/warehouse/product/Attribute.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/Attribute.groovy
@@ -53,7 +53,7 @@ class Attribute {
     }
 
     static constraints = {
-        code(nullable: true, unique: true, validator: { code, attribute ->
+        code(nullable: true, validator: { code, attribute ->
             Attribute existingAttribute = Attribute.findByCode(code)
             if(existingAttribute && existingAttribute.id != attribute.id) {
                 ['default.not.unique.message']

--- a/grails-app/domain/org/pih/warehouse/product/Attribute.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/Attribute.groovy
@@ -53,7 +53,12 @@ class Attribute {
     }
 
     static constraints = {
-        code(nullable: false, unique: true)
+        code(nullable: true, unique: true, validator: { code, attribute ->
+            Attribute existingAttribute = Attribute.findByCode(code)
+            if(existingAttribute && existingAttribute.id != attribute.id) {
+                ['default.not.unique.message']
+            }
+        })
         name(nullable: false, maxSize: 255)
         description(nullable: true)
         defaultValue(nullable: true)

--- a/grails-app/domain/org/pih/warehouse/product/Attribute.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/Attribute.groovy
@@ -53,9 +53,9 @@ class Attribute {
     }
 
     static constraints = {
-        code(nullable: true, validator: { code, attribute ->
+        code(validator: { code, attribute ->
             Attribute existingAttribute = Attribute.findByCode(code)
-            if(existingAttribute && existingAttribute.id != attribute.id) {
+            if (existingAttribute && existingAttribute.id != attribute.id) {
                 ['default.not.unique.message']
             }
         })


### PR DESCRIPTION
The first change:
```
render(view: "edit", model: [attributeInstance: attributeInstance])
```
is precisely the same as Justin wrote under the ticket - there is only an edit view, and the create view doesn't exist. Even the create action renders the edit view page. The issue connected to this was visible when creating a new attribute with existing code other than an empty string.

The second change connected to validation is because of the situation - when we didn't input code, it is an empty string and it didn't fail on `unique: true` (I mean the situation when one product attribute with empty code already exists, so it should fail). It was throwing an exception
![image](https://github.com/openboxes/openboxes/assets/83239466/87a28ad5-93e0-47b0-bab4-a01254bee137)
Katarzyna asked me to make this error more meaningful, so I have created our "unique" validation which takes empty strings into account. By comparing ids I am checking if we are creating an attribute or we are editing an already existing one.