### PR TITLE
OBS-1540 Set overflow-x to hidden by default on arrayField table

### DIFF
--- a/src/js/components/form-elements/FieldArrayComponent.jsx
+++ b/src/js/components/form-elements/FieldArrayComponent.jsx
@@ -151,7 +151,7 @@ class FieldArrayComponent extends Component {
         </div>
         <div
           className="text-center border mb-1 flex-grow-1 table-content"
-          style={{ overflowY: virtualized && isPaginated ? 'hidden' : overflowStyle, maxHeight: maxTableHeight }}
+          style={{ overflowX: 'hidden', overflowY: virtualized && isPaginated ? 'hidden' : overflowStyle, maxHeight: maxTableHeight }}
         >
           <TableBodyComponent
             fields={fields}


### PR DESCRIPTION
Since we are not taking advantage of the horizontal scroll on ArrayField tables it looks to be safe to set the `overflow-x` on the table content to `hidden` to prevent the glitching scrollbar from appearing on certain application widths.
The only overflow property that was set, was overflow-y which enabled scrolling on virtualized and paginated tables.