### PR TITLE
OBPIH-5805 Approver cannot edit requests - Approvals end to end workflow

### DIFF
--- a/src/js/components/stock-movement-wizard/StockMovementVerifyRequest.jsx
+++ b/src/js/components/stock-movement-wizard/StockMovementVerifyRequest.jsx
@@ -9,6 +9,7 @@ import PackingPage from 'components/stock-movement-wizard/outbound/PackingPage';
 import PickPage from 'components/stock-movement-wizard/outbound/PickPage';
 import SendMovementPage from 'components/stock-movement-wizard/outbound/SendMovementPage';
 import EditPage from 'components/stock-movement-wizard/request/EditPage';
+import { canEditRequest } from 'components/stock-transfer/utils';
 import Wizard from 'components/wizard/Wizard';
 import apiClient from 'utils/apiClient';
 import { translateWithDefaultMessage } from 'utils/Translate';
@@ -223,8 +224,9 @@ class StockMovementVerifyRequest extends Component {
 
   render() {
     const { values, currentPage } = this.state;
-    const { currentLocation } = this.props;
-    const showOnly = values.origin && values.origin.id !== currentLocation.id;
+    const { currentLocation, currentUser } = this.props;
+    const showOnly = (values.origin && values.origin.id !== currentLocation.id) ||
+      (values?.isElectronicType && !canEditRequest(currentUser, values, currentLocation));
 
     if (values.stockMovementId) {
       return (
@@ -251,6 +253,7 @@ const mapStateToProps = state => ({
   translate: translateWithDefaultMessage(getTranslate(state.localize)),
   hasPackingSupport: state.session.currentLocation.hasPackingSupport,
   currentLocation: state.session.currentLocation,
+  currentUser: state.session.user,
 });
 
 export default connect(mapStateToProps, {
@@ -279,6 +282,9 @@ StockMovementVerifyRequest.propTypes = {
   initialValues: PropTypes.shape({
     shipmentStatus: PropTypes.string,
   }),
+  currentUser: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 StockMovementVerifyRequest.defaultProps = {

--- a/src/js/components/stock-movement-wizard/StockMovementVerifyRequest.jsx
+++ b/src/js/components/stock-movement-wizard/StockMovementVerifyRequest.jsx
@@ -9,9 +9,9 @@ import PackingPage from 'components/stock-movement-wizard/outbound/PackingPage';
 import PickPage from 'components/stock-movement-wizard/outbound/PickPage';
 import SendMovementPage from 'components/stock-movement-wizard/outbound/SendMovementPage';
 import EditPage from 'components/stock-movement-wizard/request/EditPage';
-import { canEditRequest } from 'components/stock-transfer/utils';
 import Wizard from 'components/wizard/Wizard';
 import apiClient from 'utils/apiClient';
+import canEditRequest from 'utils/permissionUtils';
 import { translateWithDefaultMessage } from 'utils/Translate';
 
 import 'components/stock-movement-wizard/StockMovement.scss';

--- a/src/js/components/stock-movement-wizard/request/EditPage.jsx
+++ b/src/js/components/stock-movement-wizard/request/EditPage.jsx
@@ -23,11 +23,11 @@ import TableRowWithSubfields from 'components/form-elements/TableRowWithSubfield
 import TextField from 'components/form-elements/TextField';
 import DetailsModal from 'components/stock-movement-wizard/modals/DetailsModal';
 import SubstitutionsModal from 'components/stock-movement-wizard/modals/SubstitutionsModal';
-import { canEditRequest } from 'components/stock-transfer/utils';
 import RequisitionStatus from 'consts/requisitionStatus';
 import apiClient from 'utils/apiClient';
 import { renderFormField } from 'utils/form-utils';
 import { formatProductDisplayName, showOutboundEditValidationErrors } from 'utils/form-values-utils';
+import canEditRequest from 'utils/permissionUtils';
 import renderHandlingIcons from 'utils/product-handling-icons';
 import Translate, { translateWithDefaultMessage } from 'utils/Translate';
 
@@ -1522,11 +1522,9 @@ class EditItemsPage extends Component {
 
   isAddingItemsAllowed() {
     const { currentUser, currentLocation } = this.props;
+    const { values } = this.state;
 
-    if (
-      this.state.values?.isElectronicType &&
-      !canEditRequest(currentUser, this.state.values, currentLocation)
-    ) {
+    if (values?.isElectronicType && !canEditRequest(currentUser, values, currentLocation)) {
       return false;
     }
 

--- a/src/js/components/stock-movement-wizard/request/EditPage.jsx
+++ b/src/js/components/stock-movement-wizard/request/EditPage.jsx
@@ -1503,37 +1503,16 @@ class EditItemsPage extends Component {
       });
   }
 
-  /**
-   * If we are in requesting location (destination), allow to add items only for a person
-   * who created a stock request
-   *
-   * If we are in verifying/fulfilling location (origin), allow to add items for any person
-   * verifying the request
-   * @returns {boolean}
-   */
-  isUserAllowedToAddItems() {
-    const { requestedBy, origin, destination } = this.state.values;
-    const { currentUser, currentLocation } = this.props;
-    if (currentLocation?.id === origin?.id) {
-      return true;
-    }
-    return currentLocation?.id === destination?.id && requestedBy?.id === currentUser?.id;
-  }
-
   isAddingItemsAllowed() {
     const { currentUser, currentLocation } = this.props;
     const { values } = this.state;
-
-    if (values?.isElectronicType && !canEditRequest(currentUser, values, currentLocation)) {
-      return false;
-    }
 
     const allowedStatuses = [
       RequisitionStatus.CREATED,
       RequisitionStatus.EDITING,
       RequisitionStatus.VERIFYING,
     ];
-    return this.isUserAllowedToAddItems() &&
+    return canEditRequest(currentUser, values, currentLocation) &&
       allowedStatuses.includes(this.state.values?.associations?.requisition?.status);
   }
 

--- a/src/js/components/stock-movement/outbound/StockMovementOutboundTable.jsx
+++ b/src/js/components/stock-movement/outbound/StockMovementOutboundTable.jsx
@@ -16,6 +16,7 @@ import DataTable, { TableCell } from 'components/DataTable';
 import DateCell from 'components/DataTable/DateCell';
 import Button from 'components/form-elements/Button';
 import ShipmentIdentifier from 'components/stock-movement/common/ShipmentIdentifier';
+import { canEditRequest } from 'components/stock-transfer/utils';
 import useOutboundListTableData from 'hooks/list-pages/outbound/useOutboundListTableData';
 import ActionDots from 'utils/ActionDots';
 import { getShipmentTypeTooltip } from 'utils/list-utils';
@@ -30,6 +31,7 @@ const StockMovementOutboundTable = ({
   translate,
   requisitionStatuses,
   currentLocation,
+  currentUser,
   isRequestsOpen,
   isUserAdmin,
 }) => {
@@ -65,7 +67,10 @@ const StockMovementOutboundTable = ({
     actions.push(showAction);
 
     // Edit
-    if (!isReceived && !isPartiallyReceived) {
+    if (
+      !isReceived && !isPartiallyReceived &&
+      canEditRequest(currentUser, row.original, currentLocation)
+    ) {
       const editAction = {
         defaultLabel: 'Edit Stock Movement',
         label: 'react.stockMovement.action.edit.label',
@@ -280,6 +285,7 @@ const mapStateToProps = state => ({
   currentLocation: state.session.currentLocation,
   isUserAdmin: state.session.isUserAdmin,
   currentLocale: state.session.activeLanguage,
+  currentUser: state.session.user,
 });
 
 export default connect(mapStateToProps)(StockMovementOutboundTable);
@@ -293,6 +299,9 @@ StockMovementOutboundTable.propTypes = {
   currentLocation: PropTypes.shape({
     id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
+  }).isRequired,
+  currentUser: PropTypes.shape({
+    id: PropTypes.string.isRequired,
   }).isRequired,
   requisitionStatuses: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string,

--- a/src/js/components/stock-movement/outbound/StockMovementOutboundTable.jsx
+++ b/src/js/components/stock-movement/outbound/StockMovementOutboundTable.jsx
@@ -16,11 +16,11 @@ import DataTable, { TableCell } from 'components/DataTable';
 import DateCell from 'components/DataTable/DateCell';
 import Button from 'components/form-elements/Button';
 import ShipmentIdentifier from 'components/stock-movement/common/ShipmentIdentifier';
-import { canEditRequest } from 'components/stock-transfer/utils';
 import useOutboundListTableData from 'hooks/list-pages/outbound/useOutboundListTableData';
 import ActionDots from 'utils/ActionDots';
 import { getShipmentTypeTooltip } from 'utils/list-utils';
 import { mapShipmentTypes } from 'utils/option-utils';
+import canEditRequest from 'utils/permissionUtils';
 import StatusIndicator from 'utils/StatusIndicator';
 import Translate, { translateWithDefaultMessage } from 'utils/Translate';
 

--- a/src/js/components/stock-transfer/utils.jsx
+++ b/src/js/components/stock-transfer/utils.jsx
@@ -1,9 +1,5 @@
 import _ from 'lodash';
 
-import ActivityCode from 'consts/activityCode';
-import RequisitionStatus from 'consts/requisitionStatus';
-import { supports } from 'utils/supportedActivitiesUtils';
-
 const PENDING = 'PENDING';
 const CANCELED = 'CANCELED';
 
@@ -98,22 +94,3 @@ export function prepareRequest(stockTransfer, status) {
 
   return { ...stockTransfer, stockTransferItems, status };
 }
-
-export const canEditRequest = (currentUser, request, location) => {
-  const isRequestApprovalSupported = supports(
-    location?.supportedActivities,
-    ActivityCode.APPROVE_REQUEST,
-  );
-  const isUserRequestor = currentUser?.id === request?.requestedBy?.id;
-
-  // If request approval is not supported by the location we are able to edit every request
-  if (!isRequestApprovalSupported) {
-    return true;
-  }
-
-  // If the location supports request approval, only the requestor is able to edit
-  // and the request couldn't be approved / rejected when editing
-  return isUserRequestor &&
-    request.statusCode !== RequisitionStatus.APPROVED &&
-    request.statusCode !== RequisitionStatus.REJECTED;
-};

--- a/src/js/components/stock-transfer/utils.jsx
+++ b/src/js/components/stock-transfer/utils.jsx
@@ -1,5 +1,9 @@
 import _ from 'lodash';
 
+import ActivityCode from 'consts/activityCode';
+import RequisitionStatus from 'consts/requisitionStatus';
+import { supports } from 'utils/supportedActivitiesUtils';
+
 const PENDING = 'PENDING';
 const CANCELED = 'CANCELED';
 
@@ -94,3 +98,22 @@ export function prepareRequest(stockTransfer, status) {
 
   return { ...stockTransfer, stockTransferItems, status };
 }
+
+export const canEditRequest = (currentUser, request, location) => {
+  const isRequestApprovalSupported = supports(
+    location?.supportedActivities,
+    ActivityCode.APPROVE_REQUEST,
+  );
+  const isUserRequestor = currentUser?.id === request?.requestedBy?.id;
+
+  // If request approval is not supported by the location we are able to edit every request
+  if (!isRequestApprovalSupported) {
+    return true;
+  }
+
+  // If the location supports request approval, only the requestor is able to edit
+  // and the request couldn't be approved / rejected when editing
+  return isUserRequestor &&
+    request.statusCode !== RequisitionStatus.APPROVED &&
+    request.statusCode !== RequisitionStatus.REJECTED;
+};

--- a/src/js/consts/requisitionStatus.js
+++ b/src/js/consts/requisitionStatus.js
@@ -17,6 +17,9 @@ const RequisitionStatus = {
   FULFILLED: 'FULFILLED',
   REVIEWING: 'REVIEWING',
   CONFIRMING: 'CONFIRMING',
+  PENDING_APPROVAL: 'PENDING_APPROVAL',
+  APPROVED: 'APPROVED',
+  REJECTED: 'REJECTED',
 };
 
 export default RequisitionStatus;

--- a/src/js/utils/permissionUtils.js
+++ b/src/js/utils/permissionUtils.js
@@ -1,0 +1,24 @@
+import ActivityCode from 'consts/activityCode';
+import RequisitionStatus from 'consts/requisitionStatus';
+import { supports } from 'utils/supportedActivitiesUtils';
+
+const canEditRequest = (currentUser, request, location) => {
+  const isRequestApprovalSupported = supports(
+    location?.supportedActivities,
+    ActivityCode.APPROVE_REQUEST,
+  );
+
+  // If request approval is not supported by the location we are able to edit every request
+  if (!isRequestApprovalSupported) {
+    return true;
+  }
+
+  const isUserRequestor = currentUser?.id === request?.requestedBy?.id;
+  // If the location supports request approval, only the requestor is able to edit
+  // and the request can't be approved / rejected when editing
+  return isUserRequestor &&
+    request.statusCode !== RequisitionStatus.APPROVED &&
+    request.statusCode !== RequisitionStatus.REJECTED;
+};
+
+export default canEditRequest;

--- a/src/js/utils/permissionUtils.js
+++ b/src/js/utils/permissionUtils.js
@@ -2,21 +2,42 @@ import ActivityCode from 'consts/activityCode';
 import RequisitionStatus from 'consts/requisitionStatus';
 import { supports } from 'utils/supportedActivitiesUtils';
 
+const canEditRequestWithoutRequestApproval = (location, origin, destination, isUserRequestor) => {
+  const isLocationOrigin = location.id === origin?.id;
+  // If we are in verifying/fulfilling location (origin), allow to add items for any person
+  // verifying the request
+  if (isLocationOrigin) {
+    return true;
+  }
+  const isLocationDestination = location.id === destination?.id;
+  // If we are in requesting location (destination), allow to add items only for a person
+  // who created a stock request
+  return isLocationDestination && isUserRequestor;
+};
+
 const canEditRequest = (currentUser, request, location) => {
   const isRequestApprovalSupported = supports(
     location?.supportedActivities,
     ActivityCode.APPROVE_REQUEST,
   );
-
-  // If request approval is not supported by the location we are able to edit every request
+  const isUserRequestor = currentUser?.id === request?.requestedBy?.id;
+  // If request approval is not supported by the location we have to check if the
+  // location is destination or origin
   if (!isRequestApprovalSupported) {
-    return true;
+    return canEditRequestWithoutRequestApproval(
+      location,
+      request?.origin,
+      request?.destination,
+      isUserRequestor,
+    );
   }
 
-  const isUserRequestor = currentUser?.id === request?.requestedBy?.id;
+  const isLocationOrigin = location.id === request?.origin?.id;
+  const isLocationDestination = location.id === request?.destination?.id;
   // If the location supports request approval, only the requestor is able to edit
   // and the request can't be approved / rejected when editing
   return isUserRequestor &&
+    (isLocationDestination || isLocationOrigin) &&
     request.statusCode !== RequisitionStatus.APPROVED &&
     request.statusCode !== RequisitionStatus.REJECTED;
 };

--- a/src/js/utils/permissionUtils.js
+++ b/src/js/utils/permissionUtils.js
@@ -2,7 +2,7 @@ import ActivityCode from 'consts/activityCode';
 import RequisitionStatus from 'consts/requisitionStatus';
 import { supports } from 'utils/supportedActivitiesUtils';
 
-const canEditRequestWithoutRequestApproval = (location, origin, destination, isUserRequestor) => {
+const canEditRequestWithoutRequiredApproval = (location, origin, destination, isUserRequestor) => {
   const isLocationOrigin = location.id === origin?.id;
   // If we are in verifying/fulfilling location (origin), allow to add items for any person
   // verifying the request
@@ -16,15 +16,15 @@ const canEditRequestWithoutRequestApproval = (location, origin, destination, isU
 };
 
 const canEditRequest = (currentUser, request, location) => {
-  const isRequestApprovalSupported = supports(
+  const isApprovalRequired = supports(
     location?.supportedActivities,
     ActivityCode.APPROVE_REQUEST,
   );
   const isUserRequestor = currentUser?.id === request?.requestedBy?.id;
   // If request approval is not supported by the location we have to check if the
   // location is destination or origin
-  if (!isRequestApprovalSupported) {
-    return canEditRequestWithoutRequestApproval(
+  if (!isApprovalRequired) {
+    return canEditRequestWithoutRequiredApproval(
       location,
       request?.origin,
       request?.destination,


### PR DESCRIPTION
I asked Manon about the designated behavior of the edit options:
1. When we are on the view page - after clicking edit we are redirected to the add items view page of the selected request, but this view is read-only. The "edit items" button is not visible.
2. When we are on the requests list - the edit option on the dropdown for the selected requests is not visible.

The edit option is not visible when:
1. Our location supports requests approval - request can be edited when it is not in approved/rejected status. It can be edited only by the requestor.
2. Our location doesn't support request approval - it should stay as it was before, every person can edit every request (restrictions are only based on locations)