### PR TITLE
OBGM-683 Fix error message for delete Stock Movement

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/api/StockMovementApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/StockMovementApiController.groovy
@@ -10,7 +10,6 @@
 package org.pih.warehouse.api
 
 import grails.converters.JSON
-import grails.gorm.transactions.Transactional
 import org.apache.commons.lang.math.NumberUtils
 import org.grails.web.json.JSONObject
 import org.pih.warehouse.core.ActivityCode
@@ -33,7 +32,7 @@ import org.pih.warehouse.requisition.RequisitionType
 import org.pih.warehouse.shipping.Shipment
 import org.pih.warehouse.shipping.ShipmentStatusCode
 
-@Transactional
+
 class StockMovementApiController {
 
     def dataService


### PR DESCRIPTION
The ticket connected to this PR was reopened after QA because I didn't do the same changes which I did in #4246 .
In the previous PR I only changed the `StockMovementController` but I  also had to do the same for `StockMovementAPIController`.

The issue was of course that StockMvoementAPIController was transactional making it impossible to catch exceptions inside those controller methods.

I have looked through all of the methods in the `StockMvoementAPIController` and from what I can tell it should be safe to remove `@Transactional` from this controller since every method uses the transactional services.