### PR TITLE
OBPIH-5909 Fix list table pagination reset on filter change

### DIFF
--- a/src/js/hooks/list-pages/useTableData.jsx
+++ b/src/js/hooks/list-pages/useTableData.jsx
@@ -43,8 +43,14 @@ const useTableData = ({
     // Each time we fetch, we want to 'reset' the token/signal
     sourceRef.current = CancelToken.source();
     // reset pagination on each search execution
-    tableRef.current.onPageChange(0);
-    tableRef.current.fireFetchData();
+    if (tableRef.current?.state?.page > 0) {
+      // onPageChange(pageIndex) triggers fireFetchData() when pageIndex !== currenPage
+      // which is why we are calling onPageChange(0) and fireFetchData() separately
+      // by doing that we are trying to avoid double fetching
+      tableRef.current.onPageChange(0);
+    } else {
+      tableRef.current.fireFetchData();
+    }
   };
 
   // If filterParams change, refetch the data with applied filters


### PR DESCRIPTION
The solution which I implemented in my previous PR
```js
tableRef.current.onPageChange(0);
tableRef.current.fireFetchData();
```

introduced I bug which caused the table to double fetch the data when resetting the pagination to the first page.
The issue seems to be that, `onPageChange(0)` triggers the `fireFetchData()` which would result in two `fireFetchData()` API calls to race (one with offset 0 and another with previous offset value).

At first, I thought that replacing `tableRef.current.fireFetchData();` with  `tableRef.current.onPageChange(0);` would solve the problem, but `onPageChange(0)` does not trigger the fireFetch on the initial load, basically it does not trigger the fireFetchData when we are trying to changePage to the same value as the currentPage.

I hope the comment I left in the code explains clearly enough the reasoning for this approach.