### PR TITLE
OBPIH-5826 Approval comment indicator fix

### DIFF
--- a/src/main/groovy/org/pih/warehouse/api/StockMovement.groovy
+++ b/src/main/groovy/org/pih/warehouse/api/StockMovement.groovy
@@ -180,7 +180,7 @@ class StockMovement implements Validateable{
             trackingNumber      : trackingNumber,
             driverName          : driverName,
             comments            : comments,
-            currentEvent        : requisition.mostRecentEvent,
+            currentEvent        : requisition?.mostRecentEvent,
             requestedBy         : requestedBy,
             lineItems           : lineItems,
             lineItemCount       : lineItemCount,


### PR DESCRIPTION
add nullsafe operator for cases where stockMovement is not from requisition