### PR TITLE
OBPIH-6111 Fix substitution and calculation of each price

### DIFF
--- a/src/js/components/productSupplier/create/ProductSupplierForm.jsx
+++ b/src/js/components/productSupplier/create/ProductSupplierForm.jsx
@@ -18,6 +18,7 @@ const ProductSupplierForm = () => {
     triggerValidation,
     dirtyFields,
     onSubmit,
+    setProductPackageQuantity,
   } = useProductSupplierForm();
 
   return (
@@ -33,6 +34,7 @@ const ProductSupplierForm = () => {
             errors,
             triggerValidation,
             dirtyFields,
+            setProductPackageQuantity,
           }}
         />
       </form>

--- a/src/js/components/productSupplier/create/ProductSupplierFormMain.jsx
+++ b/src/js/components/productSupplier/create/ProductSupplierFormMain.jsx
@@ -13,6 +13,7 @@ const ProductSupplierFormMain = ({ formProps }) => {
     control,
     errors,
     triggerValidation,
+    setProductPackageQuantity,
   } = formProps;
 
   return (
@@ -29,6 +30,7 @@ const ProductSupplierFormMain = ({ formProps }) => {
       <PricingSection
         control={control}
         errors={errors}
+        setProductPackageQuantity={setProductPackageQuantity}
       />
     </div>
   );
@@ -99,5 +101,6 @@ ProductSupplierFormMain.propTypes = {
       })),
     }),
     triggerValidation: PropTypes.func.isRequired,
+    setProductPackageQuantity: PropTypes.func.isRequired,
   }).isRequired,
 };

--- a/src/js/components/productSupplier/create/sections/PricingSection.jsx
+++ b/src/js/components/productSupplier/create/sections/PricingSection.jsx
@@ -7,7 +7,7 @@ import FixedPrice from 'components/productSupplier/create/subsections/FixedPrice
 import PackageSpecification
   from 'components/productSupplier/create/subsections/PackageSpecification';
 
-const PricingSection = ({ control, errors }) => (
+const PricingSection = ({ control, errors, setProductPackageQuantity }) => (
   <Section title={{
     label: 'react.productSupplier.form.section.pricing',
     defaultMessage: 'Pricing',
@@ -16,6 +16,7 @@ const PricingSection = ({ control, errors }) => (
     <PackageSpecification
       control={control}
       errors={errors}
+      setProductPackageQuantity={setProductPackageQuantity}
     />
     <FixedPrice
       control={control}
@@ -45,4 +46,5 @@ PricingSection.propTypes = {
       message: PropTypes.string,
     }),
   }).isRequired,
+  setProductPackageQuantity: PropTypes.func.isRequired,
 };

--- a/src/js/components/productSupplier/create/subsections/PackageSpecification.jsx
+++ b/src/js/components/productSupplier/create/subsections/PackageSpecification.jsx
@@ -8,7 +8,7 @@ import TextInput from 'components/form-elements/v2/TextInput';
 import Subsection from 'components/Layout/v2/Subsection';
 import useQuantityUnitOfMeasureOptions from 'hooks/options-data/useQuantityUnitOfMeasureOptions';
 
-const PackageSpecification = ({ control, errors }) => {
+const PackageSpecification = ({ control, errors, setProductPackageQuantity }) => {
   const { quantityUom } = useQuantityUnitOfMeasureOptions();
   const uom = useWatch({ control, name: 'uom' });
 
@@ -28,6 +28,11 @@ const PackageSpecification = ({ control, errors }) => {
             render={({ field }) => (
               <SelectField
                 {...field}
+                onChange={(val) => {
+                  field?.onChange(val);
+                  // preselect value 1 when unit of measure Each is selected
+                  setProductPackageQuantity(val);
+                }}
                 required
                 title={{
                   id: 'react.productSupplier.form.uom.title',
@@ -160,4 +165,5 @@ PackageSpecification.propTypes = {
       message: PropTypes.string,
     }),
   }).isRequired,
+  setProductPackageQuantity: PropTypes.func.isRequired,
 };

--- a/src/js/hooks/productSupplier/form/useProductSupplierForm.js
+++ b/src/js/hooks/productSupplier/form/useProductSupplierForm.js
@@ -139,16 +139,14 @@ const useProductSupplierForm = () => {
   },
   [packagePrice, productPackageQuantity]);
 
-  const uom = useWatch({ control, name: 'uom' });
-
   // preselect value 1 when unit of measure Each is selected
-  useEffect(() => {
-    if (uom?.id === 'EA') {
+  const setProductPackageQuantity = (unitOfMeasure) => {
+    if (unitOfMeasure?.id === 'EA') {
       setValue('productPackageQuantity', 1, { shouldValidate: true });
-    } else {
-      setValue('productPackageQuantity', undefined);
+      return;
     }
-  }, [uom]);
+    setValue('productPackageQuantity', '');
+  };
 
   return {
     control,
@@ -157,6 +155,7 @@ const useProductSupplierForm = () => {
     isValid,
     triggerValidation: trigger,
     onSubmit,
+    setProductPackageQuantity,
   };
 };
 


### PR DESCRIPTION
The bug has been introduced by this commit: https://github.com/openboxes/openboxes/pull/4524/commits/ad702489c329c9893e48f8b3af3460c1a05d78e5

When editing a source, the product package quantity was cleared (set to `undefined`) after initialization of default values of the product source.
It was due to two `useEffects` impacting on each other - at first we were setting the default values in `getDefaultValues` method, and since the `uom` was also set, it triggered the `useEffect` that was eventually setting the product package quantity to `undefined`.

This `useEffect` would be OK, but if it was triggered only for manual editing of the `uom`- since we can't distiungish whether it has been run manually or by the `uom` change of the `getDefaultValues`, I refactored this to be a method that is triggered `onChange` of the `uom` input.