### PR TITLE
OBPIH-6100 Create a reusable Date component

### DIFF
--- a/src/js/components/form-elements/v2/DateField.jsx
+++ b/src/js/components/form-elements/v2/DateField.jsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+
+import moment from 'moment';
+import PropTypes from 'prop-types';
+import DatePicker from 'react-datepicker';
+
+import DateFieldInput from 'components/form-elements/v2/DateFieldInput';
+import { DateFormat, TimeFormat } from 'consts/timeFormat';
+import InputWrapper from 'wrappers/InputWrapper';
+
+import './style.scss';
+
+const DateField = ({
+  title,
+  required,
+  tooltip,
+  disabled,
+  errorMessage,
+  placeholder,
+  button,
+  className,
+  ...fieldProps
+}) => {
+  const [date, setDate] = useState(null);
+
+  const onChange = (pickedDate) => setDate(moment(pickedDate, DateFormat.MM_DD_YYYY));
+
+  const onClear = () => setDate(null);
+
+  return (
+    <InputWrapper
+      title={title}
+      required={required}
+      tooltip={tooltip}
+      errorMessage={errorMessage}
+      button={button}
+    >
+      <DatePicker
+        customInput={<DateFieldInput onClear={onClear} />}
+        className={`form-element-input ${errorMessage ? 'has-errors' : ''} ${className}`}
+        dropdownMode="scroll"
+        onChange={onChange}
+        dateFormat={DateFormat.MM_DD_YYYY}
+        timeFormat={TimeFormat.HH_MM}
+        disabled={disabled}
+        selected={date}
+        timeIntervals={15}
+        yearDropdownItemNumber={3}
+        showYearDropdown
+        scrollableYearDropdown
+        utcOffset={0}
+        placeholderText={placeholder}
+        {...fieldProps}
+      />
+    </InputWrapper>
+  );
+};
+
+export default DateField;
+
+DateField.propTypes = {
+  // Message which will be shown on the tooltip above the field
+  tooltip: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    defaultMessage: PropTypes.string.isRequired,
+  }),
+  // Indicator whether the red asterisk has to be shown
+  required: PropTypes.bool,
+  // Title displayed above the field
+  title: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    defaultMessage: PropTypes.string.isRequired,
+  }),
+  // Button on the right side above the input
+  button: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    defaultMessage: PropTypes.string.isRequired,
+    onClick: PropTypes.func.isRequired,
+  }),
+  // Indicator whether the field should be disabled
+  disabled: PropTypes.bool,
+  // If the errorMessage is not empty then the field is bordered
+  // and the message is displayed under the input
+  errorMessage: PropTypes.string,
+  // Text displayed within input field
+  placeholder: PropTypes.string,
+  className: PropTypes.string,
+};
+
+DateField.defaultProps = {
+  tooltip: null,
+  required: false,
+  title: null,
+  button: null,
+  errorMessage: null,
+  disabled: false,
+  placeholder: '',
+  className: '',
+};

--- a/src/js/components/form-elements/v2/DateField.jsx
+++ b/src/js/components/form-elements/v2/DateField.jsx
@@ -19,9 +19,10 @@ const DateField = ({
   placeholder,
   button,
   className,
+  defaultValue,
   ...fieldProps
 }) => {
-  const [date, setDate] = useState(null);
+  const [date, setDate] = useState(defaultValue);
 
   const onChange = (pickedDate) => setDate(moment(pickedDate, DateFormat.MM_DD_YYYY));
 
@@ -85,6 +86,7 @@ DateField.propTypes = {
   // Text displayed within input field
   placeholder: PropTypes.string,
   className: PropTypes.string,
+  defaultValue: PropTypes.string,
 };
 
 DateField.defaultProps = {
@@ -96,4 +98,5 @@ DateField.defaultProps = {
   disabled: false,
   placeholder: '',
   className: '',
+  defaultValue: null,
 };

--- a/src/js/components/form-elements/v2/DateFieldInput.jsx
+++ b/src/js/components/form-elements/v2/DateFieldInput.jsx
@@ -12,23 +12,31 @@ const DateFieldInput = forwardRef(({
   className,
   disabled,
   ...props
-}, ref) => (
-  <div
-    className={`${disabled ? 'disabled' : ''} ${className}`}
-    {...props}
-    ref={ref}
-    tabIndex="0"
-    role="button"
-  >
-    <span>{value || placeholder}</span>
-    {!disabled
-      && (
-      <span className="form-element-icons-wrapper">
-        {value ? <RiCloseLine onClick={onClear} /> : <RiCalendarLine />}
-      </span>
-      )}
-  </div>
-));
+}, ref) => {
+  const disabledProps = disabled ? {
+    className: `disabled ${className}`,
+  } : {
+    className,
+    tabIndex: 0,
+    role: 'button',
+  };
+
+  return (
+    <div
+      {...props}
+      {...disabledProps}
+      ref={ref}
+    >
+      <span>{value || placeholder}</span>
+      {!disabled
+        && (
+          <span className="form-element-icons-wrapper">
+            {value ? <RiCloseLine onClick={onClear} /> : <RiCalendarLine />}
+          </span>
+        )}
+    </div>
+  );
+});
 
 export default DateFieldInput;
 

