### PR TITLE
OBGM-711 Empty active field read as inactive in product sources import

### DIFF
--- a/grails-app/domain/org/pih/warehouse/product/ProductSupplier.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/ProductSupplier.groovy
@@ -65,7 +65,7 @@ class ProductSupplier implements Serializable, Comparable<ProductSupplier> {
     Date dateCreated
     Date lastUpdated
 
-    @BindUsing({ obj, source -> source["active"] != null ? source["active"] : true })
+    @BindUsing({ productSupplier, source -> source["active"] != null ? source["active"] : true })
     Boolean active = Boolean.TRUE
 
     static transients = ["defaultProductPackage", "globalProductSupplierPreference", "attributes"]

--- a/grails-app/domain/org/pih/warehouse/product/ProductSupplier.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/ProductSupplier.groovy
@@ -9,6 +9,7 @@
  **/
 package org.pih.warehouse.product
 
+import grails.databinding.BindUsing
 import org.pih.warehouse.core.Organization
 import org.pih.warehouse.core.ProductPrice
 import org.pih.warehouse.core.RatingTypeCode
@@ -64,6 +65,7 @@ class ProductSupplier implements Serializable, Comparable<ProductSupplier> {
     Date dateCreated
     Date lastUpdated
 
+    @BindUsing({ obj, source -> source["active"] != null ? source["active"] : true })
     Boolean active = Boolean.TRUE
 
     static transients = ["defaultProductPackage", "globalProductSupplierPreference", "attributes"]

--- a/src/main/groovy/org/pih/warehouse/importer/ProductSupplierExcelImporter.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/ProductSupplierExcelImporter.groovy
@@ -48,7 +48,7 @@ class ProductSupplierExcelImporter extends AbstractExcelImporter {
     ]
 
     static Map propertyMap = [
-            active                                : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
+            active                                : ([expectedType: ExpectedPropertyType.StringType, defaultValue: true]),
             id                                    : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
             code                                  : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
             name                                  : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),

--- a/src/main/groovy/org/pih/warehouse/importer/ProductSupplierExcelImporter.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/ProductSupplierExcelImporter.groovy
@@ -48,7 +48,7 @@ class ProductSupplierExcelImporter extends AbstractExcelImporter {
     ]
 
     static Map propertyMap = [
-            active                                : ([expectedType: ExpectedPropertyType.StringType, defaultValue: true]),
+            active                                : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
             id                                    : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
             code                                  : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),
             name                                  : ([expectedType: ExpectedPropertyType.StringType, defaultValue: null]),


### PR DESCRIPTION
The default value for this property was set in the domain:
![image](https://github.com/openboxes/openboxes/assets/83239466/82a30618-5d1d-4853-a129-d0b46d093324)


In Grails 1 when we don't provide value for the active column, we don't have this property in the `params` object, so in this line:
`productSupplier = new ProductSupplier(params)`
we used the default value from the domain.

In Grails 3 when we don't provide the value, we have `active: null` in the params object, so the `true` value from the domain is overridden by the null value and this is treated as a false.

Besides the solution that I pushed, I am thinking also about:
- Just write:
```
productSupplier.active = params["active"] ? params["active"] : true
```
but I think the current solution is much cleaner.
- Use the `@BindUsing` annotation and check if we provide the value inside it.
```
    @BindUsing({ obj, source -> source['active] ? source['active'] : true })
    Boolean active = Boolean.TRUE
```
Let me know what you think about those approaches.