### PR TITLE
OBPIH-5821 Move send notification logic to notificationService and add individual links for approvers to request list

### DIFF
--- a/grails-app/domain/org/pih/warehouse/requisition/Requisition.groovy
+++ b/grails-app/domain/org/pih/warehouse/requisition/Requisition.groovy
@@ -151,7 +151,8 @@ class Requisition implements Comparable<Requisition>, Serializable {
         statusSortOrder formula: RequisitionStatus.getStatusSortOrderFormula()
         monthRequested formula: "date_format(date_requested, '%M %Y')"
         comments joinTable: [name: "requisition_comment", key: "requisition_id"]
-        events joinTable: [name: "requisition_event", key: "requisition_id"]
+        // Fetch join in the events should be removed in Grails 3 and replaced with proper join query using data services
+        events joinTable: [name: "requisition_event", key: "requisition_id"], fetch: 'join'
         approvers joinTable: [name: "requisition_approvers", key: "requisition_id"]
     }
 

--- a/grails-app/domain/org/pih/warehouse/requisition/Requisition.groovy
+++ b/grails-app/domain/org/pih/warehouse/requisition/Requisition.groovy
@@ -151,8 +151,7 @@ class Requisition implements Comparable<Requisition>, Serializable {
         statusSortOrder formula: RequisitionStatus.getStatusSortOrderFormula()
         monthRequested formula: "date_format(date_requested, '%M %Y')"
         comments joinTable: [name: "requisition_comment", key: "requisition_id"]
-        // Fetch join in the events should be removed in Grails 3 and replaced with proper join query using data services
-        events joinTable: [name: "requisition_event", key: "requisition_id"], fetch: 'join'
+        events joinTable: [name: "requisition_event", key: "requisition_id"]
         approvers joinTable: [name: "requisition_approvers", key: "requisition_id"]
     }
 

--- a/grails-app/services/org/pih/warehouse/inventory/RequisitionStatusTransitionEventService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/RequisitionStatusTransitionEventService.groovy
@@ -23,7 +23,7 @@ class RequisitionStatusTransitionEventService implements ApplicationListener<Req
 
     void onApplicationEvent(RequisitionStatusTransitionEvent event) {
         Requisition requisition = event.requisition
-        notificationService.publishRequisitionStatusTransitionNotifications(requisition, event.newStatus)
-        requisitionService.triggerRequisitionStatusTransition(requisition, event.newStatus, event.createdBy)
+        requisitionService.triggerRequisitionStatusTransition(requisition, event.createdBy)
+        notificationService.publishRequisitionStatusTransitionNotifications(requisition)
     }
 }

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -246,7 +246,7 @@ class StockMovementService {
         } else {
             requisition.status = status
             requisition.save(flush: true)
-            publishEvent(new RequisitionStatusTransitionEvent(requisition, requisition.status, AuthService.currentUser.get()))
+            publishEvent(new RequisitionStatusTransitionEvent(requisition, AuthService.currentUser.get()))
         }
     }
 

--- a/grails-app/services/org/pih/warehouse/report/NotificationService.groovy
+++ b/grails-app/services/org/pih/warehouse/report/NotificationService.groovy
@@ -244,23 +244,23 @@ class NotificationService {
         return recipients
     }
 
