### PR TITLE
OBPIH-5865 Apostrophe in product search gives error

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/api/ProductApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/ProductApiController.groovy
@@ -118,7 +118,7 @@ class ProductApiController extends BaseDomainApiController {
             return
         }
 
-        String[] terms = params?.name?.split(",| ")?.findAll { it }
+        String[] terms = params?.name?.replaceAll("'", "\\\\'")?.split(",| ")?.findAll { it }
         def products, availableItems = []
         if(params.availableItems) {
             Location location = Location.get(session.warehouse.id)


### PR DESCRIPTION
According to the MySQL documentation: https://dev.mysql.com/doc/refman/8.0/en/string-literals.html#character-escape-sequences

I added a `replaceAll` for all passed single quotes to execute within an SQL query. There is a table with special characters escape sequences:
![image](https://github.com/openboxes/openboxes/assets/83239466/11b2628c-cd40-47fa-94af-c1b64946c901)
