### PR TITLE
OBGM-706 Error message when sort by Formulary column on Product List 

### DIFF
--- a/src/js/components/products/ProductsListTable.jsx
+++ b/src/js/components/products/ProductsListTable.jsx
@@ -89,6 +89,7 @@ const ProductsListTable = ({
       Header: <Translate id="react.productsList.filters.catalog.label" defaultMessage="Formulary" />,
       accessor: 'productCatalogs',
       minWidth: 200,
+      sortable: false,
       Cell: row =>
         (<TableCell
           {...row}


### PR DESCRIPTION
I asked Manon about the sorting behavior that needs to be applied here since it doesn’t work on obdev1 either (One product can have more than one formulary, so the question was if should we sort them by amount of formularies or in any other way). Manon said it would be better to remove this sorting option because users use filters to manage data in this column.