### PR TITLE
OBPIH-5884 Add missing inventoryItem data on getStockMovementItem

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -749,6 +749,11 @@ class StockMovementService {
             }
             requisitionItems.each { requisitionItem ->
                 StockMovementItem stockMovementItem = StockMovementItem.createFromRequisitionItem(requisitionItem)
+                InventoryItem inventoryItem = inventoryService.findInventoryItemByProductAndLotNumber(stockMovementItem.product, stockMovementItem.lotNumber)
+                if (inventoryItem) {
+                    inventoryItem.quantity = productAvailabilityService.getQuantityOnHand(inventoryItem)
+                    stockMovementItem.inventoryItem = inventoryItem
+                }
                 stockMovementItems.add(stockMovementItem)
             }
         } else {


### PR DESCRIPTION
When getting a list of stockMovementItems on inbound create page, inventoryItem variable was missing data which caused some validation issues.

I noticed that we are not assigning the inventoryItem on stockMovementItem for a case where SM is from requisition.
This is the logic how it;s done when SM is from shipment.
```groovy
 StockMovementItem stockMovementItem = StockMovementItem.createFromShipmentItem(shipmentItem)
                if (stockMovementItem.inventoryItem) {
                    def quantity = productAvailabilityService.getQuantityOnHand(stockMovementItem.inventoryItem)
                    stockMovementItem.inventoryItem.quantity = quantity
                }
                stockMovementItems.add(stockMovementItem)
```