### PR TITLE
OBPIH-6033 Add endpoint to fetch preference type options

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/UrlMappings.groovy
+++ b/grails-app/controllers/org/pih/warehouse/UrlMappings.groovy
@@ -89,6 +89,11 @@ class UrlMappings {
             action = [GET: "usersOptions"]
         }
 
+        "/api/preferenceTypeOptions" {
+            controller = { "selectOptionsApi" }
+            action = [GET: "preferenceTypeOptions"]
+        }
+
         "/api/products"(parseRequest: true) {
             controller = { "productApi" }
             action = [GET: "list"]

--- a/grails-app/controllers/org/pih/warehouse/api/SelectOptionsApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/SelectOptionsApiController.groovy
@@ -12,6 +12,7 @@ package org.pih.warehouse.api
 import grails.converters.JSON
 import org.pih.warehouse.core.GlAccount
 import org.pih.warehouse.core.PaymentTerm
+import org.pih.warehouse.core.PreferenceType
 import org.pih.warehouse.core.Tag
 import org.pih.warehouse.core.User
 import org.pih.warehouse.core.UserService
@@ -77,4 +78,13 @@ class SelectOptionsApiController {
         render([data: users] as JSON)
     }
 
+    def preferenceTypeOptions() {
+        List<Map<String, String>> preferenceTypes = genericApiService.getList(PreferenceType.class.simpleName, [:]).collect {
+            [
+                id: it.id,
+                label: it.name
+            ]
+        }
+        render([data: preferenceTypes] as JSON)
+    }
 }


### PR DESCRIPTION
Before @jmiranda resolves his spike related to the select options api convention, I used generic api `getList` even though we don't like it, just to avoid throwing my own convention with a service method, before you are back and because it is enough for now, to be able to proceed with the further work.