### PR TITLE
OBPIH-6102 Create reusable checkbox  form component

### DIFF
--- a/src/js/components/form-elements/v2/Checkbox.jsx
+++ b/src/js/components/form-elements/v2/Checkbox.jsx
@@ -6,14 +6,13 @@ import InputWrapper from 'wrappers/InputWrapper';
 
 import './style.scss';
 
-const TextInput = ({
+const CheckBox = ({
   title,
   tooltip,
-  required,
   button,
   disabled,
   errorMessage,
-  placeholder,
+  labelPosition,
   id,
   name,
   ...fieldProps
@@ -21,32 +20,32 @@ const TextInput = ({
   <InputWrapper
     title={title}
     tooltip={tooltip}
-    required={required}
     button={button}
-    inputId={id || name}
     errorMessage={errorMessage}
+    inputId={id || name}
+    labelPosition={labelPosition}
   >
-    <input
-      id={id || name}
-      name={name}
-      disabled={disabled}
-      className={`form-element-input ${errorMessage ? 'has-errors' : ''}`}
-      placeholder={placeholder}
-      {...fieldProps}
-    />
+    <div className="form-element-checkbox ">
+      <input
+        id={id || name}
+        name={name}
+        type="checkbox"
+        disabled={disabled}
+        className={`${errorMessage ? 'has-errors' : ''}`}
+        {...fieldProps}
+      />
+    </div>
   </InputWrapper>
 );
 
-export default TextInput;
+export default CheckBox;
 
-TextInput.propTypes = {
+CheckBox.propTypes = {
   // Message which will be shown on the tooltip above the field
   tooltip: PropTypes.shape({
     id: PropTypes.string.isRequired,
     defaultMessage: PropTypes.string.isRequired,
   }),
-  // Indicator whether the red asterisk has to be shown
-  required: PropTypes.bool,
   // Title displayed above the field
   title: PropTypes.shape({
     id: PropTypes.string.isRequired,
@@ -63,22 +62,21 @@ TextInput.propTypes = {
   // If the errorMessage is not empty then the field is bordered
   // and the message is displayed under the input
   errorMessage: PropTypes.string,
-  // Text displayed within input field
-  placeholder: PropTypes.string,
+  // position of input label
+  labelPosition: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
   // html element id
   id: PropTypes.string,
   // html element name
   name: PropTypes.string,
 };
 
-TextInput.defaultProps = {
+CheckBox.defaultProps = {
   tooltip: null,
-  required: false,
   title: null,
   button: null,
   errorMessage: null,
   disabled: false,
-  placeholder: '',
   id: undefined,
   name: undefined,
+  labelPosition: 'right',
 };

--- a/src/js/components/form-elements/v2/style.scss
+++ b/src/js/components/form-elements/v2/style.scss
@@ -92,6 +92,15 @@ input, .date-field-input {
   }
 }
 
+// CHECKBOX
+
+.form-element-checkbox {
+  height: 36px;
+  width: 36px;
+  border-radius: 4px;
+  padding: 8px;
+}
+
 // DATE FIELD
 
 .react-datepicker-popper {

--- a/src/js/wrappers/InputWrapper.jsx
+++ b/src/js/wrappers/InputWrapper.jsx
@@ -16,11 +16,15 @@ const InputWrapper = ({
   title,
   errorMessage,
   className,
+  inputId,
+  labelPosition,
 }) => (
-  <div className={`input-wrapper-container ${className}`}>
-    <div>
-      <div className="input-wrapper-title">
-        {title && <Translate id={title?.id} defaultMessage={title?.defaultMessage} />}
+  <div className={`input-wrapper-container ${className} input-wrapper-label-position-${labelPosition}`}>
+    <div className="input-wrapper-title">
+      <div className="input-wrapper-label">
+        <label htmlFor={inputId} className="m-0">
+          {title && <Translate id={title?.id} defaultMessage={title?.defaultMessage} />}
+        </label>
         {tooltip && (
         <Tooltip
           html={(
@@ -29,10 +33,10 @@ const InputWrapper = ({
             </span>
               )}
         >
-          <RiQuestionLine />
+          <RiQuestionLine className="ml-1" />
         </Tooltip>
         )}
-        {required && <span className="input-wrapper-asterisk">&#42;</span>}
+        {required && <span className="input-wrapper-asterisk ml-1">&#42;</span>}
       </div>
       {button && (
       <div
@@ -77,6 +81,10 @@ InputWrapper.propTypes = {
   // Message displayed under the input
   errorMessage: PropTypes.string,
   className: PropTypes.string,
+  // id of an input element to be mapped to label tag
+  inputId: PropTypes.string,
+  // input label position
+  labelPosition: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
 };
 
 InputWrapper.defaultProps = {
@@ -86,4 +94,6 @@ InputWrapper.defaultProps = {
   button: null,
   errorMessage: null,
   className: '',
+  inputId: undefined,
+  labelPosition: 'top',
 };

--- a/src/js/wrappers/style.scss
+++ b/src/js/wrappers/style.scss
@@ -1,4 +1,6 @@
 .input-wrapper-container {
+  display: flex;
+  flex-direction: column;
   width: 100%;
   font-weight: 600;
   font-size: 12px;
@@ -12,13 +14,16 @@
 
   & > div {
     display: flex;
-    justify-content: space-between;
+  }
+
+  .input-wrapper-label {
+    display: flex;
   }
 
   .input-wrapper-title {
     display: flex;
     flex-direction: row;
-    gap: 3px;
+    justify-content: space-between;
   }
 
   .input-wrapper-asterisk {
@@ -32,6 +37,40 @@
   }
 
   .input-wrapper-error-message {
+    order: 2;
     color: var(--color-red);
+  }
+}
+
+.input-wrapper-label-position {
+  &-top .input-wrapper-title {
+    order: 0;
+  }
+  &-bottom .input-wrapper-title {
+    order: 1;
+  }
+  &-left {
+    align-items: center;
+    flex-direction: row;
+    flex-wrap: wrap;
+    padding-top: 1rem;
+
+    .input-wrapper-error-message {
+      width: 100%;
+    }
+  }
+  &-right {
+    align-items: center;
+    flex-direction: row;
+    flex-wrap: wrap;
+    padding-top: 1rem;
+
+    .input-wrapper-title {
+      order: 1;
+    }
+
+    .input-wrapper-error-message {
+      width: 100%;
+    }
   }
 }


### PR DESCRIPTION
There are two modifications to the input wrapper
 first, since this checkbox component has the label on it's right side I added a _modified_ to the InputWrapper to have the ability to position this label top, bottom, left and right so it would be much more reusable to future form components.

I have also added a `<label />` tag and attributes `htmlFor` and `ids` for better semantics. This will help us target these input elements for automated testing so this change is required. 