### PR TITLE
OBGM-753 Empty string validation on name and code of organization

### DIFF
--- a/grails-app/domain/org/pih/warehouse/core/Organization.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Organization.groovy
@@ -37,10 +37,10 @@ class Organization extends Party {
     }
 
     static constraints = {
-        code(nullable: false, unique: true,
+        code(nullable: false, blank: false, unique: true,
                 minSize: Holders.grailsApplication.config.openboxes.identifier.organization.minSize,
                 maxSize: Holders.grailsApplication.config.openboxes.identifier.organization.maxSize)
-        name(nullable: false, maxSize: 255)
+        name(nullable: false, blank: false, maxSize: 255)
         description(nullable: true, maxSize: 255)
         defaultLocation(nullable: true)
         active(nullable: false)

--- a/grails-app/services/org/pih/warehouse/core/OrganizationService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/OrganizationService.groovy
@@ -10,7 +10,7 @@
 package org.pih.warehouse.core
 
 import grails.gorm.transactions.Transactional
-import grails.validation.ValidationException
+import org.apache.commons.lang.StringUtils
 
 @Transactional
 class OrganizationService {
@@ -44,19 +44,25 @@ class OrganizationService {
         return findOrCreateOrganization(name, code, [])
     }
 
-    Organization findOrCreateOrganization(String name, String code, List<RoleType> roleTypes) {
-        Organization organization = org.pih.warehouse.core.Organization.find {
-            or {
-                and {
-                    eq("code", code)
-                    ne("code", "")
-                }
-                and {
-                    eq("name", name)
-                    ne("name", "")
-                }
-            }
+    Organization findOrganization(String name, String code) {
+        Organization organization = Organization.createCriteria().get {
+            eq("code", code)
+            ne("code", StringUtils.EMPTY)
+            isNotNull("code")
         }
+        if (!organization) {
+            organization = Organization.createCriteria().list(max: 1) {
+                eq("name", name)
+                ne("name", StringUtils.EMPTY)
+                isNotNull("name")
+                order("dateCreated", "asc")
+            }[0]
+        }
+        return organization
+    }
+
+    Organization findOrCreateOrganization(String name, String code, List<RoleType> roleTypes) {
+        Organization organization = findOrganization(name, code)
         if (!organization) {
             organization = new Organization()
             organization.name = name

--- a/grails-app/services/org/pih/warehouse/core/OrganizationService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/OrganizationService.groovy
@@ -45,7 +45,18 @@ class OrganizationService {
     }
 
     Organization findOrCreateOrganization(String name, String code, List<RoleType> roleTypes) {
-        Organization organization = Organization.findByCodeOrName(code, name)
+        Organization organization = org.pih.warehouse.core.Organization.find {
+            or {
+                and {
+                    eq("code", code)
+                    ne("code", "")
+                }
+                and {
+                    eq("name", name)
+                    ne("name", "")
+                }
+            }
+        }
         if (!organization) {
             organization = new Organization()
             organization.name = name


### PR DESCRIPTION
- added blank GORM validators to prevent from inserting empty string values
- added a consdition to search for exsiting organization by code and name which are not empty strings