### PR TITLE
OBGM-690 Unable to clear values on Forecasting tab on edit location

### DIFF
--- a/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy
@@ -9,10 +9,13 @@
  **/
 package org.pih.warehouse.inventory
 
+import grails.databinding.BindUsing
+import org.pih.warehouse.NullBinderHelper
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.product.Product
 import util.InventoryUtil
 
+@BindUsing(NullBinderHelper)
 class InventoryLevel {
 
     String id

--- a/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy
@@ -15,7 +15,6 @@ import org.pih.warehouse.core.Location
 import org.pih.warehouse.product.Product
 import util.InventoryUtil
 
-@BindUsing(EmptyStringsToNullBinder)
 class InventoryLevel {
 
     String id
@@ -48,12 +47,15 @@ class InventoryLevel {
     BigDecimal forecastPeriodDays = 30
 
     // Lead time in days (safety stock is lead time days x daily forecast quantity)
+    @BindUsing({ obj, source -> EmptyStringsToNullBinder.bindEmptyStringToNull(source, "expectedLeadTimeDays")})
     BigDecimal expectedLeadTimeDays
 
     // Replenishment period in days
+    @BindUsing({ obj, source -> EmptyStringsToNullBinder.bindEmptyStringToNull(source, "replenishmentPeriodDays")})
     BigDecimal replenishmentPeriodDays
 
     // Demand time period in days
+    @BindUsing({ obj, source -> EmptyStringsToNullBinder.bindEmptyStringToNull(source, "demandTimePeriodDays")})
     BigDecimal demandTimePeriodDays
 
     // Preferred bin location

--- a/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy
@@ -10,12 +10,12 @@
 package org.pih.warehouse.inventory
 
 import grails.databinding.BindUsing
-import org.pih.warehouse.NullBinderHelper
+import org.pih.warehouse.EmptyStringsToNullBinder
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.product.Product
 import util.InventoryUtil
 
-@BindUsing(NullBinderHelper)
+@BindUsing(EmptyStringsToNullBinder)
 class InventoryLevel {
 
     String id

--- a/grails-app/utils/org/pih/warehouse/EmptyStringsToNullBinder.groovy
+++ b/grails-app/utils/org/pih/warehouse/EmptyStringsToNullBinder.groovy
@@ -3,7 +3,7 @@ package org.pih.warehouse
 import grails.databinding.BindingHelper
 import grails.databinding.DataBindingSource
 
-class NullBinderHelper<T> implements BindingHelper<T> {
+class EmptyStringsToNullBinder<T> implements BindingHelper<T> {
 
     @Override
      T getPropertyValue(Object obj, String propertyName, DataBindingSource source) {

--- a/grails-app/utils/org/pih/warehouse/EmptyStringsToNullBinder.groovy
+++ b/grails-app/utils/org/pih/warehouse/EmptyStringsToNullBinder.groovy
@@ -5,8 +5,12 @@ import grails.databinding.DataBindingSource
 
 class EmptyStringsToNullBinder<T> implements BindingHelper<T> {
 
+    static final T bindEmptyStringToNull(Object source, String fieldName) {
+        return source[fieldName] == "" ? null : source[fieldName]
+    }
+
     @Override
-     T getPropertyValue(Object obj, String propertyName, DataBindingSource source) {
-        return source[propertyName] == "" ? null : source[propertyName]
+    T getPropertyValue(Object obj, String propertyName, DataBindingSource source) {
+        return bindEmptyStringToNull(source, propertyName)
     }
 }

--- a/grails-app/utils/org/pih/warehouse/NullBinderHelper.groovy
+++ b/grails-app/utils/org/pih/warehouse/NullBinderHelper.groovy
@@ -1,0 +1,12 @@
+package org.pih.warehouse
+
+import grails.databinding.BindingHelper
+import grails.databinding.DataBindingSource
+
+class NullBinderHelper<T> implements BindingHelper<T> {
+
+    @Override
+     T getPropertyValue(Object obj, String propertyName, DataBindingSource source) {
+        return source[propertyName] == "" ? null : source[propertyName]
+    }
+}


### PR DESCRIPTION
In one of my previous PRs, I introduced the `convertEmptyStringsToNull` setting in our config because, in the resources I found and pasted in https://github.com/openboxes/openboxes/pull/4212, it looked like it was introduced between Grails 3.1.9 and 3.3.1 versions of Grails and it looked like help for us to get closer with the Grails 1 behavior. This setting resolved actually some tickets, so I think it is a good change, but in this ticket, I found that we weren't able to assign empty strings to a few properties, because those empty strings were used in the BigDecimal constructor - it normally throws an error, so in this case Grails doesn't bind those values. Those values had to be null to be bounded correctly and they were nulls in Grails 1. 🤔 So it's a little bit different that in this case it is a different behavior than those I noticed before - and was noticed in some of the resolved tickets.

So, for those situations that need to convert empty strings to nulls, I created a generic data binding helper. It can be used by @BindUsing with this converter class as a parameter. It will be applied to the whole class on which it is applied. It can be also applied only for some of the properties, but I don't like how it will look in this case:
```
   // Lead time in days (safety stock is lead time days x daily forecast quantity)
    @BindUsing({ obj, source, propertyName -> source["expectedLeadTimeDays"] == "" ? null : source["expectedLeadTimeDays"]})
    BigDecimal expectedLeadTimeDays

    // Replenishment period in days
    @BindUsing({ obj, source -> source["replenishmentPeriodDays"] == "" ? null : source["replenishmentPeriodDays"]})
    BigDecimal replenishmentPeriodDays

    // Demand time period in days
    @BindUsing({ obj, source -> source["demandTimePeriodDays"] == "" ? null : source["demandTimePeriodDays"]})
    BigDecimal demandTimePeriodDays
```
If you guys think this approach with applying it only to some of the properties is better than what I pushed to the PR I am willing to change it.