### PR TITLE
OBPIH-5870 Add required label to comment field in reject request modal

### DIFF
--- a/src/js/components/stock-movement/modals/RejectRequestModal.scss
+++ b/src/js/components/stock-movement/modals/RejectRequestModal.scss
@@ -90,5 +90,8 @@
 }
 
 .request-modal-textarea {
-  height: 150px;
+  .form-element-container {
+    height: 150px !important;
+    margin-bottom: 0;
+  }
 }

--- a/src/js/components/stock-movement/modals/RejectRequestModalContent.jsx
+++ b/src/js/components/stock-movement/modals/RejectRequestModalContent.jsx
@@ -97,7 +97,7 @@ const RejectRequestModalContent = ({
               }),
             )}
           </div>
-          <div className="btn-toolbar justify-content-between pt-3">
+          <div className="btn-toolbar justify-content-between">
             <Button
               type="button"
               onClick={closeRejectionModal}


### PR DESCRIPTION
The label was hidden under the comment field after adding `rows: 7`, so I had to resize the container to show the message.