### PR TITLE
OBGM-687 price and package issue in product source import

### DIFF
--- a/grails-app/migrations/0.9.x/changelog-2023-09-08-1340-remove-missing-price-fk-on-product-packages.xml
+++ b/grails-app/migrations/0.9.x/changelog-2023-09-08-1340-remove-missing-price-fk-on-product-packages.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+
+  <changeSet author="drodzewicz" id="080920231340-0">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <sqlCheck expectedResult="0">
+          SELECT COUNT(*) FROM product_package ppkg
+          LEFT JOIN product_price pp
+          ON ppkg.product_price_id=pp.id
+          WHERE ppkg.product_price_id IS NOT NULL AND pp.id IS NULL;
+        </sqlCheck>
+      </not>
+    </preConditions>
+    <sql>
+      UPDATE product_package pkg
+      SET pkg.product_price_id = NULL
+      WHERE pkg.id IN (SELECT * FROM (
+      SELECT ppkg.id FROM product_package ppkg
+      LEFT JOIN product_price pp
+      ON ppkg.product_price_id=pp.id
+      WHERE ppkg.product_price_id IS NOT NULL AND pp.id IS NULL
+      ) as ppkg_ids);
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/grails-app/migrations/0.9.x/changelog-2023-09-08-1340-remove-product-price-fk-on-product-package-pointing-to-non-existing-record.xml
+++ b/grails-app/migrations/0.9.x/changelog-2023-09-08-1340-remove-product-price-fk-on-product-package-pointing-to-non-existing-record.xml
@@ -14,6 +14,13 @@
         </sqlCheck>
       </not>
     </preConditions>
+    <comment>
+      This migration is meant to fix a bug found on OBGM-687
+      which caused an issue when importing product sources.
+      An invalid product price was not persisted in the database,
+      but an id (FK) was added to the product_package table on product_price_id column
+      which pointed to non-existing record.
+    </comment>
     <sql>
       UPDATE product_package pkg
       SET pkg.product_price_id = NULL

--- a/grails-app/migrations/0.9.x/changelog.xml
+++ b/grails-app/migrations/0.9.x/changelog.xml
@@ -5,4 +5,5 @@
 
     <include file="0.9.x/changelog-2023-02-21-1340-alter-table-order-change-date-ordered-column-type.xml" />
     <include file="0.9.x/changelog-2023-09-07-1140-add-missing-is_root-value-to-root-catalog.xml" />
+    <include file="0.9.x/changelog-2023-09-08-1340-remove-missing-price-fk-on-product-packages.xml" />
 </databaseChangeLog>

--- a/grails-app/migrations/0.9.x/changelog.xml
+++ b/grails-app/migrations/0.9.x/changelog.xml
@@ -5,5 +5,5 @@
 
     <include file="0.9.x/changelog-2023-02-21-1340-alter-table-order-change-date-ordered-column-type.xml" />
     <include file="0.9.x/changelog-2023-09-07-1140-add-missing-is_root-value-to-root-catalog.xml" />
-    <include file="0.9.x/changelog-2023-09-08-1340-remove-missing-price-fk-on-product-packages.xml" />
+    <include file="0.9.x/changelog-2023-09-08-1340-remove-product-price-fk-on-product-package-pointing-to-non-existing-record.xml" />
 </databaseChangeLog>

