### PR TITLE
OBPIH-5802 Fetch users based on role in fulfilling location

### DIFF
--- a/grails-app/services/org/pih/warehouse/core/UserService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/UserService.groovy
@@ -272,7 +272,7 @@ class UserService {
         List<String> roleIds = roleTypeList ? Role.findAllByRoleTypeInList(roleTypeList).collect{ it.id } : null
         Location location = params.location ? Location.get(params.location) : null
 
-        return User.createCriteria().list() {
+        return User.createCriteria().listDistinct() {
             if (params.active != null) {
                 eq("active", Boolean.valueOf(params.active))
             }

--- a/src/js/components/stock-movement-wizard/request/CreateStockMovement.jsx
+++ b/src/js/components/stock-movement-wizard/request/CreateStockMovement.jsx
@@ -108,7 +108,7 @@ const DEFAULT_FIELDS = {
           props.fetchStockLists(value, props.destination);
           if (value?.supportedActivities?.includes(ActivityCode.APPROVE_REQUEST)) {
             props.setSupportsApprover(true);
-            props.fetchAvailableApprovers();
+            props.fetchAvailableApprovers(value.id);
           } else {
             props.setSupportsApprover(false);
           }
@@ -234,7 +234,7 @@ class CreateStockMovement extends Component {
     if (this.state.values.origin) {
       if (this.state.values.origin?.supportedActivities?.includes(ActivityCode.APPROVE_REQUEST)) {
         this.setSupportsApprover(true);
-        this.fetchAvailableApprovers();
+        this.fetchAvailableApprovers(this.state.values.origin.id);
       } else {
         this.setSupportsApprover(false);
       }
@@ -301,9 +301,9 @@ class CreateStockMovement extends Component {
       .catch(() => this.props.hideSpinner());
   }
 
-  fetchAvailableApprovers() {
+  fetchAvailableApprovers(locationId) {
     return userApi.getUsersOptions({
-      params: { roleTypes: RoleType.ROLE_REQUISITION_APPROVER },
+      params: { roleTypes: RoleType.ROLE_REQUISITION_APPROVER, location: locationId },
     })
       .then((response) => {
         const options = response.data.data?.map(user => ({
@@ -481,8 +481,8 @@ class CreateStockMovement extends Component {
                 stocklists: this.state.stocklists,
                 fetchStockLists: (origin, destination) =>
                   this.fetchStockLists(origin, destination, mutators.clearStocklist),
-                fetchAvailableApprovers: () => {
-                  this.fetchAvailableApprovers().then((resp) => {
+                fetchAvailableApprovers: (locationId) => {
+                  this.fetchAvailableApprovers(locationId).then((resp) => {
                     // if there is only one available approver to choose from
                     // then preselect this options by default
                     if (resp?.length === 1) {

--- a/src/js/utils/Select.jsx
+++ b/src/js/utils/Select.jsx
@@ -313,8 +313,8 @@ class Select extends Component {
       if (fieldValue?.displayName || showLabelTooltip) {
         return false;
       }
-
-      return !(showValueTooltip && fieldValue);
+      const hasFieldValue = Array.isArray(fieldValue) ? fieldValue.length : fieldValue;
+      return !(showValueTooltip && hasFieldValue);
     };
 
     return (


### PR DESCRIPTION
Forgot to add the location parameter on the frontend when fetching approvers based on location roles.

~Additionally fixed the multi-select tooltip, which was showing up because it's value is an `Array` instead of simple `[]`.
When casting an `Array(0)` to a `boolean` it returns `true` unlike casting a `[]` which returns `false`~

Additionally fixed the multi-select tooltip, which was showing up because it's value is an array which is a truthy even when it is empty. 