### PR TITLE
OBGM-532 Fix issue of creating multiple ROOT categories on category import

### DIFF
--- a/grails-app/services/org/pih/warehouse/product/ProductService.groovy
+++ b/grails-app/services/org/pih/warehouse/product/ProductService.groovy
@@ -925,14 +925,14 @@ class ProductService {
      * @return
      */
     Category findOrCreateRootCategory(String rootCategoryName) {
-        def rootCategory = Category.findByName(rootCategoryName)
+        def rootCategory = Category.findByNameAndIsRoot(rootCategoryName, true)
 
-        if (rootCategory && rootCategory.isRoot) {
+        if (rootCategory) {
             return rootCategory
         }
 
         rootCategory = new Category(parentCategory: null, name: rootCategoryName, isRoot: true)
-        rootCategory.save(failOnError: true)
+        rootCategory.save(failOnError: true, flush: true)
 
         return rootCategory
     }


### PR DESCRIPTION
There were two problem that I was able to spot in this issue, so let me explain each of them:

### Additional ROOT category entry in `default_OB_categories.csv`
When inspecting the category csv import files I noticed that the  `default_OB_categories.csv` has a ROOT category defined as an entry
![image](https://github.com/openboxes/openboxes/assets/35233347/83ec1bda-2fed-41e0-bb92-eaccbef5b180)

Following the code of how we import the categories we can see that before importing the category list we _find/create_ a root category `findOrCreateRootCategory()` and later we loop through all of the csv file entries and import them.
https://github.com/openboxes/openboxes/blob/a18cecb090c97a07a10cc1b0f600730b79a9ac8f/grails-app/services/org/pih/warehouse/product/ProductService.groovy#L1430-L1446 

Everything looks right until we look a little deeper.
So first of all when we, _find/create_ the root category we are saving it at the end of the session, since we have not specified the `flush: true` on the save
https://github.com/openboxes/openboxes/blob/a18cecb090c97a07a10cc1b0f600730b79a9ac8f/grails-app/services/org/pih/warehouse/product/ProductService.groovy#L920-L930

And later when we loop through the csv categories entries we use `findOrCreateCategoryWithParentCategory()` method to _find/create_  the categories
https://github.com/openboxes/openboxes/blob/a18cecb090c97a07a10cc1b0f600730b79a9ac8f/grails-app/services/org/pih/warehouse/product/ProductService.groovy#L940-L946 
Notice that we are first trying to find the Category in the database to avoid duplicate creation of the categories.
The problem comes up at the **first entry** of the `default_OB_categories.csv` _(referencing the first image from above)_.
the first entry from the CSV that we are trying to save is **ROOT**, when querying the database for a category with name **ROOT**, it returns `null` because the previously created ROOT category from `findOrCreateRootCategory()` has not been saved yet, and since it returned `null` we created that new ROOT category instead of ignoring it.
So to fix this Issue I decided to persist to the database that initially created root category so all of the entries are aware of it's existence.

### Bad querying for Root category
Another problem that I came across was something that I noticed only on **obdev3**, at first I was puzzled by it but soon enough I understood the problem.
The issue was that after every import it would create a new ROOT category. While inspecting the obdev3 database I noticed that there was one, **first record** which was named ROOT but was not a root category, it didn't have a `True` set on **isRoot** field.
```
id 					|	 dateCreated 		:	 isRoot
------------------------------------------------------------------------------------
ROOT					|	2010-08-25 00:00:00.0	:	null
cab2b1fa88babf360188bee1f3ad010f	|	2023-06-15 11:47:39.0	:	false
cab2b1fa88babf360188bee7bc940114	|	2023-06-15 11:53:58.0	:	false
cab2b1fa88babf360188beeada620115	|	2023-06-15 11:57:22.0	:	true
cab2b1fa89cf037a0189cfd1d4480024	|	2023-08-07 11:46:22.0	:	true
cab2b1fa89cf037a0189cfd3acfe0026	|	2023-08-07 11:48:23.0	:	true
cab2b1fa89deade70189df332fd802ae	|	2023-08-10 11:27:01.0	:	true
cab2b1fa8a46a06e018a4a731cff0029	|	2023-08-31 07:16:12.0	:	true
cab2b1fa8a46a06e018a4a73abb7002a	|	2023-08-31 07:16:49.0	:	true
```
https://github.com/openboxes/openboxes/blob/a18cecb090c97a07a10cc1b0f600730b79a9ac8f/grails-app/services/org/pih/warehouse/product/ProductService.groovy#L920-L930
So when we execute the `findOrCreateRootCategory()` function, it queries the 
```groovy
def rootCategory = Category.findByName(rootCategoryName)
```
which returns the first entry since it's the first match, but since this category is not root category, it fails this if statement
```groovy
if (rootCategory && rootCategory.isRoot) { ... }
```
and creates a new ROOT category.
To fix this issue we instead need to query for a category on both conditions, the **name** and **isRoot**
