### PR TITLE
OBPIH-5820 Email alert to approver(s) - Approvals email alerts

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -690,6 +690,7 @@ email.yourItemReceived.message=Your item has been RECEIVED into {0} in shipment 
 email.contactAdmin.message=Please contact your local OpenBoxes administrator with any questions you have about the status of this item. If you have an OpenBoxes account, you can view the shipment via
 email.contactAdminReceiving.message=Please contact the receiver listed above or your local OpenBoxes administrator with any questions you have about the status of this item. If you see a quantity in the cancelled column, this means that the warehouse received fewer items than expected, possibly as a result of a data error or a loss during shipment. The receiver can explain the situation. If you have an OpenBoxes account, you can view the shipment via
 email.thisLink.label=this link
+email.requestReceived.message=You have received a new request from: {0}, created by: {1}. Click <a href='{2}'>here</a> to review your requests pending your approval.
 # Error / bug messages
 error.class.label=Error occurred on
 error.details.label=Steps to reproduce

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -690,7 +690,7 @@ email.yourItemReceived.message=Your item has been RECEIVED into {0} in shipment 
 email.contactAdmin.message=Please contact your local OpenBoxes administrator with any questions you have about the status of this item. If you have an OpenBoxes account, you can view the shipment via
 email.contactAdminReceiving.message=Please contact the receiver listed above or your local OpenBoxes administrator with any questions you have about the status of this item. If you see a quantity in the cancelled column, this means that the warehouse received fewer items than expected, possibly as a result of a data error or a loss during shipment. The receiver can explain the situation. If you have an OpenBoxes account, you can view the shipment via
 email.thisLink.label=this link
-email.requestReceived.message=You have received a new request from: {0}, created by: {1}. Click <a href='{2}'>here</a> to review your requests pending your approval.
+email.requestReceived.message=You have received a new request from: {0}, created by: {1}. Click <a href="{2}">here</a> to review your requests pending your approval.
 # Error / bug messages
 error.class.label=Error occurred on
 error.details.label=Steps to reproduce

