### PR TITLE
OBGM-669 Investigate changes in importing file properties

### DIFF
--- a/src/main/groovy/org/pih/warehouse/importer/ImportDataCommand.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/ImportDataCommand.groovy
@@ -45,7 +45,7 @@ class ImportDataCommand implements Validateable {
             }
 
             return ['application/vnd.ms-excel', 'text/plain', 'text/csv', 'text/tsv'].any { fileType ->
-                val.part.fileItem.contentType == fileType
+                val.part.contentType == fileType
             }
         })
         importType(nullable: false)


### PR DESCRIPTION
At this moment we had only one place where the `fileItem` was used.

So, the `MultipartFile` (which we are widely used in our command instances) looks like that:
```java
public interface MultipartFile extends InputStreamSource {

	String getName();
	String getOriginalFilename();
	String getContentType();
	boolean isEmpty();
	long getSize();
	byte[] getBytes() throws IOException;
	@Override
	InputStream getInputStream() throws IOException;
	void transferTo(File dest) throws IOException, IllegalStateException;
}
```
We have also `CommonsMultipartFile` which implements the `MultipartFile` interface - here we have the `fileItem` property (We are using this class in some places also).
```java
public class CommonsMultipartFile implements MultipartFile, Serializable {

	protected static final Log logger = LogFactory.getLog(CommonsMultipartFile.class);
	private final FileItem fileItem;
	private final long size;
	private boolean preserveFilename = false;
        ...
}
```
All of the properties that we were using are accessible by the methods guaranteed by the `MultipartFile` interface.
I looked up how it looked like in Grails 1.
And I will split my explanation into two parts:
![image](https://github.com/openboxes/openboxes/assets/83239466/6ab2c8a7-dcb7-4300-a07c-94dd52f661f9)
This part can be a reason for some of the errors that we had...Each of those place use `ImportDataCommand` which has the `importFile` property, but it is a `def` neither `MultipartFile` nor `CommonsMultpartFile`. As we already know we have to use types to get our data bound correctly in command instances. In Grails 3 in this place, we have `MultipartFile` which doesn't have the `fileItem` property.
And the second part is in two methods: uploading document(s), in Grails 1 it doesn't matter if we add `fileItem`:
![image](https://github.com/openboxes/openboxes/assets/83239466/c5051fc8-bd37-4dfa-87de-9114fccdc69c)
![image](https://github.com/openboxes/openboxes/assets/83239466/a8fe3200-e61a-4fa3-8915-83b3f5fc8b81)
But it says that we don't have `fileItem` property
![image](https://github.com/openboxes/openboxes/assets/83239466/c5ef2346-c073-48b8-b292-eeab1bd7b533)
In Grails 3 it throws an exception:
![image](https://github.com/openboxes/openboxes/assets/83239466/0b93d7d4-dcb1-4e0a-815b-a67355699c60)
![image](https://github.com/openboxes/openboxes/assets/83239466/d4e686b6-fc19-4f0b-9db8-a1af00a5a04e)
