### PR TITLE
OBPIH-6052 validation for zero items to invoice in invoices workflow

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -3212,6 +3212,7 @@ react.invoice.confirmChange.label=Confirm change
 react.invoice.create.label=Create
 react.invoice.createInvoice.label=Create Invoice
 react.invoice.currency.label=Currency
+react.invoice.error.enterQuantity.label=Enter proper quantity
 react.invoice.error.createInvoice.label=Could not create invoice
 react.invoice.errors.quantityToInvoice.label=Wrong quantity to invoice value
 react.invoice.invoiceDate.label=Invoice Date

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -3255,6 +3255,8 @@ react.invoice.column.currency=Currency
 react.invoice.error.userFetching.label=Could not fetch user for createdBy filter
 react.invoice.export.invoice.label=Export Invoices
 react.invoice.export.invoiceLineDetails.label=Export Invoice Line Details
+react.invoice.message.confirmSave.label=Confirm save
+react.invoice.confirmSave.message=Are you sure you want to save? There are some lines with empty or zero quantity, those lines will be deleted.
 
 # Stock Movement
 # Atributes

--- a/grails-app/services/org/pih/warehouse/invoice/InvoiceService.groovy
+++ b/grails-app/services/org/pih/warehouse/invoice/InvoiceService.groovy
@@ -211,8 +211,10 @@ class InvoiceService {
     }
 
     def updateItems(Invoice invoice, List items) {
+        List<InvoiceItem> currentInvoiceItems = InvoiceItem.findAllByInvoice(invoice)
+
         items.each { item ->
-            InvoiceItem invoiceItem = InvoiceItem.get(item.id)
+            InvoiceItem invoiceItem = currentInvoiceItems.find{ it.id == item?.id }
             // update existing invoice item
             if (invoiceItem) {
                 if (item.quantity > 0) {

--- a/grails-app/services/org/pih/warehouse/invoice/InvoiceService.groovy
+++ b/grails-app/services/org/pih/warehouse/invoice/InvoiceService.groovy
@@ -211,10 +211,8 @@ class InvoiceService {
     }
 
     def updateItems(Invoice invoice, List items) {
-        List<InvoiceItem> currentInvoiceItems = InvoiceItem.findAllByInvoice(invoice)
-
         items.each { item ->
-            InvoiceItem invoiceItem = currentInvoiceItems.find{ it.id == item?.id }
+            InvoiceItem invoiceItem = invoice.invoiceItems?.find{ it.id == item?.id }
             // update existing invoice item
             if (invoiceItem) {
                 if (item.quantity > 0) {

--- a/grails-app/services/org/pih/warehouse/invoice/InvoiceService.groovy
+++ b/grails-app/services/org/pih/warehouse/invoice/InvoiceService.groovy
@@ -213,16 +213,24 @@ class InvoiceService {
     def updateItems(Invoice invoice, List items) {
         items.each { item ->
             InvoiceItem invoiceItem = InvoiceItem.get(item.id)
+            // update existing invoice item
             if (invoiceItem) {
-                invoiceItem.quantity = item.quantity
-            } else {
-                InvoiceItemCandidate candidateItem = InvoiceItemCandidate.get(item.id)
-                if (!candidateItem) {
-                    throw new IllegalArgumentException("No Invoice Item Candidate found with ID ${item.id}")
+                if (item.quantity > 0) {
+                    invoiceItem.quantity = item.quantity
+                } else {
+                    removeInvoiceItem(invoiceItem.id)
                 }
-                invoiceItem = createFromInvoiceItemCandidate(candidateItem)
-                invoiceItem.quantity = item.quantityToInvoice
-                invoice.addToInvoiceItems(invoiceItem)
+            } else {
+                // create new invoice item from candidate
+                if (item.quantityToInvoice > 0) {
+                    InvoiceItemCandidate candidateItem = InvoiceItemCandidate.get(item.id)
+                    if (!candidateItem) {
+                        throw new IllegalArgumentException("No Invoice Item Candidate found with ID ${item.id}")
+                    }
+                    invoiceItem = createFromInvoiceItemCandidate(candidateItem)
+                    invoiceItem.quantity = item.quantityToInvoice
+                    invoice.addToInvoiceItems(invoiceItem)
+                }
             }
         }
 

--- a/src/js/api/services/InvoiceApi.js
+++ b/src/js/api/services/InvoiceApi.js
@@ -1,9 +1,12 @@
-import { INVOICE_API } from 'api/urls';
+import { INVOICE_API, INVOICE_ITEMS, REMOVE_INVOICE_ITEM } from 'api/urls';
 import apiClient from 'utils/apiClient';
 import exportFileFromAPI from 'utils/file-download-util';
 
 export default {
   getInvoices: config => apiClient.get(INVOICE_API, config),
+  getInvoiceItems: (invoiceId, config) => apiClient.get(INVOICE_ITEMS(invoiceId), config),
+  saveInvoiceItems: (invoiceId, payload) => apiClient.post(INVOICE_ITEMS(invoiceId), payload),
+  removeInvoiceItem: (invoiceId) => apiClient.delete(REMOVE_INVOICE_ITEM(invoiceId)),
   downloadInvoices: params => exportFileFromAPI({
     url: INVOICE_API,
     params,

--- a/src/js/api/urls.js
+++ b/src/js/api/urls.js
@@ -34,6 +34,8 @@ export const STOCK_TRANSFER_REMOVE_ALL_ITEMS = id => `${STOCK_TRANSFER_BY_ID(id)
 
 // INVOICE
 export const INVOICE_API = `${API}/invoices`;
+export const INVOICE_ITEMS = id => `${INVOICE_API}/${id}/items`;
+export const REMOVE_INVOICE_ITEM = id => `${INVOICE_API}/${id}/removeItem`;
 
 // INVOICE ITEM
 export const INVOICE_ITEM_API = `${API}/invoiceItems`;

--- a/src/js/components/invoice/AddItemsPage.jsx
+++ b/src/js/components/invoice/AddItemsPage.jsx
@@ -395,7 +395,7 @@ class AddItemsPage extends Component {
     const errors = {};
     errors.invoiceItems = [];
     _.forEach(values?.invoiceItems, (item, key) => {
-      if (_.isNil(_.get(item, 'quantity'))) {
+      if (_.isNil(item?.quantity)) {
         errors.invoiceItems[key] = { quantity: 'react.invoice.error.enterQuantity.label' };
       }
       if (_.has(item, 'isValid') && !item.isValid) {

--- a/src/js/components/invoice/AddItemsPage.jsx
+++ b/src/js/components/invoice/AddItemsPage.jsx
@@ -364,8 +364,10 @@ class AddItemsPage extends Component {
   validate(values) {
     const errors = {};
     errors.invoiceItems = [];
-
     _.forEach(values?.invoiceItems, (item, key) => {
+      if (_.isNil(_.get(item, 'quantity'))) {
+        errors.invoiceItems[key] = { quantity: 'react.invoice.error.enterQuantity.label' };
+      }
       if (_.has(item, 'isValid') && !item.isValid) {
         errors.invoiceItems[key] = { quantity: item?.errorMessage };
       }
@@ -472,7 +474,7 @@ class AddItemsPage extends Component {
                   <Translate id="react.default.button.previous.label" defaultMessage="Previous" />
                 </button>
                 <button
-                  disabled={invalid}
+                  disabled={invalid || !values.invoiceItems?.length}
                   onClick={() => this.nextPage(values)}
                   className="btn btn-outline-primary btn-form float-right btn-xs"
                 >

--- a/src/js/components/invoice/AddItemsPage.jsx
+++ b/src/js/components/invoice/AddItemsPage.jsx
@@ -4,22 +4,24 @@ import arrayMutators from 'final-form-arrays';
 import update from 'immutability-helper';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
+import { confirmAlert } from 'react-confirm-alert';
 import { Form } from 'react-final-form';
+import { getTranslate } from 'react-localize-redux';
 import { connect } from 'react-redux';
 
 import { hideSpinner, showSpinner } from 'actions';
+import invoiceApi from 'api/services/InvoiceApi';
+import invoiceItemApi from 'api/services/InvoiceItemApi';
 import ArrayField from 'components/form-elements/ArrayField';
 import ButtonField from 'components/form-elements/ButtonField';
 import LabelField from 'components/form-elements/LabelField';
 import TextField from 'components/form-elements/TextField';
 import InvoiceItemsModal from 'components/invoice/InvoiceItemsModal';
 import { INVOICE_URL, ORDER_URL, STOCK_MOVEMENT_URL } from 'consts/applicationUrls';
-import apiClient from 'utils/apiClient';
 import { renderFormField } from 'utils/form-utils';
 import { getInvoiceDescription } from 'utils/form-values-utils';
 import accountingFormat from 'utils/number-utils';
-import Translate from 'utils/Translate';
-import invoiceItemApi from 'api/services/InvoiceItemApi';
+import Translate, { translateWithDefaultMessage } from 'utils/Translate';
 
 const DELETE_BUTTON_FIELD = {
   type: ButtonField,
@@ -202,6 +204,7 @@ class AddItemsPage extends Component {
     this.updateRow = this.updateRow.bind(this);
     this.saveInvoiceItems = this.saveInvoiceItems.bind(this);
     this.validateInvoiceItem = this.validateInvoiceItem.bind(this);
+    this.confirmSave = this.confirmSave.bind(this);
 
     this.debouncedInvoiceItemValidation = _.debounce(this.validateInvoiceItem, 1000);
   }
@@ -253,8 +256,12 @@ class AddItemsPage extends Component {
     this.setState({
       isFirstPageLoaded: true,
     });
-    const url = `/api/invoices/${this.state.values.id}/items?offset=${startIndex}&max=${this.props.pageSize}`;
-    apiClient.get(url)
+    invoiceApi.getInvoiceItems(this.state.values.id, {
+      params: {
+        offset: startIndex,
+        max: this.props.pageSize,
+      },
+    })
       .then((response) => {
         this.setInvoiceItems(response, startIndex);
       });
@@ -295,7 +302,6 @@ class AddItemsPage extends Component {
    * @public
    */
   saveInvoiceItems(values) {
-    const url = `/api/invoices/${this.state.values.id}/items`;
     const payload = {
       id: values.id,
       invoiceItems: _.map(values.invoiceItems, item => ({
@@ -304,10 +310,29 @@ class AddItemsPage extends Component {
       })),
     };
     if (payload.invoiceItems.length) {
-      return apiClient.post(url, payload)
+      return invoiceApi.saveInvoiceItems(this.state.values.id, payload)
         .catch(() => Promise.reject(new Error('react.invoice.error.saveInvoiceItems.label')));
     }
     return Promise.resolve();
+  }
+
+  confirmSave(onConfirm) {
+    confirmAlert({
+      title: this.props.translate('react.invoice.message.confirmSave.label', 'Confirm save'),
+      message: this.props.translate(
+        'react.invoice.confirmSave.message',
+        'Are you sure you want to save? There are some lines with empty or zero quantity, those lines will be deleted.',
+      ),
+      buttons: [
+        {
+          label: this.props.translate('react.default.yes.label', 'Yes'),
+          onClick: onConfirm,
+        },
+        {
+          label: this.props.translate('react.default.no.label', 'No'),
+        },
+      ],
+    });
   }
 
   /**
@@ -316,9 +341,14 @@ class AddItemsPage extends Component {
    * @public
    */
   nextPage(values) {
-    this.saveInvoiceItems(values).then(() => {
-      this.props.nextPage(values);
-    });
+    const hasZeros = _.some(values.invoiceItems, (item) => _.parseInt(item.quantity) === 0);
+    if (hasZeros) {
+      this.confirmSave(() => {
+        this.saveInvoiceItems(values).then(() => this.props.nextPage(values));
+      });
+    } else {
+      this.saveInvoiceItems(values).then(() => this.props.nextPage(values));
+    }
   }
 
   /**
@@ -338,10 +368,10 @@ class AddItemsPage extends Component {
    * @public
    */
   removeItem(itemId, values, index) {
-    const removeItemsUrl = `/api/invoices/${itemId}/removeItem`;
     const item = values.invoiceItems[index];
     const newTotalValue = parseFloat(this.state.values.totalValue) - parseFloat(item.totalAmount);
-    return apiClient.delete(removeItemsUrl)
+
+    return invoiceApi.removeInvoiceItem(itemId)
       .then(() => {
         this.setState({
           values: {
@@ -491,6 +521,7 @@ class AddItemsPage extends Component {
 
 const mapStateToProps = state => ({
   pageSize: state.session.pageSize,
+  translate: translateWithDefaultMessage(getTranslate(state.localize)),
 });
 
 export default (connect(mapStateToProps, { showSpinner, hideSpinner })(AddItemsPage));
@@ -508,4 +539,5 @@ AddItemsPage.propTypes = {
   showSpinner: PropTypes.func.isRequired,
   /** Function called when data has loaded */
   hideSpinner: PropTypes.func.isRequired,
+  translate: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
The most important part I would say is located in the `InvoiceService`.
To have the same behavior as we have in inbounde/outbound stockMovements I had to add additional logic that would eliminate invoiceItems with quantity == 0.

- Additionally it was preventing user from going forward if there are no items in the add items page table.
- Adding a confirmation modal with message that there are zeros in your rows and will be deleted.
- And I also used this opportunity to move some hardcoded services to `invoiceApi` like `getInvoiceItems`, `removeItems` and `saveInvoiceitems`