### PR TITLE
OBGM-503 Bring back changes to bootstrap.groovy that were reverted during reabse

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -56,7 +56,7 @@ spring:
 quartz:
     pluginEnabled: true
     jdbcStore: false
-    autoStartup: true
+    autoStartup: false
     monitor:
         layout: custom
         showTriggerNames: true


### PR DESCRIPTION
Brought back changes lost in the rebase for the migration from https://github.com/openboxes/openboxes/commit/274c38b8f0d2d66db9222a18b27f2dbde8cea0cc

The changes aren't too big since it mostly involved moving some code in appropriate methods and calling them on init.

Besides some differences with new code that we had implemented in the mean time, in the old commit I noticed
```
log.info("Starting Quartz scheduler ...")
Scheduler scheduler = grailsApplication.mainContext.getBean("quartzScheduler")
scheduler.start()
```
I have omitted this chunk of code since we have configured `autoStartup: true` in the `application.yml` and from what I gathered it means that we don't have to call start on quartzScheduler manually since it will be started for us on startup.