### PR TITLE
OBPIH-5984 Fix issue causing approval email for status update to ISSUED to not be sent to the requestor

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -255,7 +255,7 @@ class StockMovementService {
 
         log.info "Update status ${id} " + status
         // TODO: In Grails the get below should be replaced by the data service get that joins the Events
-        Requisition requisition = Requisition.get(id)
+        Requisition requisition = requisitionService.getRequisitionWithEvents(id)
         if (status == RequisitionStatus.CHECKING) {
             Shipment shipment = requisition.shipment
             shipment?.expectedShippingDate = new Date()

--- a/grails-app/services/org/pih/warehouse/report/NotificationService.groovy
+++ b/grails-app/services/org/pih/warehouse/report/NotificationService.groovy
@@ -16,7 +16,6 @@ import org.codehaus.groovy.grails.plugins.web.taglib.ApplicationTagLib
 import org.codehaus.groovy.grails.plugins.web.taglib.RenderTagLib
 import org.codehaus.groovy.grails.web.context.ServletContextHolder
 import org.codehaus.groovy.grails.web.errors.GrailsWrappedRuntimeException
-import org.hibernate.Hibernate
 import org.pih.warehouse.api.PartialReceipt
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.MailService
@@ -270,11 +269,6 @@ class NotificationService {
         if (!recipient.email) {
             return
         }
-        // Due to the fact that we get LazyInitializationException thrown when building this mail
-        // Specifically when accessing mostRecentEvent value, we want to hydrate this value
-        // so we have access to it outside outside of the session
-        // TODO in grails 3 create a @service method which would fetch all of the necessary data without the need to refetch Requisition
-        Hibernate.initialize(requisition.mostRecentEvent)
         String subject = "${requisition.requestNumber} ${requisition.name}"
         String template = "/email/approvalsStatusChanged"
         String body = renderTemplate(template, [requisition: requisition])

--- a/grails-app/services/org/pih/warehouse/requisition/RequisitionService.groovy
+++ b/grails-app/services/org/pih/warehouse/requisition/RequisitionService.groovy
@@ -11,6 +11,7 @@ package org.pih.warehouse.requisition
 
 import grails.validation.ValidationException
 import javassist.NotFoundException
+import org.hibernate.criterion.CriteriaSpecification
 import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.Comment
@@ -835,6 +836,14 @@ class RequisitionService {
         if (comment) {
             event.comment = comment
             requisition.addToComments(comment)
+        }
+    }
+
+    // TODO in Grails 3 move this method to @Service RequisitionDataService
+    Requisition getRequisitionWithEvents(String id) {
+        return Requisition.createCriteria().get {
+            createAlias('events', 'events', CriteriaSpecification.LEFT_JOIN)
+            eq("id", id)
         }
     }
 


### PR DESCRIPTION
After our discussion on the tech huddle, I decided to pursue the solution of manually committing the transaction, flushing it to the database and fetching a fresh `Requisition` with updated status in the async event that we are publishing for sending notifications.