### PR TITLE
OBPIH-5806 Update with PENDING_APPROVAL status on approval submit and REQUESTED on reagular outbound

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -136,6 +136,9 @@ class StockMovementService {
                     //RequisitionStatus.EDITING:
                     case StockMovementStatusCode.REQUESTED:
                         break
+                    //RequisitionStatus.PENDING_APPROVAL:
+                    case StockMovementStatusCode.PENDING_APPROVAL:
+                        break
                     //RequisitionStatus.VERIFYING:
                     case StockMovementStatusCode.VALIDATED:
                         break

--- a/grails-app/services/org/pih/warehouse/requisition/RequisitionService.groovy
+++ b/grails-app/services/org/pih/warehouse/requisition/RequisitionService.groovy
@@ -836,13 +836,15 @@ class RequisitionService {
         // OBPIH-5134 Request approval feature implements additional status transitions for a request
         // If fulfilling location does not require approval we omit all other status transitions and set it to VERIFYING
         switch(newStatus) {
+            case RequisitionStatus.PENDING_APPROVAL:
+                if (requisition.origin.approvalRequired) {
+                    transitionRequisitionStatus(requisition, RequisitionStatus.PENDING_APPROVAL, EventCode.PENDING_APPROVAL, currentUser)
+                    requisition.approvalRequired = true
+                    break
+                }
             case RequisitionStatus.VERIFYING:
                 transitionRequisitionStatus(requisition, RequisitionStatus.VERIFYING, EventCode.SUBMITTED, currentUser)
                 requisition.approvalRequired = false
-                break
-            case RequisitionStatus.PENDING_APPROVAL:
-                transitionRequisitionStatus(requisition, RequisitionStatus.PENDING_APPROVAL, EventCode.PENDING_APPROVAL, currentUser)
-                requisition.approvalRequired = true
                 break
             case RequisitionStatus.APPROVED:
                 transitionRequisitionStatus(requisition, RequisitionStatus.APPROVED, EventCode.APPROVED, currentUser)

--- a/grails-app/services/org/pih/warehouse/requisition/RequisitionService.groovy
+++ b/grails-app/services/org/pih/warehouse/requisition/RequisitionService.groovy
@@ -834,24 +834,30 @@ class RequisitionService {
 
     void triggerRequisitionStatusTransition(Requisition requisition, User currentUser, RequisitionStatus newStatus) {
         // OBPIH-5134 Request approval feature implements additional status transitions for a request
-        // If fulfilling location does not require approval we omit all other status transitions and set it to VERIFYING
         switch(newStatus) {
-            case RequisitionStatus.PENDING_APPROVAL:
-                if (requisition.origin.approvalRequired) {
-                    transitionRequisitionStatus(requisition, RequisitionStatus.PENDING_APPROVAL, EventCode.PENDING_APPROVAL, currentUser)
-                    requisition.approvalRequired = true
-                    break
-                }
             case RequisitionStatus.VERIFYING:
                 transitionRequisitionStatus(requisition, RequisitionStatus.VERIFYING, EventCode.SUBMITTED, currentUser)
                 requisition.approvalRequired = false
                 break
+            case RequisitionStatus.PENDING_APPROVAL:
+                if (!requisition.origin.approvalRequired) {
+                    throw new IllegalArgumentException("Fulfilling location must support Request Approval")
+                }
+                transitionRequisitionStatus(requisition, RequisitionStatus.PENDING_APPROVAL, EventCode.PENDING_APPROVAL, currentUser)
+                requisition.approvalRequired = true
+                break
             case RequisitionStatus.APPROVED:
+                if (!requisition.origin.approvalRequired) {
+                    throw new IllegalArgumentException("Fulfilling location must support Request Approval")
+                }
                 transitionRequisitionStatus(requisition, RequisitionStatus.APPROVED, EventCode.APPROVED, currentUser)
                 requisition.dateApproved = new Date()
                 requisition.approvedBy = currentUser
                 break
             case RequisitionStatus.REJECTED:
+                if (!requisition.origin.approvalRequired) {
+                    throw new IllegalArgumentException("Fulfilling location must support Request Approval")
+                }
                 transitionRequisitionStatus(requisition, RequisitionStatus.REJECTED, EventCode.REJECTED, currentUser)
                 requisition.dateRejected = new Date()
                 requisition.rejectedBy = currentUser

--- a/grails-app/services/org/pih/warehouse/requisition/RequisitionService.groovy
+++ b/grails-app/services/org/pih/warehouse/requisition/RequisitionService.groovy
@@ -836,14 +836,13 @@ class RequisitionService {
         // OBPIH-5134 Request approval feature implements additional status transitions for a request
         // If fulfilling location does not require approval we omit all other status transitions and set it to VERIFYING
         switch(newStatus) {
+            case RequisitionStatus.VERIFYING:
+                transitionRequisitionStatus(requisition, RequisitionStatus.VERIFYING, EventCode.SUBMITTED, currentUser)
+                requisition.approvalRequired = false
+                break
             case RequisitionStatus.PENDING_APPROVAL:
-                if (requisition.origin.approvalRequired) {
-                    transitionRequisitionStatus(requisition, RequisitionStatus.PENDING_APPROVAL, EventCode.PENDING_APPROVAL, currentUser)
-                    requisition.approvalRequired = true
-                } else {
-                    transitionRequisitionStatus(requisition, RequisitionStatus.VERIFYING, EventCode.SUBMITTED, currentUser)
-                    requisition.approvalRequired = false
-                }
+                transitionRequisitionStatus(requisition, RequisitionStatus.PENDING_APPROVAL, EventCode.PENDING_APPROVAL, currentUser)
+                requisition.approvalRequired = true
                 break
             case RequisitionStatus.APPROVED:
                 transitionRequisitionStatus(requisition, RequisitionStatus.APPROVED, EventCode.APPROVED, currentUser)

--- a/src/groovy/org/pih/warehouse/requisition/RequisitionStatus.groovy
+++ b/src/groovy/org/pih/warehouse/requisition/RequisitionStatus.groovy
@@ -127,6 +127,8 @@ enum RequisitionStatus {
             case StockMovementStatusCode.REQUESTING:
                 return RequisitionStatus.EDITING
             case StockMovementStatusCode.REQUESTED:
+                return RequisitionStatus.VERIFYING
+            case StockMovementStatusCode.PENDING_APPROVAL:
                 return RequisitionStatus.PENDING_APPROVAL
             case StockMovementStatusCode.PACKED:
                 return RequisitionStatus.CHECKING

--- a/src/js/components/stock-movement-wizard/request/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/request/AddItemsPage.jsx
@@ -1229,7 +1229,13 @@ class AddItemsPage extends Component {
   submitRequest(lineItems) {
     const nonEmptyLineItems = _.filter(lineItems, val => !_.isEmpty(val) && val.product);
     this.saveRequisitionItems(nonEmptyLineItems)
-      .then(() => this.transitionToNextStep('PENDING_APPROVAL'));
+      .then(() => {
+        if (supports(this.state.values.origin?.supportedActivities, ActivityCode.APPROVE_REQUEST)) {
+          this.transitionToNextStep('PENDING_APPROVAL');
+        } else {
+          this.transitionToNextStep('REQUESTED');
+        }
+      });
   }
 
   /**

--- a/src/js/components/stock-movement-wizard/request/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/request/AddItemsPage.jsx
@@ -22,6 +22,7 @@ import TextField from 'components/form-elements/TextField';
 import notification from 'components/Layout/notifications/notification';
 import ActivityCode from 'consts/activityCode';
 import NotificationType from 'consts/notificationTypes';
+import RequisitionStatus from 'consts/requisitionStatus';
 import apiClient from 'utils/apiClient';
 import { renderFormField } from 'utils/form-utils';
 import { isRequestFromWard, supports } from 'utils/supportedActivitiesUtils';
@@ -1231,9 +1232,9 @@ class AddItemsPage extends Component {
     this.saveRequisitionItems(nonEmptyLineItems)
       .then(() => {
         if (supports(this.state.values.origin?.supportedActivities, ActivityCode.APPROVE_REQUEST)) {
-          this.transitionToNextStep('PENDING_APPROVAL');
+          this.transitionToNextStep(RequisitionStatus.PENDING_APPROVAL);
         } else {
-          this.transitionToNextStep('REQUESTED');
+          this.transitionToNextStep(RequisitionStatus.REQUESTED);
         }
       });
   }

--- a/src/js/components/stock-movement-wizard/request/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/request/AddItemsPage.jsx
@@ -1229,7 +1229,7 @@ class AddItemsPage extends Component {
   submitRequest(lineItems) {
     const nonEmptyLineItems = _.filter(lineItems, val => !_.isEmpty(val) && val.product);
     this.saveRequisitionItems(nonEmptyLineItems)
-      .then(() => this.transitionToNextStep('REQUESTED'));
+      .then(() => this.transitionToNextStep('PENDING_APPROVAL'));
   }
 
   /**


### PR DESCRIPTION
lets discuss...


The issue came up when trying to create an outbound with a location which has the supported activity for request approval.
The expected behaviour would be that on Edit step an outbound should have status `VERIFYING` but instead it was `WAITING FOR APPROVAL`.

The reason for that was that in both cases (Request and Outbound) we update status with `{ status: 'REQUESTED' }` which is mapped to `PENDING_APPROVAL` (change which was introduced in [here](https://github.com/openboxes/openboxes/pull/4288/files#diff-64dcf115d2530bcb242b9a4d135db1e44c97f2ca945b602816d3b78f33eedd58R115))

Was there a particular reason why we didn't separate VERIFYING and PEWNDING_APPROVAL as individual cases?