--- a/grails-app/services/org/pih/warehouse/data/ProductSupplierDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSupplierDataService.groovy
@@ -163,7 +163,7 @@ class ProductSupplierDataService {
         UnitOfMeasure unitOfMeasure = params.defaultProductPackageUomCode ?
                 UnitOfMeasure.findByCode(params.defaultProductPackageUomCode) : null
         BigDecimal price = params.defaultProductPackagePrice ?
-                new BigDecimal(params.defaultProductPackagePrice) : null
+                new BigDecimal(params.defaultProductPackagePrice) : 0
         Integer quantity = params.defaultProductPackageQuantity as Integer
 
         ProductSupplier productSupplier = ProductSupplier.findByIdOrCode(params["id"], params["code"])

--- a/grails-app/services/org/pih/warehouse/data/ProductSupplierDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSupplierDataService.groovy
@@ -163,7 +163,7 @@ class ProductSupplierDataService {
         UnitOfMeasure unitOfMeasure = params.defaultProductPackageUomCode ?
                 UnitOfMeasure.findByCode(params.defaultProductPackageUomCode) : null
         BigDecimal price = params.defaultProductPackagePrice ?
-                new BigDecimal(params.defaultProductPackagePrice) : 0
+                new BigDecimal(params.defaultProductPackagePrice) : null
         Integer quantity = params.defaultProductPackageQuantity as Integer
 
         ProductSupplier productSupplier = ProductSupplier.findByIdOrCode(params["id"], params["code"])
@@ -192,15 +192,17 @@ class ProductSupplierDataService {
                 defaultProductPackage.product = productSupplier.product
                 defaultProductPackage.uom = unitOfMeasure
                 defaultProductPackage.quantity = quantity
-                ProductPrice productPrice = new ProductPrice()
-                productPrice.price = price
-                defaultProductPackage.productPrice = productPrice
+                if (price != null) {
+                    ProductPrice productPrice = new ProductPrice()
+                    productPrice.price = price
+                    defaultProductPackage.productPrice = productPrice
+                }
                 productSupplier.addToProductPackages(defaultProductPackage)
-            } else if (price && !defaultProductPackage.productPrice) {
+            } else if (price != null && !defaultProductPackage.productPrice) {
                 ProductPrice productPrice = new ProductPrice()
                 productPrice.price = price
                 defaultProductPackage.productPrice = productPrice
-            } else if (price && defaultProductPackage.productPrice) {
+            } else if (price != null && defaultProductPackage.productPrice) {
                 defaultProductPackage.productPrice.price = price
                 defaultProductPackage.lastUpdated = new Date()
             }

--- a/grails-app/views/category/edit.gsp
+++ b/grails-app/views/category/edit.gsp
@@ -36,7 +36,7 @@
                                         <label><warehouse:message code="category.parent.label"/></label>
                                     </td>
                                     <td class="value">
-                                        <g:selectCategory name="parentCategory.id" class="chzn-select-deselect" value="${categoryInstance?.parentCategory?.id}"/>
+                                        <g:selectCategory name="parentCategory.id" class="chzn-select-deselect" value="${categoryInstance?.parentCategory?.id}" noSelection="['null':'']"/>
                                     </td>
                                 </tr>
                                 <tr class="prop">

--- a/grails-app/views/inventoryItem/_showSuppliers.gsp
+++ b/grails-app/views/inventoryItem/_showSuppliers.gsp
@@ -105,7 +105,7 @@
                         </td>
 
                         <td>
-                            <g:if test="${defaultProductPackage}">
+                            <g:if test="${defaultProductPackage?.productPrice != null}">
                                 <g:hasRoleFinance onAccessDenied="${g.message(code:'errors.blurred.message', args: [g.message(code:'default.none.label')])}">
                                     <g:formatNumber number="${defaultProductPackage?.productPrice?.price}" />
                                     ${grailsApplication.config.openboxes.locale.defaultCurrencyCode}

--- a/grails-app/views/product/_productPackages.gsp
+++ b/grails-app/views/product/_productPackages.gsp
@@ -53,7 +53,7 @@
                 </td>
                 <td>
                     <g:hasRoleFinance onAccessDenied="${g.message(code:'errors.blurred.message', args: ['0.00'])}">
-                        <g:if test="${pkg?.productPrice?.price != null}">
+                        <g:if test="${pkg?.productPrice != null}">
                             <g:formatNumber number="${pkg?.productPrice?.price}" />
                             ${grailsApplication.config.openboxes.locale.defaultCurrencyCode}
                         </g:if>

--- a/grails-app/views/product/_productPackages.gsp
+++ b/grails-app/views/product/_productPackages.gsp
@@ -53,8 +53,10 @@
                 </td>
                 <td>
                     <g:hasRoleFinance onAccessDenied="${g.message(code:'errors.blurred.message', args: ['0.00'])}">
-                        <g:formatNumber number="${pkg?.productPrice?.price}" />
-                        ${grailsApplication.config.openboxes.locale.defaultCurrencyCode}
+                        <g:if test="${pkg?.productPrice?.price != null}">
+                            <g:formatNumber number="${pkg?.productPrice?.price}" />
+                            ${grailsApplication.config.openboxes.locale.defaultCurrencyCode}
+                        </g:if>
                     </g:hasRoleFinance>
                 </td>
                 <td class="right">


### PR DESCRIPTION
This is a rather ugly bug and I think we should investigate it a little more, but first, let me explain what is going on, because there are many connected things that cause this issue. 
_Sorry in advance for my complicated explanation_

First I need to give some context into domain structure and create product source logic, so Let me highlight the relationship and constraint on certain fields in this hierarchy tree.

On **ProductSupplier** we have a 1:many relationship with a **ProductPackage**, and **ProductPackage** has a `nullable: true` **ProductPrice** which has a field **price** that is `nullable: false`.

When creating a product source using import data, without specifying the package price in the column, we are expecting it to throw a validation exception, because we are assigning `null` to **ProductPrice** which has **price** as a required field.

https://github.com/openboxes/openboxes/blob/c283d367017dc6886d1ba30fa54fd8fdf7217aa3/grails-app/services/org/pih/warehouse/data/ProductSupplierDataService.groovy#L195-L198

Calling a `productPrice.validate()` does return `false` and `productPrice.errors` does contain the validation error that we expect, but when we are at the point of saving the `ProductSupplier`
https://github.com/openboxes/openboxes/blob/c283d367017dc6886d1ba30fa54fd8fdf7217aa3/grails-app/services/org/pih/warehouse/data/ProductSupplierDataService.groovy#L146-L149
an exception is not being thrown, instead It creates the ProductSupllier with ProductPackage that has assigned **product_price_id** for non existing **ProductPrice**, because during save, **ProductPrice** was not saved due to validation error.
So it creates a problem where ProductPackage has an orphan product_price_id which does not correspond to any record in ProductPrice table since it doesn't exist.

So when GORM was trying to fetch `ProductPackage.productPrice` it caused an error since it can't populate this field with a given id, because no record with such an id exists. 

To prevent this issue from happening I changed the default `null` to `0` on ProductPrice during import which is probably what should have been there in the first place, since the same logic is applied for ProductPackage creation on `ProductController > savePackage`
https://github.com/openboxes/openboxes/blob/2d0fdc948f936357d26476b10d6fec47e6f8a0bf/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy#L379-L383 

and I also made a DB migration to remove the orphan foreign keys on ProductPackage table.

One of the problems seems to be when saving nested data, it does not "bubble up the exceptions" which should prevent the record from being created. I have noticed this previously but did not give it much attention since previously all I had to do was call the`.validate()` on that nested object.
I tried to investigate it, and looked into some configuration that we might have missed but was unsuccessful in finding a solution.
My first thought was to add `save(deepValidate: true)`  which in theory should be true by default, but it did not solve the issue.