### PR TITLE
OBGM-726 Fix gsp list table styles

### DIFF
--- a/grails-app/views/mobile/outboundList.gsp
+++ b/grails-app/views/mobile/outboundList.gsp
@@ -49,7 +49,7 @@
             </g:each>
             </tbody>
         </table>
-        <div class="pagination">
+        <div class="paginateButtons">
             <g:paginate total="${stockMovements.totalCount}"/>
         </div>
     </div>

--- a/grails-app/views/mobile/productList.gsp
+++ b/grails-app/views/mobile/productList.gsp
@@ -52,7 +52,7 @@
             </g:each>
 
         </table>
-        <div class="pagination">
+        <div class="paginateButtons">
             <g:paginate total="${productSummaries.totalCount}"/>
         </div>
     </div>

--- a/grails-app/views/productComponent/index.gsp
+++ b/grails-app/views/productComponent/index.gsp
@@ -19,14 +19,14 @@
             </g:link>
         </div>
         <div id="list-productComponent" class="box content scaffold-create" role="main">
-            <h1><warehouse:message code="default.list.label" args="[entityName]" /></h1>
+            <h2><warehouse:message code="default.list.label" args="[entityName]" /></h2>
             <g:if test="${flash.message}">
                 <div class="message" role="status">${flash.message}</div>
             </g:if>
             <f:table collection="${productComponentList}" properties="['id', 'assemblyProduct', 'componentProduct', 'quantity', 'unitOfMeasure']"/>
             <g:set var="totalCount" value="${productComponentCount ?: 0}"/>
             <g:if test="${totalCount > params.max}">
-                <div class="pagination">
+                <div class="paginateButtons">
                     <g:paginate total="${productComponentCount ?: 0}" />
                 </div>
             </g:if>

--- a/grails-app/views/role/index.gsp
+++ b/grails-app/views/role/index.gsp
@@ -19,14 +19,14 @@
             </g:link>
         </div>
         <div id="list-role" class="box content scaffold-create" role="main">
-            <h1><warehouse:message code="default.list.label" args="[entityName]" /></h1>
+            <h2><warehouse:message code="default.list.label" args="[entityName]" /></h2>
             <g:if test="${flash.message}">
                 <div class="message" role="status">${flash.message}</div>
             </g:if>
             <f:table collection="${roleList}" properties="['id','name','roleType','description']" />
             <g:set var="totalCount" value="${roleCount ?: 0}"/>
             <g:if test="${totalCount > params.max}">
-                <div class="pagination">
+                <div class="paginateButtons">
                     <g:paginate total="${roleCount ?: 0}" />
                 </div>
             </g:if>

--- a/src/main/templates/scaffolding/index.gsp
+++ b/src/main/templates/scaffolding/index.gsp
@@ -19,14 +19,14 @@
             </g:link>
         </div>
         <div id="list-${propertyName}" class="box content scaffold-create" role="main">
-            <h1><warehouse:message code="default.list.label" args="[entityName]" /></h1>
+            <h2><warehouse:message code="default.list.label" args="[entityName]" /></h2>
             <g:if test="\${flash.message}">
                 <div class="message" role="status">\${flash.message}</div>
             </g:if>
             <f:table collection="\${${propertyName}List}" />
             <g:set var="totalCount" value="\${${propertyName}Count ?: 0}"/>
             <g:if test="\${totalCount > params.max}">
-                <div class="pagination">
+                <div class="paginateButtons">
                     <g:paginate total="\${${propertyName}Count ?: 0}" />
                 </div>
             </g:if>


### PR DESCRIPTION
Looking at commits I wasn't able to find any trail to when the eg. `class="pagination'` was changed to `class="paginateButtons"`.
Both develop and feature branch don't have any common commits, probably was a result of moving the files around the project.
The correct class for list pages are **paginateButtons** and **h2** instead of **h1** for the heading