### PR TITLE
OBGM-685 Fix cell merging on packing list xlsx document

### DIFF
--- a/grails-app/services/org/pih/warehouse/core/DocumentService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/DocumentService.groovy
@@ -868,7 +868,9 @@ class DocumentService {
                     row.getCell(CELL_INDEX++).setCellStyle(tableDataPalletStyle)
                     // If we're at a place in the XLS file where we want to merge cells (e.g. the packing list)
                     // Then we merge rows when the container name is different from the previous container name
-                    //sheet.addMergedRegion(CellRangeAddress.valueOf("A${packLevelOneInitialRowIndex + 1}:A${packLevelOneFinalRowIndex + 1}"))
+                    if (packLevelOneInitialRowIndex != packLevelOneFinalRowIndex) {
+                        sheet.addMergedRegion(CellRangeAddress.valueOf("A${packLevelOneInitialRowIndex + 1}:A${packLevelOneFinalRowIndex + 1}"))
+                    }
 
                     packLevelOneInitialRowIndex = row.getRowNum()
                     packLevelOneFinalRowIndex = row.getRowNum()


### PR DESCRIPTION
The newer version of document generation plugin does not allow merger of a single cell.
Comparing it to develop branch, previously it was possible to execute merger of cells give the argument eg. **A:1:A:1**.
Now, given such an argument, the merge method throws an error that two or more cells must be provided which is why this line was previously commented.