### PR TITLE
OBPIH-5984 Fix lazyInitialization issue when building approval emails

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/RequisitionStatusTransitionEventService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/RequisitionStatusTransitionEventService.groovy
@@ -10,6 +10,7 @@
 package org.pih.warehouse.inventory
 
 import org.pih.warehouse.report.NotificationService
+import org.pih.warehouse.requisition.Requisition
 import org.pih.warehouse.requisition.RequisitionStatusTransitionEvent
 import org.springframework.context.ApplicationListener
 
@@ -18,8 +19,9 @@ class RequisitionStatusTransitionEventService implements ApplicationListener<Req
     NotificationService notificationService
 
     void onApplicationEvent(RequisitionStatusTransitionEvent event) {
-        if (event.requisition.shouldSendApprovalNotification()) {
-            notificationService.publishRequisitionStatusTransitionNotifications(event.requisition)
+        Requisition requisition = Requisition.get(event.requisition.id)
+        if (requisition.shouldSendApprovalNotification()) {
+            notificationService.publishRequisitionStatusTransitionNotifications(requisition)
         }
     }
 }

--- a/grails-app/services/org/pih/warehouse/inventory/RequisitionStatusTransitionEventService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/RequisitionStatusTransitionEventService.groovy
@@ -19,6 +19,9 @@ class RequisitionStatusTransitionEventService implements ApplicationListener<Req
     NotificationService notificationService
 
     void onApplicationEvent(RequisitionStatusTransitionEvent event) {
+        // Fetch the Requisition again to avoid LazyInitializationException when building the email template
+        // In some of the templates we access some deeply nested values like event comments and statuses
+        // TODO in grails 3 create a @service method which would fetch all of the necessary data without the need to refetch Requisition
         Requisition requisition = Requisition.get(event.requisition.id)
         if (requisition.shouldSendApprovalNotification()) {
             notificationService.publishRequisitionStatusTransitionNotifications(requisition)


### PR DESCRIPTION
In the end, the issue was with `LazyInitializationException` which occurred when building the approver emails.
The interesting part was that it didn't occur every time and at first, I had trouble reproducing this bug locally.

To be more specific there is a case where we access some values like `requisitions.events` inside of the GSP templates and extract status and comment from it, and that's the place where the lazyInitializationException is being thrown.
To fix this issue I decided to just fetch the Requisition again in the event handler instead of relying on the requisition passed in the `RequisitionStatusTransitionEvent`.

Wrapping the method with `Requisition.withSession` didn't help btw.
```
Requisition.withSession {
        if (requisition.shouldSendApprovalNotification()) {
            notificationService.publishRequisitionStatusTransitionNotifications(requisition)
        }
}
```
