### PR TITLE
OBGM-716 Unable to place PO

### DIFF
--- a/grails-app/services/org/pih/warehouse/order/OrderService.groovy
+++ b/grails-app/services/org/pih/warehouse/order/OrderService.groovy
@@ -457,7 +457,6 @@ class OrderService {
     boolean canApproveOrder(Order order, User userInstance) {
         if (isApprovalRequired(order)) {
             List<RoleType> defaultRoleTypes = grailsApplication.config.openboxes.purchasing.approval.defaultRoleTypes
-                    .collect { RoleType.valueOf(it) }
             return userService.hasAnyRoles(userInstance, defaultRoleTypes)
         }
         return Boolean.TRUE


### PR DESCRIPTION
It was once fixed by @alannadolny : https://github.com/openboxes/openboxes/pull/4129
The problem is that then, we had the `defaultRoleTypes` specified in `application.yml` and there, those were strings + `application.yml` is "overwriting" the `runtime.groovy`, hence the bug appeared after doing a cleanup here: https://github.com/openboxes/openboxes/pull/4357/files#diff-2345571d250535e4fc0497dd6c69264ff94e35858391237390112d005c9d1a36 where the `defaultRoleTypes` had been removed from the `application.yml` and it started taking the `runtime.groovy` into account.
To fix the issue I just reverted Alan's change from #4129, because in `runtime.groovy` we don't use strings, but enum classes.