-    void publishRequisitionStatusTransitionNotifications(Requisition requisition, RequisitionStatus newStatus) {
-        List<Person> approvers = resolveNotificationRecipients(requisition)
+    void publishRequisitionStatusTransitionNotifications(Requisition requisition) {
+        List<Person> recipients = resolveNotificationRecipients(requisition)
 
-        if (newStatus == RequisitionStatus.PENDING_APPROVAL) {
-            publishRequisitionPendingApprovalNotifications(requisition, approvers)
+        if (requisition.status == RequisitionStatus.PENDING_APPROVAL) {
+            publishRequisitionPendingApprovalNotifications(requisition, recipients)
         }
     }
 
-    void publishRequisitionPendingApprovalNotifications(Requisition requisition, List<Person> receivers) {
+    void publishRequisitionPendingApprovalNotifications(Requisition requisition, List<Person> recipients) {
         String subject = "${requisition.requestNumber} ${requisition.name}"
         String template = "/email/approvalsAlert"
 
-        receivers.each { receiver ->
-            if (receiver.email) {
-                String redirectToRequestsList = "/stockMovement/list?direction=OUTBOUND&sourceType=ELECTRONIC&approver=${receiver.id}"
+        recipients.each { recipient ->
+            if (recipient.email) {
+                String redirectToRequestsList = "/stockMovement/list?direction=OUTBOUND&sourceType=ELECTRONIC&approver=${recipient.id}"
                 String body = renderTemplate(template, [requisition: requisition, redirectUrl: redirectToRequestsList])
-                mailService.sendHtmlMail(subject, body, receiver.email)
+                mailService.sendHtmlMail(subject, body, recipient.email)
             }
         }
     }

--- a/grails-app/services/org/pih/warehouse/report/NotificationService.groovy
+++ b/grails-app/services/org/pih/warehouse/report/NotificationService.groovy
@@ -22,6 +22,7 @@ import org.pih.warehouse.core.MailService
 import org.pih.warehouse.core.Person
 import org.pih.warehouse.core.RoleType
 import org.pih.warehouse.core.User
+import org.pih.warehouse.requisition.Requisition
 import org.pih.warehouse.shipping.Shipment
 import org.springframework.web.context.request.RequestContextHolder
 import org.springframework.web.context.support.WebApplicationContextUtils
@@ -223,6 +224,19 @@ class NotificationService {
             }
         } catch (EmailException e) {
             log.error("Unable to send confirmation email: " + e.message, e)
+        }
+    }
+
+    def sendRequestPendingForApprovalNotification(Requisition requisition, List<Person> receivers) {
+        String subject = "${requisition.requestNumber} ${requisition.name}"
+        String template = "/email/approvalsAlert"
+
+        receivers.each {receiver ->
+            if (receiver.email) {
+                String redirectToRequestsList = "/stockMovement/list?direction=OUTBOUND&sourceType=ELECTRONIC&approver=${receiver.id}"
+                String body = renderTemplate(template, [requisition: requisition, redirectUrl: redirectToRequestsList])
+                mailService.sendHtmlMail(subject, body, receiver.email)
+            }
         }
     }
 

--- a/grails-app/services/org/pih/warehouse/requisition/RequisitionService.groovy
+++ b/grails-app/services/org/pih/warehouse/requisition/RequisitionService.groovy
@@ -825,10 +825,10 @@ class RequisitionService {
         return new Event(eventDate: eventDate, eventType: eventType, eventLocation: eventLocation, createdBy: currentUser)
     }
 
-    void triggerRequisitionStatusTransition(Requisition requisitionInstance, RequisitionStatus status, User currentUser) {
+    void triggerRequisitionStatusTransition(Requisition requisitionInstance, User currentUser) {
         Requisition.withSession {
             Requisition requisition = Requisition.get(requisitionInstance.id)
-            if (status == RequisitionStatus.PENDING_APPROVAL) {
+            if (requisition.status == RequisitionStatus.PENDING_APPROVAL) {
                 if (requisition.origin.approvalRequired) {
                     Event event = createEvent(EventCode.PENDING_APPROVAL, requisition.origin, new Date(), currentUser)
                     requisition.addToEvents(event)

--- a/grails-app/views/email/_approvalsAlert.gsp
+++ b/grails-app/views/email/_approvalsAlert.gsp
@@ -9,7 +9,13 @@
         <g:render template="/email/header"/>
     </div>
     <div>
-        <g:message code="email.requestReceived.message" args="[requisition.destination, requisition.requestedBy, redirectUrl]" />
+        <g:message
+                code="email.requestReceived.message"
+                args="[requisition.destination,
+                       requisition.requestedBy,
+                       g.createLink(uri: redirectUrl, absolute: true),
+                ]"
+        />
     </div>
     &nbsp;
 </div>

--- a/src/groovy/org/pih/warehouse/requisition/RequisitionStatusTransitionEvent.groovy
+++ b/src/groovy/org/pih/warehouse/requisition/RequisitionStatusTransitionEvent.groovy
@@ -6,14 +6,11 @@ import org.springframework.context.ApplicationEvent
 class RequisitionStatusTransitionEvent extends ApplicationEvent {
     Requisition requisition
 
-    RequisitionStatus newStatus
-
     User createdBy
 
-    RequisitionStatusTransitionEvent(Requisition requisition, RequisitionStatus newStatus, User createdBy) {
+    RequisitionStatusTransitionEvent(Requisition requisition, User createdBy) {
         super(requisition)
         this.requisition = requisition
-        this.newStatus = newStatus
         this.createdBy = createdBy
     }
 }


### PR DESCRIPTION
@alannadolny When I called the `publishDefaultEmailNotifications()` in the `onApplicationEvent` there was a problem with `g.render` and `g.crealink` which threw an exception

```
Method threw 'java.lang.IllegalStateException' exception.

No thread-bound request found: Are you referring to request attributes outside of an actual web request, or processing a request outside of the originally receiving thread? If you are actually operating within a web request and still receive this message, your code is probably running outside of DispatcherServlet/DispatcherPortlet: In this case, use RequestContextListener or RequestContextFilter to expose the current request.
```

looking at other methods connected to sending mail located in `notificationService` I noticed that they use `renderTemplate()` helper function to render these templates. Most likely it is a workaround for the same problem which I mentioned before.

Additionally, I decided to move this method to **notificationService** since most of our "sendMail" functions live there, unless you disagree with this decision then I'll move it back.





--------------------------------------------------------------------------------------------------------------------------------------------
For now, I selected a base branch `OBPIH-5803` because I needed the functionality of triggering the event on submit to send an email.
When that branch is going to be merged to develop I will rebase and will change the base branch to develop.