--- a/grails-app/services/org/pih/warehouse/inventory/RequisitionStatusTransitionEventService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/RequisitionStatusTransitionEventService.groovy
@@ -21,9 +21,9 @@ class RequisitionStatusTransitionEventService {
 
 
     void publishDefaultEmailNotifications(Requisition requisition, Collection receivers) {
-        String redirectToRequestsList = "/openboxes/stockMovement/list?direction=OUTBOUND&sourceType=ELECTRONIC"
-        String subject = "${requisition.requestNumber} ${requisition.name}"
         def g = grailsApplication.mainContext.getBean('org.codehaus.groovy.grails.plugins.web.taglib.ApplicationTagLib')
+        String subject = "${requisition.requestNumber} ${requisition.name}"
+        String redirectToRequestsList = "${g.createLink(uri: "/stockMovement/list?direction=OUTBOUND&sourceType=ELECTRONIC", absolute: true)}"
         GString body = "${g.render(template: "/email/approvalsAlert", model: [requisition: requisition, redirectUrl: redirectToRequestsList])}"
 
         mailService.sendHtmlMail(subject, body, receivers)

--- a/grails-app/services/org/pih/warehouse/inventory/RequisitionStatusTransitionEventService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/RequisitionStatusTransitionEventService.groovy
@@ -11,6 +11,7 @@ package org.pih.warehouse.inventory
 
 import org.codehaus.groovy.grails.commons.GrailsApplication
 import org.pih.warehouse.core.MailService
+import org.pih.warehouse.core.Person
 import org.pih.warehouse.requisition.Requisition
 
 
@@ -20,12 +21,16 @@ class RequisitionStatusTransitionEventService {
     GrailsApplication grailsApplication
 
 
-    void publishDefaultEmailNotifications(Requisition requisition, Collection receivers) {
+    void publishDefaultEmailNotifications(Requisition requisition, List<Person> receivers) {
         def g = grailsApplication.mainContext.getBean('org.codehaus.groovy.grails.plugins.web.taglib.ApplicationTagLib')
         String subject = "${requisition.requestNumber} ${requisition.name}"
         String redirectToRequestsList = "${g.createLink(uri: "/stockMovement/list?direction=OUTBOUND&sourceType=ELECTRONIC", absolute: true)}"
         GString body = "${g.render(template: "/email/approvalsAlert", model: [requisition: requisition, redirectUrl: redirectToRequestsList])}"
 
-        mailService.sendHtmlMail(subject, body, receivers)
+        receivers.each {receiver ->
+            if (receiver.email) {
+                mailService.sendHtmlMail(subject, body, receiver.email)
+            }
+        }
     }
 }

--- a/grails-app/services/org/pih/warehouse/inventory/RequisitionStatusTransitionEventService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/RequisitionStatusTransitionEventService.groovy
@@ -1,0 +1,31 @@
+/**
+* Copyright (c) 2012 Partners In Health.  All rights reserved.
+* The use and distribution terms for this software are covered by the
+* Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+* which can be found in the file epl-v10.html at the root of this distribution.
+* By using this software in any fashion, you are agreeing to be bound by
+* the terms of this license.
+* You must not remove this notice, or any other, from this software.
+**/
+package org.pih.warehouse.inventory
+
+import org.codehaus.groovy.grails.commons.GrailsApplication
+import org.pih.warehouse.core.MailService
+import org.pih.warehouse.requisition.Requisition
+
+
+class RequisitionStatusTransitionEventService {
+
+    MailService mailService
+    GrailsApplication grailsApplication
+
+
+    void publishDefaultEmailNotifications(Requisition requisition, Collection receivers) {
+        String redirectToRequestsList = "/openboxes/stockMovement/list?direction=OUTBOUND&sourceType=ELECTRONIC"
+        String subject = "${requisition.requestNumber} ${requisition.name}"
+        def g = grailsApplication.mainContext.getBean('org.codehaus.groovy.grails.plugins.web.taglib.ApplicationTagLib')
+        GString body = "${g.render(template: "/email/approvalsAlert", model: [requisition: requisition, redirectUrl: redirectToRequestsList])}"
+
+        mailService.sendHtmlMail(subject, body, receivers)
+    }
+}

--- a/grails-app/views/email/_approvalsAlert.gsp
+++ b/grails-app/views/email/_approvalsAlert.gsp
@@ -1,0 +1,53 @@
+<%@ page contentType="text/html"%>
+<style>
+label {
+    font-weight: bold;
+}
+</style>
+<div>
+    <div class="header">
+        <g:render template="/email/header"/>
+    </div>
+    <div>
+        <g:message code='email.requestReceived.message' args='[requisition.destination, requisition.requestedBy, redirectUrl]' />
+    </div>
+    &nbsp;
+</div>
+<div>
+    <table>
+        <thead style="text-align: left;">
+        <tr>
+            <th>
+                <g:message code="product.productCode.label" />
+            </th>
+            <th>
+                <g:message code="product.title.label" />
+            </th>
+            <th>
+                <g:message code="product.uom.label" />
+            </th>
+            <th>
+                <g:message code="requisition.quantity.label" />
+            </th>
+        </tr>
+        </thead>
+        <g:if test="${requisition.requisitionItems}">
+            <g:each var="item" in="${requisition.requisitionItems}">
+                <tr>
+                    <td>
+                        ${item?.product?.productCode}
+                    </td>
+                    <td>
+                        ${item?.product?.name}
+                    </td>
+                    <td>
+                        ${item?.product?.unitOfMeasure}
+                    </td>
+                    <td style="text-align: center">
+                        ${item?.quantity}
+                    </td>
+                </tr>
+            </g:each>
+        </g:if>
+    </table>
+</div>

--- a/grails-app/views/email/_approvalsAlert.gsp
+++ b/grails-app/views/email/_approvalsAlert.gsp
@@ -1,21 +1,21 @@
 <%@ page contentType="text/html"%>
 <style>
-label {
-    font-weight: bold;
-}
+    label {
+        font-weight: bold;
+    }
 </style>
 <div>
     <div class="header">
         <g:render template="/email/header"/>
     </div>
     <div>
-        <g:message code='email.requestReceived.message' args='[requisition.destination, requisition.requestedBy, redirectUrl]' />
+        <g:message code="email.requestReceived.message" args="[requisition.destination, requisition.requestedBy, redirectUrl]" />
     </div>
     &nbsp;
 </div>
 <div>
     <table>
-        <thead style="text-align: left;">
+        <thead style="text-align: left">
         <tr>
             <th>
                 <g:message code="product.productCode.label" />


### PR DESCRIPTION
I am not calling this function in this PR, because in the draft created by Justin during TH, we decided to call it on an event. So it should be placed like that (code from notes from TH):
```
class RequisitionStatusTransitionEventService implements EventListener<RequisitionStatusTransitionEvent>
    def onApplicationEvent (RequisitionStatusTransitionEvent event) {
        triggerRequisitionTransitions(event)
        publishWebhookEvent(event)
        publishMessageQueueEvent(event) // FHIR event for a specific thingy thing
        publishDefaultEmailNotifications(event)
    }
}
```
I created here `RequisitionStatusTransitionEventService` just for the `publishDefaultEmailNotifications` method. The rest of the code (including event) is a part of another ticket.