### PR TITLE
OBPIH-5972 trim white space from firstname and last name when binding user to recipient on PO items import

### DIFF
--- a/grails-app/services/org/pih/warehouse/data/PersonDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/PersonDataService.groovy
@@ -71,7 +71,7 @@ class PersonDataService {
     }
 
     String[] extractNames(String combinedNames) {
-        String[] names = combinedNames.split(" ", 2)
+        String[] names = combinedNames.split(" ", 2)*.trim()
         if (names.length <= 1) {
             throw new RuntimeException("Recipient ${combinedNames} must have at least two names (i.e. first name and last name)")
         }


### PR DESCRIPTION
The issue is that somehow in the database there was a user which had an extra space in it's **firstname** column value like
```
firstname: "name ",
lastname: "lastname"
```
I don't know how that extra space appeared there, because I tested creating _Person/User_ in the UI and via import and in both cases it clears the extra white space, the only way I was able to reproduce it is updating the value directly in the database.

When exporting the PO items excel it exports the users value with that extra space "name  lastname"  _(there are two spaces in between)_ and trying to re-import the same file causes the system to not find the set user because when we do `split(" ")` it splits by the first space and now we are looking for users with a combo firstname and last name 
`[ firstname: "name", lastname: " lastname" ]`

adding `*.trim()` does solve the problem in a way, but I am not sure if it is necessary because the simplest solution would be to just  fix the data and I am not sure if we want to dive that deep into parsing/transforming potentially incorrect data.

I pushed this PR as an example and to give you guys a better context to what is happening, but if you think that we should not go this direction and just fix the data then we can close this PR.