### PR TITLE
OBPIH-6014 Fix async select dropdown to be wider for longer labels

### DIFF
--- a/src/js/components/form-elements/FilterSelectField.jsx
+++ b/src/js/components/form-elements/FilterSelectField.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import _ from 'lodash';
 import PropTypes from 'prop-types';
@@ -12,23 +12,30 @@ import 'components/Filter/FilterStyles.scss';
 import 'components/form-elements/FilterSelectField.scss';
 
 const Dropdown = ({
-  children, style, inputContainerRec,
+  children,
+  style,
+  inputContainerRec,
+  hasOptions,
 }) => {
   const dropdownRef = useRef(null);
   // if current dropdown width is smaller than the input container
   // then change dropdown width to the same width as the input container
-  const currentDropdownWidth = dropdownRef.current?.offsetWidth;
-  const inputContainerWidth = inputContainerRec?.width;
-  const dropdownWidth = inputContainerWidth > currentDropdownWidth
-    ? inputContainerWidth
-    : currentDropdownWidth;
+  const [drpWidth, setDtrWidth] = useState(undefined);
+  useEffect(() => {
+    const currentDropdownWidth = dropdownRef.current?.offsetWidth;
+    const inputContainerWidth = inputContainerRec?.width;
+    if (inputContainerWidth > currentDropdownWidth) {
+      setDtrWidth(inputContainerWidth);
+    }
+  }, [hasOptions]);
+
   return (
     <div
       ref={dropdownRef}
       className="filter-select__dropdown"
       style={{
         ...style,
-        width: dropdownWidth,
+        width: drpWidth,
         left: inputContainerRec.left,
         top: inputContainerRec?.bottom,
       }}
@@ -51,6 +58,7 @@ Dropdown.propTypes = {
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired,
   }).isRequired,
+  hasOptions: PropTypes.bool.isRequired,
 };
 
 Dropdown.defaultProps = {
@@ -66,7 +74,10 @@ const Menu = (props) => {
       target={inputContainer}
       container={document.getElementById('root')}
     >
-      <Dropdown inputContainerRec={inputContainer.getBoundingClientRect()} >
+      <Dropdown
+        inputContainerRec={inputContainer.getBoundingClientRect()}
+        hasOptions={!!props.options.length}
+      >
         <div className="filter-select__custom-option" {...props.innerProps}>
           {props.children}
         </div>

--- a/src/js/components/form-elements/FilterSelectField.jsx
+++ b/src/js/components/form-elements/FilterSelectField.jsx
@@ -92,6 +92,8 @@ Menu.propTypes = {
   selectProps: PropTypes.shape({
     id: PropTypes.string.isRequired,
   }).isRequired,
+  options: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string,
+    PropTypes.shape({})])).isRequired,
 };
 
 const Option = props => (

--- a/src/js/components/form-elements/FilterSelectField.jsx
+++ b/src/js/components/form-elements/FilterSelectField.jsx
@@ -20,12 +20,12 @@ const Dropdown = ({
   const dropdownRef = useRef(null);
   // if current dropdown width is smaller than the input container
   // then change dropdown width to the same width as the input container
-  const [drpWidth, setDtrWidth] = useState(undefined);
+  const [dropdownWidth, setDropdownWidth] = useState(undefined);
   useEffect(() => {
     const currentDropdownWidth = dropdownRef.current?.offsetWidth;
     const inputContainerWidth = inputContainerRec?.width;
     if (inputContainerWidth > currentDropdownWidth) {
-      setDtrWidth(inputContainerWidth);
+      setDropdownWidth(inputContainerWidth);
     }
   }, [hasOptions]);
 
@@ -35,7 +35,7 @@ const Dropdown = ({
       className="filter-select__dropdown"
       style={{
         ...style,
-        width: drpWidth,
+        width: dropdownWidth,
         left: inputContainerRec.left,
         top: inputContainerRec?.bottom,
       }}


### PR DESCRIPTION
The point was to re-create the dropdown and its width when the options change, because before for the async select, the width has never dynamically changed regarding the options that were loaded.
Thanks for pair programing @drodzewicz @alannadolny 