### PR TITLE
OBPIH-6021 Add an API endpoint to delete a product supplier + remove unnecessary url mapping 

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/UrlMappings.groovy
+++ b/grails-app/controllers/org/pih/warehouse/UrlMappings.groovy
@@ -113,11 +113,6 @@ class UrlMappings {
             action = [GET: "getInventoryItem"]
         }
 
-        "/api/productSupplier" {
-            controller = { "productSupplierApi" }
-            action = [GET: "list"]
-        }
-
         "/api/locations/locationTypes" {
             controller = { "locationApi" }
             action = [GET: "locationTypes"]

--- a/grails-app/controllers/org/pih/warehouse/api/ProductSupplierApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/ProductSupplierApiController.groovy
@@ -13,4 +13,9 @@ class ProductSupplierApiController {
         List<ProductSupplierListDto> productSuppliers = productSupplierService.getProductSuppliers(filterParams)
         render([data: productSuppliers, totalCount: productSuppliers.totalCount] as JSON)
     }
+
+    def delete() {
+        productSupplierService.delete(params.id)
+        render status: 204
+    }
 }

--- a/grails-app/services/org/pih/warehouse/data/ProductSupplierService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSupplierService.groovy
@@ -25,6 +25,7 @@ import org.pih.warehouse.core.UnitOfMeasure
 import org.pih.warehouse.product.Product
 import org.pih.warehouse.product.ProductPackage
 import org.pih.warehouse.product.ProductSupplier
+import org.pih.warehouse.product.ProductSupplierDataService
 import org.pih.warehouse.product.ProductSupplierListDto
 import org.pih.warehouse.product.ProductSupplierListParams
 import org.pih.warehouse.product.ProductSupplierPreference
@@ -40,6 +41,7 @@ class ProductSupplierService {
 
     def identifierService
     def dataSource
+    ProductSupplierDataService productSupplierGormService
 
 
     List<ProductSupplierListDto> getProductSuppliers(ProductSupplierListParams params) {
@@ -331,5 +333,9 @@ class ProductSupplierService {
             productSupplier.save(failOnError: true)
         }
         return productSupplier
+    }
+
+    void delete(String productSupplierId) {
+        productSupplierGormService.delete(productSupplierId)
     }
 }

--- a/src/js/api/urls.js
+++ b/src/js/api/urls.js
@@ -100,4 +100,4 @@ export const DISABLE_LOCALIZATION = (languageCode) => {
 export const GLOBAL_SEARCH = term => `${CONTEXT_PATH}/dashboard/globalSearch?searchTerms=${term}`;
 
 // PRODUCT SUPPLIER
-export const PRODUCT_SUPPLIER_API = `${API}/productSupplier`;
+export const PRODUCT_SUPPLIER_API = `${API}/productSuppliers`;


### PR DESCRIPTION
It seems not to be necessary to add a url mapping for this (and it was not necessary to add it for the list method), as it's handled fine by the generic mappings:
```groovy
"/api/${resource}s"(parseRequest: true) {
    controller = { "${params.resource}Api" }
    action = [GET: "list", POST: "create"]
}

"/api/${resource}s/$id/status"(parseRequest: true) {
    controller = { "${params.resource}Api" }
    action = [GET: "status", DELETE: "deleteStatus", POST: "updateStatus"]
}

"/api/${resource}s/$id"(parseRequest: true) {
    controller = { "${params.resource}Api" }
    action = [GET: "read", POST: "update", PUT: "update", DELETE: "delete"]
}
```
By doing so, I've also applied @jmiranda 's suggestion from [here](https://github.com/openboxes/openboxes/pull/4435#discussion_r1437925142) to change the url to be in plural form (productSuppliers, not productSupplier).