--- a/src/js/components/form-elements/v2/DateFieldInput.jsx
+++ b/src/js/components/form-elements/v2/DateFieldInput.jsx
@@ -17,6 +17,8 @@ const DateFieldInput = forwardRef(({
     className={`${disabled ? 'disabled' : ''} ${className}`}
     ref={ref}
     {...props}
+    tabIndex="0"
+    role="button"
   >
     <span>{value || placeholder}</span>
     {!disabled

--- a/src/js/components/form-elements/v2/DateFieldInput.jsx
+++ b/src/js/components/form-elements/v2/DateFieldInput.jsx
@@ -15,8 +15,8 @@ const DateFieldInput = forwardRef(({
 }, ref) => (
   <div
     className={`${disabled ? 'disabled' : ''} ${className}`}
-    ref={ref}
     {...props}
+    ref={ref}
     tabIndex="0"
     role="button"
   >
@@ -36,7 +36,7 @@ DateFieldInput.propTypes = {
   value: PropTypes.string,
   placeholder: PropTypes.string,
   onClear: PropTypes.func.isRequired,
-  className: PropTypes.string.isRequired,
+  className: PropTypes.string,
   disabled: PropTypes.bool,
 };
 
@@ -44,4 +44,5 @@ DateFieldInput.defaultProps = {
   value: null,
   placeholder: '',
   disabled: false,
+  className: '',
 };

--- a/src/js/components/form-elements/v2/DateFieldInput.jsx
+++ b/src/js/components/form-elements/v2/DateFieldInput.jsx
@@ -1,0 +1,34 @@
+import React, { forwardRef } from 'react';
+
+import PropTypes from 'prop-types';
+import { RiCalendarLine, RiCloseLine } from 'react-icons/ri';
+
+import './style.scss';
+
+const DateFieldInput = forwardRef(({
+  value,
+  placeholder,
+  onClear,
+  ...props
+}, ref) => (
+  <div
+    ref={ref}
+    {...props}
+  >
+    <span>{value || placeholder}</span>
+    <span className="form-element-icons-wrapper">{value ? <RiCloseLine onClick={onClear} /> : <RiCalendarLine />}</span>
+  </div>
+));
+
+export default DateFieldInput;
+
+DateFieldInput.propTypes = {
+  value: PropTypes.string,
+  placeholder: PropTypes.string,
+  onClear: PropTypes.func.isRequired,
+};
+
+DateFieldInput.defaultProps = {
+  value: null,
+  placeholder: '',
+};

--- a/src/js/components/form-elements/v2/DateFieldInput.jsx
+++ b/src/js/components/form-elements/v2/DateFieldInput.jsx
@@ -9,14 +9,22 @@ const DateFieldInput = forwardRef(({
   value,
   placeholder,
   onClear,
+  className,
+  disabled,
   ...props
 }, ref) => (
   <div
+    className={`${disabled ? 'disabled' : ''} ${className}`}
     ref={ref}
     {...props}
   >
     <span>{value || placeholder}</span>
-    <span className="form-element-icons-wrapper">{value ? <RiCloseLine onClick={onClear} /> : <RiCalendarLine />}</span>
+    {!disabled
+      && (
+      <span className="form-element-icons-wrapper">
+        {value ? <RiCloseLine onClick={onClear} /> : <RiCalendarLine />}
+      </span>
+      )}
   </div>
 ));
 
@@ -26,9 +34,12 @@ DateFieldInput.propTypes = {
   value: PropTypes.string,
   placeholder: PropTypes.string,
   onClear: PropTypes.func.isRequired,
+  className: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
 };
 
 DateFieldInput.defaultProps = {
   value: null,
   placeholder: '',
+  disabled: false,
 };

--- a/src/js/components/form-elements/v2/TextInput.jsx
+++ b/src/js/components/form-elements/v2/TextInput.jsx
@@ -25,7 +25,7 @@ const TextInput = ({
   >
     <input
       disabled={disabled}
-      className={`text-input ${errorMessage ? 'has-errors' : ''}`}
+      className={`form-element-input ${errorMessage ? 'has-errors' : ''}`}
       placeholder={placeholder}
       {...fieldProps}
     />

--- a/src/js/components/form-elements/v2/style.scss
+++ b/src/js/components/form-elements/v2/style.scss
@@ -1,9 +1,9 @@
-// SWITCH
-
 @mixin slider-image($image) {
   background-image: url($image);
   background-size: cover;
 }
+
+// SWITCH
 
 .switch-container {
   display: flex;
@@ -61,17 +61,20 @@
 
 // TEXT INPUT
 
-.text-input {
+.form-element-input {
   width: 100%;
   height: 36px;
   border-radius: 4px;
   padding: 8px;
   border: 1px solid var(--gray-200);
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--gray-600);
 
   &:focus {
     outline: 0;
     border: 1px solid var(--blue-primary);
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 1px rgba(104, 113, 130, 0.16), 0px 0px 0px 4px rgba(34, 100, 229, 0.15);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 1px rgba(104, 113, 130, 0.16), 0 0 0 4px rgba(34, 100, 229, 0.15);
   }
 }
 
@@ -83,6 +86,37 @@ input {
     &:focus {
       border-color: var(--color-red);
       box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 6px var(--color-red);
+    }
+  }
+}
+
+// DATE FIELD
+
+.react-datepicker-popper {
+  z-index: 999;
+}
+
+.react-datepicker__input-container {
+  width: 100%;
+
+  .date-picker {
+    width: 100%;
+  }
+
+  .form-element-input {
+    position: relative;
+    display: flex;
+  }
+
+  .form-element-icons-wrapper {
+    position: absolute;
+    right: 8px;
+    cursor: pointer;
+
+    svg {
+      width: 16px;
+      height: 16px;
+      color: var(--gray-600)
     }
   }
 }

--- a/src/js/components/form-elements/v2/style.scss
+++ b/src/js/components/form-elements/v2/style.scss
@@ -78,7 +78,7 @@
   }
 }
 
-input {
+input, div {
 
   &.has-errors {
     border: 1px solid var(--color-red);

--- a/src/js/components/form-elements/v2/style.scss
+++ b/src/js/components/form-elements/v2/style.scss
@@ -106,6 +106,10 @@ input {
   .form-element-input {
     position: relative;
     display: flex;
+
+    &.disabled {
+      background-color: var(--blue-100);
+    }
   }
 
   .form-element-icons-wrapper {

--- a/src/js/consts/timeFormat.js
+++ b/src/js/consts/timeFormat.js
@@ -1,0 +1,7 @@
+export const TimeFormat = {
+  HH_MM: 'HH:mm',
+};
+
+export const DateFormat = {
+  MM_DD_YYYY: 'MM/DD/YYYY',
+};

--- a/src/js/wrappers/style.scss
+++ b/src/js/wrappers/style.scss
@@ -19,7 +19,6 @@
     display: flex;
     flex-direction: row;
     gap: 3px;
-    margin-bottom: 3px;
   }
 
   .input-wrapper-asterisk {


### PR DESCRIPTION
Current styling of the date component:
![image](https://github.com/openboxes/openboxes/assets/83239466/fb2e5601-08af-48cb-bc61-bdf8717e875f)
![image](https://github.com/openboxes/openboxes/assets/83239466/08b878ce-8aa8-43df-8140-8083cb4a2884)
![image](https://github.com/openboxes/openboxes/assets/83239466/f0477d49-08ed-4f8e-95a7-0894ef1755b1)
![image](https://github.com/openboxes/openboxes/assets/83239466/c0197e01-50c9-4a6a-96ec-feeb23040cf1)
![image](https://github.com/openboxes/openboxes/assets/83239466/20f4bb47-49d1-4c71-b4e7-cab2f2919adb)
![image](https://github.com/openboxes/openboxes/assets/83239466/b51dc0af-1df9-4cc9-9821-ad3114abf10d)
![image](https://github.com/openboxes/openboxes/assets/83239466/51f88b08-24cb-4f66-85d1-e08316ad6791)
