### PR TITLE
Revert "OBPIH-5972 trim white space from firstname and last name when binding user to recipient on PO items import"

### DIFF
--- a/grails-app/services/org/pih/warehouse/data/PersonService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/PersonService.groovy
@@ -38,7 +38,7 @@ class PersonService {
     }
 
     String[] extractNames(String combinedNames) {
-        String[] names = combinedNames.split(" ", 2)*.trim()
+        String[] names = combinedNames.split(" ", 2)
         if (names.length <= 1) {
             throw new RuntimeException("Recipient ${combinedNames} must have at least two names (i.e. first name and last name)")
         }


### PR DESCRIPTION
Reverts openboxes/openboxes#4384