### PR TITLE
OBPIH-6080 Fix displaying a toast message while connection is restored

### DIFF
--- a/src/js/utils/apiClient.jsx
+++ b/src/js/utils/apiClient.jsx
@@ -98,7 +98,7 @@ export const handleError = (error) => {
       break;
     default:
       notification(NotificationType.ERROR_FILLED)({
-        message: error,
+        message: error?.message,
         details: errorMessage || errorMessages,
       });
   }


### PR DESCRIPTION
You can find an explanation of the problem in the ticket.