### PR TITLE
OBGM-752 Supported activities of location type are not assigned by default when create location on grails pages 

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/core/LocationController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/core/LocationController.groovy
@@ -123,7 +123,7 @@ class LocationController {
                     flash.message =
                         g.message(code: 'default.updated.message', args: [warehouse.message(code: 'location.label', default: 'Location'), locationInstance.id])
 
-                    if (locationInstance.supportedActivities.contains(ActivityCode.APPROVE_REQUEST.id)) {
+                    if (locationInstance.supportedActivities?.contains(ActivityCode.APPROVE_REQUEST.id)) {
                         flash.warning = g.message(code: 'location.supportedActivities.noRequestApprovers', args: [g.createLink(controller: "user", action: "list")])
                     }
 


### PR DESCRIPTION
When creating a new location the `locationInstance.supportedActivities` is null.