### PR TITLE
OBGM-264 Fix additional columns for CSV in consumption report

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/reporting/ConsumptionController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/reporting/ConsumptionController.groovy
@@ -10,19 +10,12 @@
 package org.pih.warehouse.reporting
 
 import grails.converters.JSON
-import grails.core.GrailsApplication
 import grails.gorm.transactions.Transactional
-import grails.util.GrailsNameUtils
-import grails.util.Holders
 import grails.validation.Validateable
 import groovy.time.TimeCategory
 import org.apache.commons.codec.digest.DigestUtils
 import org.apache.commons.collections.FactoryUtils
 import org.apache.commons.collections.list.LazyList
-import org.apache.commons.lang.ClassUtils
-import org.grails.core.DefaultGrailsDomainClass
-import org.grails.datastore.mapping.model.PersistentEntity
-import org.grails.datastore.mapping.model.PersistentProperty
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.Tag

--- a/grails-app/controllers/org/pih/warehouse/reporting/ConsumptionController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/reporting/ConsumptionController.groovy
@@ -512,23 +512,6 @@ class ShowConsumptionCommand implements Validateable {
         parametersHash(nullable: true)
     }
 
-    static String getTypePropertyName(Class type) {
-        String shortTypeName = ClassUtils.getShortClassName(type)
-        return shortTypeName.substring(0, 1).toLowerCase(Locale.ENGLISH) + shortTypeName.substring(1)
-    }
-
-    static List<ConsumptionReportProductProperty> getAvailableProperties() {
-        List<PersistentProperty> properties =
-            Holders.grailsApplication.mappingContext.getPersistentEntity(Product.class.name).persistentProperties
-        return properties.collect { PersistentProperty it ->
-            new ConsumptionReportProductProperty([
-                name: it.name,
-                naturalName: GrailsNameUtils.getNaturalName(it.name),
-                typePropertyName: getTypePropertyName(it.type)
-            ])
-        }
-    }
-
     Boolean hasParameterChanged() {
         String newParametersHash = generateParametersHash()
         return !parametersHash.equals(newParametersHash)

--- a/grails-app/controllers/org/pih/warehouse/reporting/ConsumptionController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/reporting/ConsumptionController.groovy
@@ -531,12 +531,6 @@ class ShowConsumptionCommand implements Validateable {
     }
 }
 
-class ConsumptionReportProductProperty {
-    String name
-    String naturalName
-    String typePropertyName
-}
-
 class ShowConsumptionRowCommand implements Validateable {
 
     Product product

--- a/grails-app/utils/org/pih/warehouse/CommandUtils.groovy
+++ b/grails-app/utils/org/pih/warehouse/CommandUtils.groovy
@@ -1,0 +1,24 @@
+package org.pih.warehouse
+
+import grails.util.GrailsNameUtils
+import grails.util.Holders
+import org.apache.commons.lang.ClassUtils
+
+class CommandUtils {
+    static String getTypePropertyName(Class type) {
+        String shortTypeName = ClassUtils.getShortClassName(type)
+        return shortTypeName.substring(0, 1).toLowerCase(Locale.ENGLISH) + shortTypeName.substring(1)
+    }
+
+    static List<Map> getAvailableProperties(String entityName) {
+        Map properties =
+                Holders.grailsApplication.mappingContext.getPersistentEntity(entityName)?.propertiesByName
+        return properties.collect { name, property  ->
+           [
+                name: name,
+                naturalName: GrailsNameUtils.getNaturalName(name),
+                typePropertyName: getTypePropertyName(property?.type)
+            ]
+        }
+    }
+}

--- a/grails-app/views/consumption/_filters.gsp
+++ b/grails-app/views/consumption/_filters.gsp
@@ -131,12 +131,12 @@
                         <g:hasRoleFinance>
                             <g:set var="hasRoleFinance" value="${true}"/>
                         </g:hasRoleFinance>
-                        <g:each var="propertyName" in="${command.availableProperties}">
-                            <g:set var="disabled" value="${'pricePerUnit'.equals(propertyName) && !hasRoleFinance}"/>
-                            <option value="${propertyName}"
-                                ${command.selectedProperties?.toList()?.contains(propertyName)?'selected':''}
+                        <g:each var="property" in="${command.availableProperties}">
+                            <g:set var="disabled" value="${'pricePerUnit'.equals(property.name) && !hasRoleFinance}"/>
+                            <option value="${property.name}"
+                                ${command.selectedProperties?.toList()?.contains(property.name)?'selected':''}
                                 ${disabled?'disabled':''}>
-                                ${propertyName}
+                                ${property.naturalName} (${property.typePropertyName})
                             </option>
                         </g:each>
                     </select>

--- a/grails-app/views/consumption/_filters.gsp
+++ b/grails-app/views/consumption/_filters.gsp
@@ -1,4 +1,6 @@
-<%@ page import="org.pih.warehouse.product.Product; org.pih.warehouse.core.Constants" %>
+<%@ page import="org.pih.warehouse.CommandUtils" %>
+<%@ page import="org.pih.warehouse.product.Product" %>
+<%@ page import="org.pih.warehouse.core.Constants" %>
 <style>
 .chosen-container-multi .chosen-choices li.search-field input[type="text"] {
     height: 26px;
@@ -131,7 +133,7 @@
                         <g:hasRoleFinance>
                             <g:set var="hasRoleFinance" value="${true}"/>
                         </g:hasRoleFinance>
-                        <g:each var="property" in="${command.availableProperties}">
+                        <g:each var="property" in="${CommandUtils.getAvailableProperties(Product.class.name)}">
                             <g:set var="disabled" value="${'pricePerUnit'.equals(property.name) && !hasRoleFinance}"/>
                             <option value="${property.name}"
                                 ${command.selectedProperties?.toList()?.contains(property.name)?'selected':''}


### PR DESCRIPTION
### Issues:

1. `selectedProperties` not being binded in `ShowConsumptionCommand` command in `show` method
2. getting rid of deprecated in Grails 3: `new DefaultGrailsDomainClass(Product.class)` and replacing it with `Holders.grailsApplication.mappingContext.getPersistentEntity(Product.class.name).persistentPropertyNames`

### Solutions:

1. using TYPE instead of `def`, because `def` is not binded for command since Grails 2: [Properties which are not bindable by default are those related to transient fields, dynamically typed properties and static properties.](https://grails.github.io/grails2-doc/2.5.6/ref/Constraints/bindable.html)
2. The problem was that 1. we were using persistentProperty**Names**, not persistent**Properties**, but even with that, we didn't have access to fields such as `typePropertyName` and `naturalName` which we had in Grails 1.
  In order to achieve the same behavior, I've just created static methods which implement the same behavior from Grails 1, by just checking with "CTRL" what is the implementation of `typePropertyName` and `naturalName` in Grails 1:

![Screenshot from 2023-10-24 12-22-13](https://github.com/openboxes/openboxes/assets/93163821/578a99af-811d-4a65-ad3a-309924575ec8)
![Screenshot from 2023-10-24 12-23-02](https://github.com/openboxes/openboxes/assets/93163821/9b61eab3-3c2c-44f8-b1ff-c447ba5837d1)


### General conclusions:
Do not use `def` when it is not needed. It drove me nuts to find why the `selectedProperties` was not binded for `show` method. 
I would never assume that because of the type, it won't work. 
We have typed language, and we should in my opinion use `def` only when it is necessary (when a type of variable can change, e.g. stockMovement stuff - either it can be `OutboundStockMovement` or `StockMovement`, not to cause such unexpected behaviors like this one.
