### PR TITLE
OBPIH-5814 Add NONE option to approvers filter

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/OutboundStockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/OutboundStockMovementService.groovy
@@ -42,7 +42,10 @@ class OutboundStockMovementService {
         List<ShipmentType> shipmentTypes = params.list("shipmentType") ? params.list("shipmentType").collect{ ShipmentType.read(it) } : null
         Boolean isApprovalRequired = stockMovement?.origin?.isApprovalRequired()
 
-
+        // OBPIH-5814
+        // This query returns a list of OutboundStockMovementListItem ids with applied filters
+        // which later will be hydrated by another OutboundStockMovementListItem.list()
+        // this is a workaround to prevent missing approvers data when filtering by approvers
         def stockMovementsIds = OutboundStockMovementListItem.createCriteria().list() {
             projections {
                 property "id"
@@ -154,7 +157,7 @@ class OutboundStockMovementService {
             }
         }
 
-        // Get result count
+        // Hydrate previously fetched OutboundStockMovementListItem ids, also paginate and sort the data
         def stockMovements = OutboundStockMovementListItem.createCriteria().list(max: max, offset: offset) {
             'in'("id", stockMovementsIds)
 

--- a/grails-app/services/org/pih/warehouse/inventory/OutboundStockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/OutboundStockMovementService.groovy
@@ -130,10 +130,17 @@ class OutboundStockMovementService {
                     }
                 }
             }
-            if (stockMovement.approvers) {
+            if (params.list("approver")) {
                 requisition {
-                    approvers {
-                        'in'("id", stockMovement.approvers.collect { it?.id })
+                    or {
+                        if (params.list("approver").contains("null")) {
+                            isEmpty("approvers")
+                        }
+                        if (stockMovement.approvers) {
+                            approvers {
+                                'in'("id", stockMovement.approvers.collect { it?.id })
+                            }
+                        }
                     }
                 }
             }

--- a/src/js/components/stock-movement/outbound/FilterFields.jsx
+++ b/src/js/components/stock-movement/outbound/FilterFields.jsx
@@ -106,6 +106,8 @@ export default {
       defaultPlaceholder: 'Approvers',
       showLabelTooltip: true,
       multi: true,
+      nullOption: true,
+      nullOptionDefaultLabel: 'None',
     },
     getDynamicAttr: ({
       approvers,

--- a/src/js/hooks/list-pages/outbound/useOutboundFilters.jsx
+++ b/src/js/hooks/list-pages/outbound/useOutboundFilters.jsx
@@ -9,7 +9,7 @@ import { fetchAvailableApprovers, fetchRequisitionStatusCodes, fetchShipmentType
 import filterFields from 'components/stock-movement/outbound/FilterFields';
 import useCommonFiltersCleaner from 'hooks/list-pages/useCommonFiltersCleaner';
 import { getParamList, transformFilterParams } from 'utils/list-utils';
-import { fetchLocationById, fetchUserById } from 'utils/option-utils';
+import { fetchLocationById, fetchUserById, selectNullOption } from 'utils/option-utils';
 
 const useOutboundFilters = (sourceType) => {
   const [filterParams, setFilterParams] = useState({});
@@ -119,6 +119,9 @@ const useOutboundFilters = (sourceType) => {
     if (queryProps.approver) {
       const approvers = getParamList(queryProps.approver);
       defaultValues.approver = availableApprovers.filter(({ id }) => approvers.includes(id));
+      if (approvers.includes(selectNullOption.id)) {
+        defaultValues.approver.push(selectNullOption);
+      }
     }
 
     setDefaultFilterValues(defaultValues);


### PR DESCRIPTION
Unfortunately, the approach with the subqueries that we discussed on the tech-huddle wasn't ideal, the issue that came up was with filtering by requests with **empty**  associations, so I decided to go with the simplest solution of querying the request ids and then querying the requests by the list of the these ids.

the approach with subqueries looks something like
```groovy
  if (params.list("approver")) {
      or {
          createAlias("requisition", "requisition")
          if (params.list("approver").contains("null")) {
              isEmpty("requisition.approvers")
          }
          if (stockMovement.approvers) {
              createAlias("requisition.approvers", "approver")
              add Subqueries.exists(
                      DetachedCriteria.forClass(Person.class)
                              .add(Restrictions.in("approver.id", stockMovement.approvers.id))
                              .setProjection(Projections.property("id"))
              )
          }
      }
  }
```
The issue I mentioned came up when trying to filter by **None** and some _other users_. It did not return any requests with empty approvers because `createAlias("requisition.approvers", "approver")` by default sets the association to INNER_JOIN.
When changing the jointype on **Approvers** to LEFT_JOIN, we face the same problem as in the beginning, of approver column missing the rest of the data (other than specified in filter approvers)

This issue started quite the discussion of the functionality/logic and UX of filtering by empty fields values, so I think we will have to come back to this discussing and come up with a final verdict.

For now I think we should follow the approach of how it is done on **Purchase orders** with **paymentTerms** filter. 