### PR TITLE
OBPIH-5884 Fix duplicating items and expiry date not saving on expirydate validation

### DIFF
--- a/src/js/components/stock-movement-wizard/inbound/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/inbound/AddItemsPage.jsx
@@ -276,6 +276,9 @@ class AddItemsPage extends Component {
         lineItemsToBeUpdated.push(item);
       } else if (newQty !== oldQty || newRecipient !== oldRecipient) {
         lineItemsToBeUpdated.push(item);
+      } else if (item.inventoryItem?.expirationDate && item.expirationDate &&
+        item.inventoryItem?.expirationDate !== item.expirationDate) {
+        lineItemsToBeUpdated.push(item);
       }
     });
 
@@ -597,7 +600,7 @@ class AddItemsPage extends Component {
   saveAndTransitionToNextStep(formValues, lineItems) {
     this.props.showSpinner();
 
-    this.saveRequisitionItems(lineItems)
+    this.saveRequisitionItemsInCurrentStep(lineItems)
       .then((resp) => {
         let values = formValues;
         if (resp) {
@@ -642,27 +645,6 @@ class AddItemsPage extends Component {
   }
 
   /**
-   * Saves list of stock movement items with post method.
-   * @param {object} lineItems
-   * @public
-   */
-  saveRequisitionItems(lineItems) {
-    const itemsToSave = this.getLineItemsToBeSaved(lineItems);
-    const updateItemsUrl = `/openboxes/api/stockMovements/${this.state.values.stockMovementId}/updateItems`;
-    const payload = {
-      id: this.state.values.stockMovementId,
-      lineItems: itemsToSave,
-    };
-
-    if (payload.lineItems.length) {
-      return apiClient.post(updateItemsUrl, payload)
-        .catch(() => Promise.reject(new Error('react.stockMovement.error.saveRequisitionItems.label')));
-    }
-
-    return Promise.resolve();
-  }
-
-  /**
    * Saves list of requisition items in current step (without step change). Used to export template.
    * @param {object} itemCandidatesToSave
    * @public
@@ -691,6 +673,7 @@ class AddItemsPage extends Component {
             currentLineItems: lineItemsBackendData,
             values: { ...this.state.values, lineItems: lineItemsBackendData },
           });
+          return resp;
         })
         .catch(() => Promise.reject(new Error(this.props.translate('react.stockMovement.error.saveRequisitionItems.label', 'Could not save requisition items'))));
     }


### PR DESCRIPTION
- use saveRequisitionItemsInCurrentStep instead of saveRequisitionItems when clicking next button which updates lineItems with data from response
- add additional condition for lineItemsToBeUpdated when expiryDate on item and inventoryItem do not match


I decided to remove `saveRequisitionItems` method since the only place where it was used was in `saveAndTransitionToNextStep` which I updated to use `saveRequisitionItemsInCurrentStep` instead.

`saveRequisitionItemsInCurrentStep` and `saveRequisitionItems` are nearly identical, the difference is that `saveRequisitionItemsInCurrentStep` update the lineItems state with the response that it gets form the API