### PR TITLE
OBPIH-6108 Default Preference Type section (fixes after QA)

### DIFF
--- a/src/js/components/form-elements/v2/DateField.jsx
+++ b/src/js/components/form-elements/v2/DateField.jsx
@@ -28,7 +28,7 @@ const DateField = ({
   ...fieldProps
 }) => {
   const translate = useTranslate();
-  const onClear = () => onChange(null);
+  const onClear = () => onChange(undefined);
 
   const onChangeHandler = date => onChange(date?.format(DateFormat.MMM_DD_YYYY));
 

--- a/src/js/components/productSupplier/create/ProductSupplierFormMain.jsx
+++ b/src/js/components/productSupplier/create/ProductSupplierFormMain.jsx
@@ -6,6 +6,7 @@ import AttributesSection from 'components/productSupplier/create/sections/Attrib
 import DetailsSection from 'components/productSupplier/create/sections/DetailsSection';
 import PreferenceTypeSection from 'components/productSupplier/create/sections/PreferenceTypeSection';
 import PricingSection from 'components/productSupplier/create/sections/PricingSection';
+import { FormErrorPropType } from 'utils/propTypes';
 
 import './styles.scss';
 
@@ -22,17 +23,26 @@ const ProductSupplierFormMain = ({ formProps }) => {
     <div className="d-flex gap-12 flex-column">
       <DetailsSection
         control={control}
-        errors={errors}
+        errors={{
+          basicDetails: errors?.basicDetails,
+          additionalDetails: errors?.additionalDetails,
+        }}
       />
       <PreferenceTypeSection
         control={control}
-        errors={errors}
+        errors={{
+          defaultPreferenceType: errors?.defaultPreferenceType,
+          productSupplierPreferences: errors?.productSupplierPreferences,
+        }}
         triggerValidation={triggerValidation}
         setValue={setValue}
       />
       <PricingSection
         control={control}
-        errors={errors}
+        errors={{
+          packageSpecification: errors?.packageSpecification,
+          fixedPrice: errors?.fixedPrice,
+        }}
         setProductPackageQuantity={setProductPackageQuantity}
       />
       <AttributesSection
@@ -50,67 +60,47 @@ ProductSupplierFormMain.propTypes = {
     control: PropTypes.shape({}).isRequired,
     handleSubmit: PropTypes.func.isRequired,
     errors: PropTypes.shape({
-      supplier: PropTypes.shape({
-        message: PropTypes.string,
+      basicDetails: PropTypes.shape({
+        code: FormErrorPropType,
+        product: FormErrorPropType,
+        legacyCode: FormErrorPropType,
+        supplier: FormErrorPropType,
+        supplierCode: FormErrorPropType,
+        name: FormErrorPropType,
+        active: FormErrorPropType,
       }),
-      name: PropTypes.shape({
-        message: PropTypes.string,
-      }),
-      supplierCode: PropTypes.shape({
-        message: PropTypes.string,
-      }),
-      product: PropTypes.shape({
-        message: PropTypes.string,
-      }),
-      uom: PropTypes.shape({
-        message: PropTypes.string,
-      }),
-      productPackageQuantity: PropTypes.shape({
-        message: PropTypes.string,
-      }),
-      minOrderQuantity: PropTypes.shape({
-        message: PropTypes.string,
-      }),
-      productPackagePrice: PropTypes.shape({
-        message: PropTypes.string,
-      }),
-      eachPrice: PropTypes.shape({
-        message: PropTypes.string,
+      additionalDetails: PropTypes.shape({
+        manufacturer: FormErrorPropType,
+        ratingTypeCode: FormErrorPropType,
+        manufacturerCode: FormErrorPropType,
+        brandName: FormErrorPropType,
       }),
       defaultPreferenceType: PropTypes.shape({
-        message: PropTypes.string,
-      }),
-      validFrom: PropTypes.shape({
-        message: PropTypes.string,
-      }),
-      validUntil: PropTypes.shape({
-        message: PropTypes.string,
-      }),
-      bidName: PropTypes.shape({
-        message: PropTypes.string,
+        preferenceType: FormErrorPropType,
+        validityStartDate: FormErrorPropType,
+        validityEndDate: FormErrorPropType,
+        bidName: FormErrorPropType,
       }),
       productSupplierPreferences: PropTypes.arrayOf(PropTypes.shape({
-        destinationParty: PropTypes.shape({
-          message: PropTypes.string,
-        }),
-        preferenceType: PropTypes.shape({
-          message: PropTypes.string,
-        }),
-        validityStartDate: PropTypes.shape({
-          message: PropTypes.string,
-        }),
-        validityEndDate: PropTypes.shape({
-          message: PropTypes.string,
-        }),
-        bidName: PropTypes.shape({
-          message: PropTypes.string,
-        }),
+        destinationParty: FormErrorPropType,
+        preferenceType: FormErrorPropType,
+        validityStartDate: FormErrorPropType,
+        validityEndDate: FormErrorPropType,
+        bidName: FormErrorPropType,
       })),
-      attributes: PropTypes.objectOf(
-        PropTypes.shape({
-          message: PropTypes.string,
-        }),
-      ),
+      packageSpecification: PropTypes.shape({
+        uom: FormErrorPropType,
+        productPackageQuantity: FormErrorPropType,
+        minOrderQuantity: FormErrorPropType,
+        productPackagePrice: FormErrorPropType,
+        eachPrice: FormErrorPropType,
+      }),
+      fixedPrice: PropTypes.shape({
+        contractPricePrice: FormErrorPropType,
+        contractPriceValidUntil: FormErrorPropType,
+        tieredPricing: FormErrorPropType,
+      }),
+      attributes: PropTypes.objectOf(FormErrorPropType),
     }),
     triggerValidation: PropTypes.func.isRequired,
     setProductPackageQuantity: PropTypes.func.isRequired,

--- a/src/js/components/productSupplier/create/ProductSupplierFormMain.jsx
+++ b/src/js/components/productSupplier/create/ProductSupplierFormMain.jsx
@@ -9,6 +9,20 @@ import PricingSection from 'components/productSupplier/create/sections/PricingSe
 import { FormErrorPropType } from 'utils/propTypes';
 
 import './styles.scss';
+import { basicDetailsFormErrors } from 'components/productSupplier/create/subsections/BasicDetails';
+import {
+  additionalDetailsFormErrors
+} from 'components/productSupplier/create/subsections/AdditionalDetails';
+import {
+  defaultPreferenceTypeFormErrors
+} from 'components/productSupplier/create/subsections/DefaultPreferenceType';
+import {
+  preferenceTypeVariationsFormErrors
+} from 'components/productSupplier/create/subsections/PreferenceTypeVariations';
+import {
+  packageSpecificationFormErrors
+} from 'components/productSupplier/create/subsections/PackageSpecification';
+import { fixedPriceFormErrors } from 'components/productSupplier/create/subsections/FixedPrice';
 
 const ProductSupplierFormMain = ({ formProps }) => {
   const {
@@ -60,46 +74,12 @@ ProductSupplierFormMain.propTypes = {
     control: PropTypes.shape({}).isRequired,
     handleSubmit: PropTypes.func.isRequired,
     errors: PropTypes.shape({
-      basicDetails: PropTypes.shape({
-        code: FormErrorPropType,
-        product: FormErrorPropType,
-        legacyCode: FormErrorPropType,
-        supplier: FormErrorPropType,
-        supplierCode: FormErrorPropType,
-        name: FormErrorPropType,
-        active: FormErrorPropType,
-      }),
-      additionalDetails: PropTypes.shape({
-        manufacturer: FormErrorPropType,
-        ratingTypeCode: FormErrorPropType,
-        manufacturerCode: FormErrorPropType,
-        brandName: FormErrorPropType,
-      }),
-      defaultPreferenceType: PropTypes.shape({
-        preferenceType: FormErrorPropType,
-        validityStartDate: FormErrorPropType,
-        validityEndDate: FormErrorPropType,
-        bidName: FormErrorPropType,
-      }),
-      productSupplierPreferences: PropTypes.arrayOf(PropTypes.shape({
-        destinationParty: FormErrorPropType,
-        preferenceType: FormErrorPropType,
-        validityStartDate: FormErrorPropType,
-        validityEndDate: FormErrorPropType,
-        bidName: FormErrorPropType,
-      })),
-      packageSpecification: PropTypes.shape({
-        uom: FormErrorPropType,
-        productPackageQuantity: FormErrorPropType,
-        minOrderQuantity: FormErrorPropType,
-        productPackagePrice: FormErrorPropType,
-        eachPrice: FormErrorPropType,
-      }),
-      fixedPrice: PropTypes.shape({
-        contractPricePrice: FormErrorPropType,
-        contractPriceValidUntil: FormErrorPropType,
-        tieredPricing: FormErrorPropType,
-      }),
+      basicDetails: basicDetailsFormErrors,
+      additionalDetails: additionalDetailsFormErrors,
+      defaultPreferenceType: defaultPreferenceTypeFormErrors,
+      productSupplierPreferences: preferenceTypeVariationsFormErrors,
+      packageSpecification: packageSpecificationFormErrors,
+      fixedPrice: fixedPriceFormErrors,
       attributes: PropTypes.objectOf(FormErrorPropType),
     }),
     triggerValidation: PropTypes.func.isRequired,

--- a/src/js/components/productSupplier/create/sections/AttributesSection.jsx
+++ b/src/js/components/productSupplier/create/sections/AttributesSection.jsx
@@ -5,6 +5,7 @@ import { Controller } from 'react-hook-form';
 
 import Section from 'components/Layout/v2/Section';
 import useProductSupplierAttributes from 'hooks/productSupplier/form/useProductSupplierAttributes';
+import { FormErrorPropType } from 'utils/propTypes';
 
 const AttributesSection = ({ control, errors }) => {
   const { attributesWithInputTypes } = useProductSupplierAttributes();
@@ -50,11 +51,7 @@ export default AttributesSection;
 
 AttributesSection.propTypes = {
   control: PropTypes.shape({}).isRequired,
-  errors: PropTypes.objectOf(
-    PropTypes.shape({
-      message: PropTypes.string,
-    }),
-  ),
+  errors: PropTypes.objectOf(FormErrorPropType),
 };
 
 AttributesSection.defaultProps = {

--- a/src/js/components/productSupplier/create/sections/DetailsSection.jsx
+++ b/src/js/components/productSupplier/create/sections/DetailsSection.jsx
@@ -5,16 +5,17 @@ import PropTypes from 'prop-types';
 import Section from 'components/Layout/v2/Section';
 import AdditionalDetails from 'components/productSupplier/create/subsections/AdditionalDetails';
 import BasicDetails from 'components/productSupplier/create/subsections/BasicDetails';
+import { FormErrorPropType } from 'utils/propTypes';
 
 const DetailsSection = ({ control, errors }) => (
   <Section title={{ label: 'react.productSupplier.form.section.details', defaultMessage: 'Details' }}>
     <BasicDetails
       control={control}
-      errors={errors}
+      errors={errors?.basicDetails}
     />
     <AdditionalDetails
       control={control}
-      errors={errors}
+      errors={errors?.additionalDetails}
     />
   </Section>
 );
@@ -24,17 +25,22 @@ export default DetailsSection;
 DetailsSection.propTypes = {
   control: PropTypes.shape({}).isRequired,
   errors: PropTypes.shape({
-    supplier: PropTypes.shape({
-      message: PropTypes.string,
+    basicDetails: PropTypes.shape({
+      code: FormErrorPropType,
+      product: FormErrorPropType,
+      legacyCode: FormErrorPropType,
+      supplier: FormErrorPropType,
+      supplierCode: FormErrorPropType,
+      name: FormErrorPropType,
+      active: FormErrorPropType,
+      dateCreated: FormErrorPropType,
+      lastUpdated: FormErrorPropType,
     }),
-    name: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    supplierCode: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    product: PropTypes.shape({
-      message: PropTypes.string,
+    additionalDetails: PropTypes.shape({
+      manufacturer: FormErrorPropType,
+      ratingTypeCode: FormErrorPropType,
+      manufacturerCode: FormErrorPropType,
+      brandName: FormErrorPropType,
     }),
   }).isRequired,
 };

--- a/src/js/components/productSupplier/create/sections/DetailsSection.jsx
+++ b/src/js/components/productSupplier/create/sections/DetailsSection.jsx
@@ -3,9 +3,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Section from 'components/Layout/v2/Section';
-import AdditionalDetails from 'components/productSupplier/create/subsections/AdditionalDetails';
-import BasicDetails from 'components/productSupplier/create/subsections/BasicDetails';
-import { FormErrorPropType } from 'utils/propTypes';
+import AdditionalDetails, { additionalDetailsFormErrors }
+  from 'components/productSupplier/create/subsections/AdditionalDetails';
+import BasicDetails, { basicDetailsFormErrors }
+  from 'components/productSupplier/create/subsections/BasicDetails';
 
 const DetailsSection = ({ control, errors }) => (
   <Section title={{ label: 'react.productSupplier.form.section.details', defaultMessage: 'Details' }}>
@@ -25,22 +26,7 @@ export default DetailsSection;
 DetailsSection.propTypes = {
   control: PropTypes.shape({}).isRequired,
   errors: PropTypes.shape({
-    basicDetails: PropTypes.shape({
-      code: FormErrorPropType,
-      product: FormErrorPropType,
-      legacyCode: FormErrorPropType,
-      supplier: FormErrorPropType,
-      supplierCode: FormErrorPropType,
-      name: FormErrorPropType,
-      active: FormErrorPropType,
-      dateCreated: FormErrorPropType,
-      lastUpdated: FormErrorPropType,
-    }),
-    additionalDetails: PropTypes.shape({
-      manufacturer: FormErrorPropType,
-      ratingTypeCode: FormErrorPropType,
-      manufacturerCode: FormErrorPropType,
-      brandName: FormErrorPropType,
-    }),
+    basicDetails: basicDetailsFormErrors,
+    additionalDetails: additionalDetailsFormErrors,
   }).isRequired,
 };

--- a/src/js/components/productSupplier/create/sections/PreferenceTypeSection.jsx
+++ b/src/js/components/productSupplier/create/sections/PreferenceTypeSection.jsx
@@ -19,6 +19,7 @@ const PreferenceTypeSection = ({
       control={control}
       errors={errors?.defaultPreferenceType}
       setValue={setValue}
+      triggerValidation={triggerValidation}
     />
     <PreferenceTypeVariations
       control={control}

--- a/src/js/components/productSupplier/create/sections/PreferenceTypeSection.jsx
+++ b/src/js/components/productSupplier/create/sections/PreferenceTypeSection.jsx
@@ -3,11 +3,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Section from 'components/Layout/v2/Section';
-import DefaultPreferenceType
+import DefaultPreferenceType, { defaultPreferenceTypeFormErrors }
   from 'components/productSupplier/create/subsections/DefaultPreferenceType';
-import PreferenceTypeVariations
+import PreferenceTypeVariations, { preferenceTypeVariationsFormErrors }
   from 'components/productSupplier/create/subsections/PreferenceTypeVariations';
-import { FormErrorPropType } from 'utils/propTypes';
 
 const PreferenceTypeSection = ({
   control,
@@ -34,19 +33,8 @@ export default PreferenceTypeSection;
 PreferenceTypeSection.propTypes = {
   control: PropTypes.shape({}).isRequired,
   errors: PropTypes.shape({
-    defaultPreferenceType: PropTypes.shape({
-      preferenceType: FormErrorPropType,
-      validityStartDate: FormErrorPropType,
-      validityEndDate: FormErrorPropType,
-      bidName: FormErrorPropType,
-    }),
-    productSupplierPreferences: PropTypes.arrayOf(PropTypes.shape({
-      destinationParty: FormErrorPropType,
-      preferenceType: FormErrorPropType,
-      validityStartDate: FormErrorPropType,
-      validityEndDate: FormErrorPropType,
-      bidName: FormErrorPropType,
-    })),
+    defaultPreferenceType: defaultPreferenceTypeFormErrors,
+    productSupplierPreferences: preferenceTypeVariationsFormErrors,
   }).isRequired,
   triggerValidation: PropTypes.func.isRequired,
   setValue: PropTypes.func.isRequired,

--- a/src/js/components/productSupplier/create/sections/PreferenceTypeSection.jsx
+++ b/src/js/components/productSupplier/create/sections/PreferenceTypeSection.jsx
@@ -7,6 +7,7 @@ import DefaultPreferenceType
   from 'components/productSupplier/create/subsections/DefaultPreferenceType';
 import PreferenceTypeVariations
   from 'components/productSupplier/create/subsections/PreferenceTypeVariations';
+import { FormErrorPropType } from 'utils/propTypes';
 
 const PreferenceTypeSection = ({
   control,
@@ -17,12 +18,12 @@ const PreferenceTypeSection = ({
   <Section title={{ label: 'react.productSupplier.section.preferenceType.title', defaultMessage: 'Preference Type' }}>
     <DefaultPreferenceType
       control={control}
-      errors={errors}
+      errors={errors?.defaultPreferenceType}
       setValue={setValue}
     />
     <PreferenceTypeVariations
       control={control}
-      errors={errors.productSupplierPreferences}
+      errors={errors?.productSupplierPreferences}
       triggerValidation={triggerValidation}
     />
   </Section>
@@ -34,33 +35,17 @@ PreferenceTypeSection.propTypes = {
   control: PropTypes.shape({}).isRequired,
   errors: PropTypes.shape({
     defaultPreferenceType: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    validFrom: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    validUntil: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    bidName: PropTypes.shape({
-      message: PropTypes.string,
+      preferenceType: FormErrorPropType,
+      validityStartDate: FormErrorPropType,
+      validityEndDate: FormErrorPropType,
+      bidName: FormErrorPropType,
     }),
     productSupplierPreferences: PropTypes.arrayOf(PropTypes.shape({
-      destinationParty: PropTypes.shape({
-        message: PropTypes.string,
-      }),
-      preferenceType: PropTypes.shape({
-        message: PropTypes.string,
-      }),
-      validityStartDate: PropTypes.shape({
-        message: PropTypes.string,
-      }),
-      validityEndDate: PropTypes.shape({
-        message: PropTypes.string,
-      }),
-      bidName: PropTypes.shape({
-        message: PropTypes.string,
-      }),
+      destinationParty: FormErrorPropType,
+      preferenceType: FormErrorPropType,
+      validityStartDate: FormErrorPropType,
+      validityEndDate: FormErrorPropType,
+      bidName: FormErrorPropType,
     })),
   }).isRequired,
   triggerValidation: PropTypes.func.isRequired,

--- a/src/js/components/productSupplier/create/sections/PricingSection.jsx
+++ b/src/js/components/productSupplier/create/sections/PricingSection.jsx
@@ -3,10 +3,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Section from 'components/Layout/v2/Section';
-import FixedPrice from 'components/productSupplier/create/subsections/FixedPrice';
-import PackageSpecification
+import FixedPrice, { fixedPriceFormErrors }
+  from 'components/productSupplier/create/subsections/FixedPrice';
+import PackageSpecification, { packageSpecificationFormErrors }
   from 'components/productSupplier/create/subsections/PackageSpecification';
-import { FormErrorPropType } from 'utils/propTypes';
 
 const PricingSection = ({ control, errors, setProductPackageQuantity }) => (
   <Section title={{
@@ -31,18 +31,8 @@ export default PricingSection;
 PricingSection.propTypes = {
   control: PropTypes.shape({}).isRequired,
   errors: PropTypes.shape({
-    packageSpecification: PropTypes.shape({
-      uom: FormErrorPropType,
-      productPackageQuantity: FormErrorPropType,
-      minOrderQuantity: FormErrorPropType,
-      productPackagePrice: FormErrorPropType,
-      eachPrice: FormErrorPropType,
-    }),
-    fixedPrice: PropTypes.shape({
-      contractPricePrice: FormErrorPropType,
-      contractPriceValidUntil: FormErrorPropType,
-      tieredPricing: FormErrorPropType,
-    }),
+    packageSpecification: packageSpecificationFormErrors,
+    fixedPrice: fixedPriceFormErrors,
   }).isRequired,
   setProductPackageQuantity: PropTypes.func.isRequired,
 };

--- a/src/js/components/productSupplier/create/sections/PricingSection.jsx
+++ b/src/js/components/productSupplier/create/sections/PricingSection.jsx
@@ -6,6 +6,7 @@ import Section from 'components/Layout/v2/Section';
 import FixedPrice from 'components/productSupplier/create/subsections/FixedPrice';
 import PackageSpecification
   from 'components/productSupplier/create/subsections/PackageSpecification';
+import { FormErrorPropType } from 'utils/propTypes';
 
 const PricingSection = ({ control, errors, setProductPackageQuantity }) => (
   <Section title={{
@@ -15,12 +16,12 @@ const PricingSection = ({ control, errors, setProductPackageQuantity }) => (
   >
     <PackageSpecification
       control={control}
-      errors={errors}
+      errors={errors?.packageSpecification}
       setProductPackageQuantity={setProductPackageQuantity}
     />
     <FixedPrice
       control={control}
-      errors={errors}
+      errors={errors?.fixedPrice}
     />
   </Section>
 );
@@ -30,20 +31,17 @@ export default PricingSection;
 PricingSection.propTypes = {
   control: PropTypes.shape({}).isRequired,
   errors: PropTypes.shape({
-    uom: PropTypes.shape({
-      message: PropTypes.string,
+    packageSpecification: PropTypes.shape({
+      uom: FormErrorPropType,
+      productPackageQuantity: FormErrorPropType,
+      minOrderQuantity: FormErrorPropType,
+      productPackagePrice: FormErrorPropType,
+      eachPrice: FormErrorPropType,
     }),
-    productPackageQuantity: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    minOrderQuantity: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    productPackagePrice: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    eachPrice: PropTypes.shape({
-      message: PropTypes.string,
+    fixedPrice: PropTypes.shape({
+      contractPricePrice: FormErrorPropType,
+      contractPriceValidUntil: FormErrorPropType,
+      tieredPricing: FormErrorPropType,
     }),
   }).isRequired,
   setProductPackageQuantity: PropTypes.func.isRequired,

--- a/src/js/components/productSupplier/create/subsections/AdditionalDetails.jsx
+++ b/src/js/components/productSupplier/create/subsections/AdditionalDetails.jsx
@@ -107,14 +107,16 @@ const AdditionalDetails = ({ control, errors }) => {
 
 export default AdditionalDetails;
 
+export const additionalDetailsFormErrors = PropTypes.shape({
+  manufacturer: FormErrorPropType,
+  ratingTypeCode: FormErrorPropType,
+  manufacturerCode: FormErrorPropType,
+  brandName: FormErrorPropType,
+});
+
 AdditionalDetails.propTypes = {
   control: PropTypes.shape({}).isRequired,
-  errors: PropTypes.shape({
-    manufacturer: FormErrorPropType,
-    ratingTypeCode: FormErrorPropType,
-    manufacturerCode: FormErrorPropType,
-    brandName: FormErrorPropType,
-  }),
+  errors: additionalDetailsFormErrors,
 };
 
 AdditionalDetails.defaultProps = {

--- a/src/js/components/productSupplier/create/subsections/AdditionalDetails.jsx
+++ b/src/js/components/productSupplier/create/subsections/AdditionalDetails.jsx
@@ -9,6 +9,7 @@ import TextInput from 'components/form-elements/v2/TextInput';
 import Subsection from 'components/Layout/v2/Subsection';
 import RoleType from 'consts/roleType';
 import { debounceOrganizationsFetch } from 'utils/option-utils';
+import { FormErrorPropType } from 'utils/propTypes';
 
 const AdditionalDetails = ({ control, errors }) => {
   const {
@@ -34,7 +35,7 @@ const AdditionalDetails = ({ control, errors }) => {
       <div className="row">
         <div className="col-lg-4 col-md-6 p-2">
           <Controller
-            name="manufacturer"
+            name="additionalDetails.manufacturer"
             control={control}
             render={({ field }) => (
               <SelectField
@@ -51,7 +52,7 @@ const AdditionalDetails = ({ control, errors }) => {
         </div>
         <div className="col-lg-4 col-md-6 p-2">
           <Controller
-            name="ratingTypeCode"
+            name="additionalDetails.ratingTypeCode"
             control={control}
             render={({ field }) => (
               <SelectField
@@ -71,7 +72,7 @@ const AdditionalDetails = ({ control, errors }) => {
         </div>
         <div className="col-lg-4 col-md-6 p-2">
           <Controller
-            name="manufacturerCode"
+            name="additionalDetails.manufacturerCode"
             control={control}
             render={({ field }) => (
               <TextInput
@@ -84,7 +85,7 @@ const AdditionalDetails = ({ control, errors }) => {
         </div>
         <div className="col-lg-4 col-md-6 p-2">
           <Controller
-            name="brandName"
+            name="additionalDetails.brandName"
             control={control}
             render={({ field }) => (
               <TextInput
@@ -109,17 +110,13 @@ export default AdditionalDetails;
 AdditionalDetails.propTypes = {
   control: PropTypes.shape({}).isRequired,
   errors: PropTypes.shape({
-    manufacturer: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    ratingTypeCode: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    manufacturerCode: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    brandName: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-  }).isRequired,
+    manufacturer: FormErrorPropType,
+    ratingTypeCode: FormErrorPropType,
+    manufacturerCode: FormErrorPropType,
+    brandName: FormErrorPropType,
+  }),
+};
+
+AdditionalDetails.defaultProps = {
+  errors: {},
 };

--- a/src/js/components/productSupplier/create/subsections/BasicDetails.jsx
+++ b/src/js/components/productSupplier/create/subsections/BasicDetails.jsx
@@ -208,19 +208,21 @@ const BasicDetails = ({ control, errors }) => {
 
 export default BasicDetails;
 
+export const basicDetailsFormErrors = PropTypes.shape({
+  code: FormErrorPropType,
+  product: FormErrorPropType,
+  legacyCode: FormErrorPropType,
+  supplier: FormErrorPropType,
+  supplierCode: FormErrorPropType,
+  name: FormErrorPropType,
+  active: FormErrorPropType,
+  dateCreated: FormErrorPropType,
+  lastUpdated: FormErrorPropType,
+});
+
 BasicDetails.propTypes = {
   control: PropTypes.shape({}).isRequired,
-  errors: PropTypes.shape({
-    code: FormErrorPropType,
-    product: FormErrorPropType,
-    legacyCode: FormErrorPropType,
-    supplier: FormErrorPropType,
-    supplierCode: FormErrorPropType,
-    name: FormErrorPropType,
-    active: FormErrorPropType,
-    dateCreated: FormErrorPropType,
-    lastUpdated: FormErrorPropType,
-  }),
+  errors: basicDetailsFormErrors,
 };
 
 BasicDetails.defaultProps = {

--- a/src/js/components/productSupplier/create/subsections/BasicDetails.jsx
+++ b/src/js/components/productSupplier/create/subsections/BasicDetails.jsx
@@ -11,6 +11,7 @@ import TextInput from 'components/form-elements/v2/TextInput';
 import Subsection from 'components/Layout/v2/Subsection';
 import { INVENTORY_ITEM_URL } from 'consts/applicationUrls';
 import { debounceOrganizationsFetch, debounceProductsFetch } from 'utils/option-utils';
+import { FormErrorPropType } from 'utils/propTypes';
 
 const BasicDetails = ({ control, errors }) => {
   const {
@@ -23,7 +24,7 @@ const BasicDetails = ({ control, errors }) => {
 
   // Watch product's input changes live, in order to display a "View Product" link
   // with a proper product id
-  const product = useWatch({ control, name: 'product' });
+  const product = useWatch({ control, name: 'basicDetails.product' });
 
   return (
     <Subsection
@@ -33,7 +34,7 @@ const BasicDetails = ({ control, errors }) => {
       <div className="row">
         <div className="col-lg-4 col-md-6 p-2">
           <Controller
-            name="code"
+            name="basicDetails.code"
             control={control}
             render={({ field }) => (
               <TextInput
@@ -53,7 +54,7 @@ const BasicDetails = ({ control, errors }) => {
         </div>
         <div className="col-lg-4 col-md-6 p-2">
           <Controller
-            name="product"
+            name="basicDetails.product"
             control={control}
             render={({ field }) => (
               <SelectField
@@ -80,7 +81,7 @@ const BasicDetails = ({ control, errors }) => {
         </div>
         <div className="col-lg-4 col-md-6 p-2">
           <Controller
-            name="legacyCode"
+            name="basicDetails.legacyCode"
             control={control}
             render={({ field }) => (
               <TextInput
@@ -97,7 +98,7 @@ const BasicDetails = ({ control, errors }) => {
         </div>
         <div className="col-lg-4 col-md-6 p-2">
           <Controller
-            name="supplier"
+            name="basicDetails.supplier"
             control={control}
             render={({ field }) => (
               <SelectField
@@ -116,7 +117,7 @@ const BasicDetails = ({ control, errors }) => {
         </div>
         <div className="col-lg-4 col-md-6 p-2">
           <Controller
-            name="supplierCode"
+            name="basicDetails.supplierCode"
             control={control}
             render={({ field }) => (
               <TextInput
@@ -134,7 +135,7 @@ const BasicDetails = ({ control, errors }) => {
         </div>
         <div className="col-lg-4 col-md-6 p-2">
           <Controller
-            name="name"
+            name="basicDetails.name"
             control={control}
             render={({ field }) => (
               <TextInput
@@ -152,7 +153,7 @@ const BasicDetails = ({ control, errors }) => {
         </div>
         <div className="col-lg-4 col-md-6 p-2">
           <Controller
-            name="dateCreated"
+            name="basicDetails.dateCreated"
             control={control}
             render={({ field }) => (
               <DateField
@@ -166,7 +167,7 @@ const BasicDetails = ({ control, errors }) => {
         </div>
         <div className="col-lg-4 col-md-6 p-2">
           <Controller
-            name="lastUpdated"
+            name="basicDetails.lastUpdated"
             control={control}
             render={({ field }) => (
               <DateField
@@ -180,7 +181,7 @@ const BasicDetails = ({ control, errors }) => {
         </div>
         <div className="col-lg-4 col-md-6 p-2">
           <Controller
-            name="active"
+            name="basicDetails.active"
             control={control}
             render={({ field }) => (
               <Switch
@@ -210,29 +211,18 @@ export default BasicDetails;
 BasicDetails.propTypes = {
   control: PropTypes.shape({}).isRequired,
   errors: PropTypes.shape({
-    code: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    legacyCode: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    dateCreated: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    lastUpdated: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    supplier: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    name: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    supplierCode: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    product: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-  }).isRequired,
+    code: FormErrorPropType,
+    product: FormErrorPropType,
+    legacyCode: FormErrorPropType,
+    supplier: FormErrorPropType,
+    supplierCode: FormErrorPropType,
+    name: FormErrorPropType,
+    active: FormErrorPropType,
+    dateCreated: FormErrorPropType,
+    lastUpdated: FormErrorPropType,
+  }),
+};
+
+BasicDetails.defaultProps = {
+  errors: {},
 };

--- a/src/js/components/productSupplier/create/subsections/DefaultPreferenceType.jsx
+++ b/src/js/components/productSupplier/create/subsections/DefaultPreferenceType.jsx
@@ -166,14 +166,16 @@ const DefaultPreferenceType = ({
 
 export default DefaultPreferenceType;
 
+export const defaultPreferenceTypeFormErrors = PropTypes.shape({
+  preferenceType: FormErrorPropType,
+  validityStartDate: FormErrorPropType,
+  validityEndDate: FormErrorPropType,
+  bidName: FormErrorPropType,
+});
+
 DefaultPreferenceType.propTypes = {
   control: PropTypes.shape({}).isRequired,
-  errors: PropTypes.shape({
-    preferenceType: FormErrorPropType,
-    validityStartDate: FormErrorPropType,
-    validityEndDate: FormErrorPropType,
-    bidName: FormErrorPropType,
-  }),
+  errors: defaultPreferenceTypeFormErrors,
   setValue: PropTypes.func.isRequired,
 };
 

--- a/src/js/components/productSupplier/create/subsections/DefaultPreferenceType.jsx
+++ b/src/js/components/productSupplier/create/subsections/DefaultPreferenceType.jsx
@@ -12,6 +12,7 @@ import TextInput from 'components/form-elements/v2/TextInput';
 import Subsection from 'components/Layout/v2/Subsection';
 import useDeletePreferenceType from 'hooks/productSupplier/form/useDeletePreferenceType';
 import Translate from 'utils/Translate';
+import { FormErrorPropType } from 'utils/propTypes';
 
 const DefaultPreferenceType = ({
   control,
@@ -168,18 +169,14 @@ export default DefaultPreferenceType;
 DefaultPreferenceType.propTypes = {
   control: PropTypes.shape({}).isRequired,
   errors: PropTypes.shape({
-    preferenceType: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    validityStartDate: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    validityEndDate: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    bidName: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-  }).isRequired,
+    preferenceType: FormErrorPropType,
+    validityStartDate: FormErrorPropType,
+    validityEndDate: FormErrorPropType,
+    bidName: FormErrorPropType,
+  }),
   setValue: PropTypes.func.isRequired,
+};
+
+DefaultPreferenceType.defaultProps = {
+  errors: {},
 };

--- a/src/js/components/productSupplier/create/subsections/DefaultPreferenceType.jsx
+++ b/src/js/components/productSupplier/create/subsections/DefaultPreferenceType.jsx
@@ -11,8 +11,8 @@ import SelectField from 'components/form-elements/v2/SelectField';
 import TextInput from 'components/form-elements/v2/TextInput';
 import Subsection from 'components/Layout/v2/Subsection';
 import useDeletePreferenceType from 'hooks/productSupplier/form/useDeletePreferenceType';
-import Translate from 'utils/Translate';
 import { FormErrorPropType } from 'utils/propTypes';
+import Translate from 'utils/Translate';
 
 const DefaultPreferenceType = ({
   control,

--- a/src/js/components/productSupplier/create/subsections/DefaultPreferenceType.jsx
+++ b/src/js/components/productSupplier/create/subsections/DefaultPreferenceType.jsx
@@ -18,6 +18,7 @@ const DefaultPreferenceType = ({
   control,
   errors,
   setValue,
+  triggerValidation,
 }) => {
   const {
     preferenceTypes,
@@ -39,6 +40,10 @@ const DefaultPreferenceType = ({
 
   const afterDelete = () => {
     setValue('defaultPreferenceType', emptyPreferenceType);
+  };
+
+  const triggerValidationOnPreferenceType = () => {
+    triggerValidation('defaultPreferenceType.preferenceType');
   };
 
   const {
@@ -98,6 +103,10 @@ const DefaultPreferenceType = ({
                 }}
                 errorMessage={errors.validityStartDate?.message}
                 {...field}
+                onBlur={(e) => {
+                  field?.onBlur?.(e);
+                  triggerValidationOnPreferenceType();
+                }}
               />
             )}
           />
@@ -118,6 +127,10 @@ const DefaultPreferenceType = ({
                 }}
                 errorMessage={errors.validityEndDate?.message}
                 {...field}
+                onBlur={(e) => {
+                  field?.onBlur?.(e);
+                  triggerValidationOnPreferenceType();
+                }}
               />
             )}
           />
@@ -137,6 +150,10 @@ const DefaultPreferenceType = ({
                 tooltip={{
                   id: 'react.productSupplier.form.bidName.tooltip',
                   defaultMessage: 'The bid during which the purchasing preference was selected',
+                }}
+                onBlur={(e) => {
+                  field?.onBlur?.(e);
+                  triggerValidationOnPreferenceType();
                 }}
               />
             )}
@@ -177,6 +194,7 @@ DefaultPreferenceType.propTypes = {
   control: PropTypes.shape({}).isRequired,
   errors: defaultPreferenceTypeFormErrors,
   setValue: PropTypes.func.isRequired,
+  triggerValidation: PropTypes.func.isRequired,
 };
 
 DefaultPreferenceType.defaultProps = {

--- a/src/js/components/productSupplier/create/subsections/DefaultPreferenceType.jsx
+++ b/src/js/components/productSupplier/create/subsections/DefaultPreferenceType.jsx
@@ -34,7 +34,7 @@ const DefaultPreferenceType = ({
     bidName: '',
     validityStartDate: '',
     validityEndDate: '',
-    preferenceType: '',
+    preferenceType: null,
   };
 
   const afterDelete = () => {

--- a/src/js/components/productSupplier/create/subsections/FixedPrice.jsx
+++ b/src/js/components/productSupplier/create/subsections/FixedPrice.jsx
@@ -7,6 +7,7 @@ import CheckBox from 'components/form-elements/v2/Checkbox';
 import DateField from 'components/form-elements/v2/DateField';
 import TextInput from 'components/form-elements/v2/TextInput';
 import Subsection from 'components/Layout/v2/Subsection';
+import { FormErrorPropType } from 'utils/propTypes';
 
 const FixedPrice = ({ control, errors }) => (
   <Subsection
@@ -19,7 +20,7 @@ const FixedPrice = ({ control, errors }) => (
     <div className="row">
       <div className="col-lg-4 p-2">
         <Controller
-          name="contractPricePrice"
+          name="fixedPrice.contractPricePrice"
           control={control}
           render={({ field }) => (
             <TextInput
@@ -41,7 +42,7 @@ const FixedPrice = ({ control, errors }) => (
       </div>
       <div className="col-lg-4 p-2">
         <Controller
-          name="contractPriceValidUntil"
+          name="fixedPrice.contractPriceValidUntil"
           control={control}
           render={({ field }) => (
             <DateField
@@ -57,7 +58,7 @@ const FixedPrice = ({ control, errors }) => (
       </div>
       <div className="col-lg-4 p-2">
         <Controller
-          name="tieredPricing"
+          name="fixedPrice.tieredPricing"
           control={control}
           render={({ field }) => (
             <CheckBox
@@ -83,15 +84,12 @@ export default FixedPrice;
 FixedPrice.propTypes = {
   control: PropTypes.shape({}).isRequired,
   errors: PropTypes.shape({
-    contractPricePrice: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    contractPriceValidUntil: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    tieredPricing: PropTypes.shape({
-      message: PropTypes.string,
-    }),
+    contractPricePrice: FormErrorPropType,
+    contractPriceValidUntil: FormErrorPropType,
+    tieredPricing: FormErrorPropType,
+  }),
+};
 
-  }).isRequired,
+FixedPrice.defaultProps = {
+  errors: {},
 };

--- a/src/js/components/productSupplier/create/subsections/FixedPrice.jsx
+++ b/src/js/components/productSupplier/create/subsections/FixedPrice.jsx
@@ -81,13 +81,15 @@ const FixedPrice = ({ control, errors }) => (
 
 export default FixedPrice;
 
+export const fixedPriceFormErrors = PropTypes.shape({
+  contractPricePrice: FormErrorPropType,
+  contractPriceValidUntil: FormErrorPropType,
+  tieredPricing: FormErrorPropType,
+});
+
 FixedPrice.propTypes = {
   control: PropTypes.shape({}).isRequired,
-  errors: PropTypes.shape({
-    contractPricePrice: FormErrorPropType,
-    contractPriceValidUntil: FormErrorPropType,
-    tieredPricing: FormErrorPropType,
-  }),
+  errors: fixedPriceFormErrors,
 };
 
 FixedPrice.defaultProps = {

--- a/src/js/components/productSupplier/create/subsections/PackageSpecification.jsx
+++ b/src/js/components/productSupplier/create/subsections/PackageSpecification.jsx
@@ -7,10 +7,11 @@ import SelectField from 'components/form-elements/v2/SelectField';
 import TextInput from 'components/form-elements/v2/TextInput';
 import Subsection from 'components/Layout/v2/Subsection';
 import useQuantityUnitOfMeasureOptions from 'hooks/options-data/useQuantityUnitOfMeasureOptions';
+import { FormErrorPropType } from 'utils/propTypes';
 
 const PackageSpecification = ({ control, errors, setProductPackageQuantity }) => {
   const { quantityUom } = useQuantityUnitOfMeasureOptions();
-  const uom = useWatch({ control, name: 'uom' });
+  const uom = useWatch({ control, name: 'packageSpecification.uom' });
 
   return (
     <Subsection
@@ -23,7 +24,7 @@ const PackageSpecification = ({ control, errors, setProductPackageQuantity }) =>
       <div className="row">
         <div className="col-lg col-md-6 p-2">
           <Controller
-            name="uom"
+            name="packageSpecification.uom"
             control={control}
             render={({ field }) => (
               <SelectField
@@ -51,7 +52,7 @@ const PackageSpecification = ({ control, errors, setProductPackageQuantity }) =>
         </div>
         <div className="col-lg col-md-6 p-2">
           <Controller
-            name="productPackageQuantity"
+            name="packageSpecification.productPackageQuantity"
             control={control}
             render={({ field }) => (
               <TextInput
@@ -75,7 +76,7 @@ const PackageSpecification = ({ control, errors, setProductPackageQuantity }) =>
         </div>
         <div className="col-lg col-md-6 p-2">
           <Controller
-            name="minOrderQuantity"
+            name="packageSpecification.minOrderQuantity"
             control={control}
             render={({ field }) => (
               <TextInput
@@ -97,7 +98,7 @@ const PackageSpecification = ({ control, errors, setProductPackageQuantity }) =>
         </div>
         <div className="col-lg col-md-6 p-2">
           <Controller
-            name="productPackagePrice"
+            name="packageSpecification.productPackagePrice"
             control={control}
             render={({ field }) => (
               <TextInput
@@ -119,7 +120,7 @@ const PackageSpecification = ({ control, errors, setProductPackageQuantity }) =>
         </div>
         <div className="col-lg col-md-6 p-2">
           <Controller
-            name="eachPrice"
+            name="packageSpecification.eachPrice"
             control={control}
             render={({ field }) => (
               <TextInput
@@ -149,21 +150,15 @@ export default PackageSpecification;
 PackageSpecification.propTypes = {
   control: PropTypes.shape({}).isRequired,
   errors: PropTypes.shape({
-    uom: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    productPackageQuantity: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    minOrderQuantity: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    productPackagePrice: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-    eachPrice: PropTypes.shape({
-      message: PropTypes.string,
-    }),
-  }).isRequired,
+    uom: FormErrorPropType,
+    productPackageQuantity: FormErrorPropType,
+    minOrderQuantity: FormErrorPropType,
+    productPackagePrice: FormErrorPropType,
+    eachPrice: FormErrorPropType,
+  }),
   setProductPackageQuantity: PropTypes.func.isRequired,
+};
+
+PackageSpecification.defaultProps = {
+  errors: {},
 };

--- a/src/js/components/productSupplier/create/subsections/PackageSpecification.jsx
+++ b/src/js/components/productSupplier/create/subsections/PackageSpecification.jsx
@@ -147,15 +147,17 @@ const PackageSpecification = ({ control, errors, setProductPackageQuantity }) =>
 
 export default PackageSpecification;
 
+export const packageSpecificationFormErrors = PropTypes.shape({
+  uom: FormErrorPropType,
+  productPackageQuantity: FormErrorPropType,
+  minOrderQuantity: FormErrorPropType,
+  productPackagePrice: FormErrorPropType,
+  eachPrice: FormErrorPropType,
+});
+
 PackageSpecification.propTypes = {
   control: PropTypes.shape({}).isRequired,
-  errors: PropTypes.shape({
-    uom: FormErrorPropType,
-    productPackageQuantity: FormErrorPropType,
-    minOrderQuantity: FormErrorPropType,
-    productPackagePrice: FormErrorPropType,
-    eachPrice: FormErrorPropType,
-  }),
+  errors: packageSpecificationFormErrors,
   setProductPackageQuantity: PropTypes.func.isRequired,
 };
 

--- a/src/js/components/productSupplier/create/subsections/PreferenceTypeVariations.jsx
+++ b/src/js/components/productSupplier/create/subsections/PreferenceTypeVariations.jsx
@@ -14,6 +14,7 @@ import usePreferenceTypeVariationsFiltering
   from 'hooks/productSupplier/form/usePreferenceTypeVariationsFiltering';
 import useResetScrollbar from 'hooks/useResetScrollbar';
 import useTranslate from 'hooks/useTranslate';
+import { FormErrorPropType } from 'utils/propTypes';
 
 const PreferenceTypeVariations = ({
   control,
@@ -117,26 +118,16 @@ PreferenceTypeVariations.propTypes = {
   control: PropTypes.shape({}).isRequired,
   errors: PropTypes.arrayOf(
     PropTypes.shape({
-      destinationParty: PropTypes.shape({
-        message: PropTypes.string,
-      }),
-      preferenceType: PropTypes.shape({
-        message: PropTypes.string,
-      }),
-      validityStartDate: PropTypes.shape({
-        message: PropTypes.string,
-      }),
-      validityEndDate: PropTypes.shape({
-        message: PropTypes.string,
-      }),
-      bidName: PropTypes.shape({
-        message: PropTypes.string,
-      }),
+      destinationParty: FormErrorPropType,
+      preferenceType: FormErrorPropType,
+      validityStartDate: FormErrorPropType,
+      validityEndDate: FormErrorPropType,
+      bidName: FormErrorPropType,
     }),
   ),
   triggerValidation: PropTypes.func.isRequired,
 };
 
 PreferenceTypeVariations.defaultProps = {
-  errors: {},
+  errors: [],
 };

--- a/src/js/components/productSupplier/create/subsections/PreferenceTypeVariations.jsx
+++ b/src/js/components/productSupplier/create/subsections/PreferenceTypeVariations.jsx
@@ -114,17 +114,19 @@ const PreferenceTypeVariations = ({
 
 export default PreferenceTypeVariations;
 
+export const preferenceTypeVariationsFormErrors = PropTypes.arrayOf(
+  PropTypes.shape({
+    destinationParty: FormErrorPropType,
+    preferenceType: FormErrorPropType,
+    validityStartDate: FormErrorPropType,
+    validityEndDate: FormErrorPropType,
+    bidName: FormErrorPropType,
+  }),
+);
+
 PreferenceTypeVariations.propTypes = {
   control: PropTypes.shape({}).isRequired,
-  errors: PropTypes.arrayOf(
-    PropTypes.shape({
-      destinationParty: FormErrorPropType,
-      preferenceType: FormErrorPropType,
-      validityStartDate: FormErrorPropType,
-      validityEndDate: FormErrorPropType,
-      bidName: FormErrorPropType,
-    }),
-  ),
+  errors: preferenceTypeVariationsFormErrors,
   triggerValidation: PropTypes.func.isRequired,
 };
 

--- a/src/js/hooks/productSupplier/form/useCalculateEachPrice.js
+++ b/src/js/hooks/productSupplier/form/useCalculateEachPrice.js
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+
+import _ from 'lodash';
+import { useWatch } from 'react-hook-form';
+
+import { decimalParser } from 'utils/form-utils';
+
+const useCalculateEachPrice = ({ control, setValue }) => {
+  const packagePrice = useWatch({ control, name: 'packageSpecification.productPackagePrice' });
+  const productPackageQuantity = useWatch({ control, name: 'packageSpecification.productPackageQuantity' });
+
+  // eachPrice is a computed value from packagePrice and productPackageQuantity
+  useEffect(() => {
+    if (
+      !_.isNil(packagePrice) &&
+      !_.isNil(productPackageQuantity) &&
+      productPackageQuantity !== 0
+    ) {
+      setValue('packageSpecification.eachPrice', decimalParser(packagePrice / productPackageQuantity, 4));
+    } else {
+      setValue('packageSpecification.eachPrice', '');
+    }
+  },
+  [packagePrice, productPackageQuantity]);
+};
+
+export default useCalculateEachPrice;

--- a/src/js/hooks/productSupplier/form/useProductSupplierForm.js
+++ b/src/js/hooks/productSupplier/form/useProductSupplierForm.js
@@ -120,8 +120,12 @@ const useProductSupplierForm = () => {
   };
 
   const defaultValues = {
-    active: true,
-    tieredPricing: false,
+    basicDetails: {
+      active: true,
+    },
+    fixedPrice: {
+      tieredPricing: false,
+    },
   };
 
   const {

--- a/src/js/hooks/productSupplier/form/useProductSupplierForm.js
+++ b/src/js/hooks/productSupplier/form/useProductSupplierForm.js
@@ -1,8 +1,6 @@
-import { useEffect } from 'react';
-
 import { zodResolver } from '@hookform/resolvers/zod';
 import _ from 'lodash';
-import { useForm, useWatch } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 
 import { fetchPreferenceTypes, fetchRatingTypeCodes } from 'actions';
@@ -145,13 +143,6 @@ const useProductSupplierForm = () => {
   });
 
   useCalculateEachPrice({ control, setValue });
-
-  /* immediately trigger validation on preferenceType fields
-  when any values on defaultPreferenceType have changed */
-  const defaultPreferenceType = useWatch({ control, name: 'defaultPreferenceType' });
-  useEffect(() => {
-    trigger('defaultPreferenceType.preferenceType');
-  }, [defaultPreferenceType]);
 
   const onSubmit = (values) => {
     const payload = {

--- a/src/js/hooks/productSupplier/form/useProductSupplierForm.js
+++ b/src/js/hooks/productSupplier/form/useProductSupplierForm.js
@@ -1,16 +1,14 @@
-import { useEffect } from 'react';
-
 import { zodResolver } from '@hookform/resolvers/zod';
 import _ from 'lodash';
-import { useForm, useWatch } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 
 import { fetchPreferenceTypes, fetchRatingTypeCodes } from 'actions';
 import productSupplierApi from 'api/services/ProductSupplierApi';
 import useOptionsFetch from 'hooks/options-data/useOptionsFetch';
+import useCalculateEachPrice from 'hooks/productSupplier/form/useCalculateEachPrice';
 import useProductSupplierAttributes from 'hooks/productSupplier/form/useProductSupplierAttributes';
 import useProductSupplierValidation from 'hooks/productSupplier/form/useProductSupplierValidation';
-import { decimalParser } from 'utils/form-utils';
 import { omitEmptyValues } from 'utils/form-values-utils';
 import { splitPreferenceTypes } from 'utils/list-utils';
 
@@ -140,6 +138,8 @@ const useProductSupplierForm = () => {
       zodResolver(validationSchema(values))(values, context, options),
   });
 
+  useCalculateEachPrice({ control, setValue });
+
   const onSubmit = (values) => {
     const payload = {
       ...omitEmptyValues(values.basicDetails),
@@ -163,23 +163,6 @@ const useProductSupplierForm = () => {
     }
     console.log(payload);
   };
-
-  const packagePrice = useWatch({ control, name: 'packageSpecification.productPackagePrice' });
-  const productPackageQuantity = useWatch({ control, name: 'packageSpecification.productPackageQuantity' });
-
-  // eachPrice is a computed value from packagePrice and productPackageQuantity
-  useEffect(() => {
-    if (
-      !_.isNil(packagePrice) &&
-      !_.isNil(productPackageQuantity) &&
-      productPackageQuantity !== 0
-    ) {
-      setValue('packageSpecification.eachPrice', decimalParser(packagePrice / productPackageQuantity, 4));
-    } else {
-      setValue('packageSpecification.eachPrice', '');
-    }
-  },
-  [packagePrice, productPackageQuantity]);
 
   // preselect value 1 when unit of measure Each is selected
   const setProductPackageQuantity = (unitOfMeasure) => {

--- a/src/js/hooks/productSupplier/form/useProductSupplierForm.js
+++ b/src/js/hooks/productSupplier/form/useProductSupplierForm.js
@@ -1,6 +1,8 @@
+import { useEffect } from 'react';
+
 import { zodResolver } from '@hookform/resolvers/zod';
 import _ from 'lodash';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 
 import { fetchPreferenceTypes, fetchRatingTypeCodes } from 'actions';
@@ -139,6 +141,13 @@ const useProductSupplierForm = () => {
   });
 
   useCalculateEachPrice({ control, setValue });
+
+  /* immediately trigger validation on preferenceType fields
+  when any values on defaultPreferenceType have changed */
+  const defaultPreferenceType = useWatch({ control, name: 'defaultPreferenceType' });
+  useEffect(() => {
+    trigger('defaultPreferenceType.preferenceType');
+  }, [defaultPreferenceType]);
 
   const onSubmit = (values) => {
     const payload = {

--- a/src/js/hooks/productSupplier/form/useProductSupplierValidation.js
+++ b/src/js/hooks/productSupplier/form/useProductSupplierValidation.js
@@ -36,153 +36,175 @@ const useProductSupplierValidation = () => {
       };
     }, {});
 
+    const basicDetailsSchema = z.object({
+      code: z
+        .string()
+        .optional(),
+      product: z.object({
+        id: z.string(),
+        value: z.string(),
+        label: z.string(),
+      }, {
+        invalid_type_error: 'Product is required',
+        required_error: 'Product is required',
+      })
+        .required(),
+      legacyCode: z
+        .string()
+        .optional(),
+      supplier: z.object({
+        id: z.string(),
+        value: z.string(),
+        label: z.string(),
+      }, {
+        invalid_type_error: 'Supplier is required',
+        required_error: 'Supplier is required',
+      })
+        .required(),
+      supplierCode: z
+        .string({ required_error: 'Supplier code is required' })
+        .min(1, 'Supplier code is required')
+        .max(255, 'Max length of supplier code is 255'),
+      name: z
+        .string({ required_error: 'Supplier Product Name is required' })
+        .min(1, 'Supplier Product Name is required')
+        .max(255, 'Max length of supplier product name is 255'),
+      active: z.boolean(),
+    });
+
+    const additionalDetailsSchema = z.object({
+      manufacturer: z.object({
+        id: z.string(),
+        value: z.string(),
+        label: z.string(),
+      })
+        .optional()
+        .nullable(),
+      ratingTypeCode: z.object({
+        id: z.string(),
+        value: z.string(),
+        label: z.string(),
+      })
+        .optional()
+        .nullable(),
+      manufacturerCode: z
+        .coerce
+        .string()
+        .optional(),
+      brandName: z
+        .coerce
+        .string()
+        .optional(),
+    });
+
+    const defaultPreferenceTypeSchema = z.object({
+      preferenceType: z.object({
+        id: z.string(),
+        value: z.string(),
+        label: z.string(),
+      })
+        .optional()
+        .nullable(),
+      validityStartDate: z
+        .coerce
+        .date()
+        .optional(),
+      validityEndDate: z
+        .coerce
+        .date()
+        .optional(),
+      bidName: z
+        .string()
+        .optional(),
+    });
+
+    const productSupplierPreferenceSchema = z.object({
+      destinationParty: z.object({
+        id: z.string(),
+        value: z.string(),
+        label: z.string(),
+      }, {
+        invalid_type_error: 'Site name is required',
+        required_error: 'Site name is required',
+      }).required()
+        .refine(checkDestinationPartyUniqueness, {
+          message: 'Destination party should be unique',
+        }),
+      preferenceType: z.object({
+        id: z.string(),
+        label: z.string(),
+      }, {
+        invalid_type_error: 'Preference type is required',
+        required_error: 'Preference type is required',
+      })
+        .required(),
+      validityEndDate: z
+        .string()
+        .optional()
+        .nullable(),
+      validityStartDate: z
+        .string()
+        .optional()
+        .nullable(),
+      bidName: z
+        .string()
+        .max(255, 'Max length of bid name is 255')
+        .optional()
+        .nullable(),
+    });
+
+    const packageSpecificationSchema = z.object({
+      uom: z
+        .object({
+          id: z.string(),
+          value: z.string(),
+          label: z.string(),
+        }, {
+          invalid_type_error: 'Default Source Package is required',
+          required_error: 'Default Source Package is required',
+        })
+        .required(),
+      productPackageQuantity: z
+        .number({ required_error: 'Package size is required' })
+        .gte(1),
+      minOrderQuantity: z
+        .number()
+        .gte(1)
+        .optional(),
+      productPackagePrice: z
+        .number()
+        .optional(),
+      // since this is a computed field we want to skip validation by setting it to any
+      eachPrice: z
+        .any()
+        .optional(),
+    });
+
+    const fixedPriceSchema = z.object({
+      contractPricePrice: z
+        .number()
+        .optional(),
+      contractPriceValidUntil: z
+        .coerce
+        .date()
+        .optional(),
+      tieredPricing: z
+        .boolean()
+        .optional(),
+    });
+
     // TODO: Add translations for the error messages
     return z
       .object({
         id: z
           .string()
           .optional(),
-        code: z
-          .string()
-          .optional(),
-        product: z.object({
-          id: z.string(),
-          value: z.string(),
-          label: z.string(),
-        }, {
-          invalid_type_error: 'Product is required',
-          required_error: 'Product is required',
-        })
-          .required(),
-        legacyCode: z
-          .string()
-          .optional(),
-        supplier: z.object({
-          id: z.string(),
-          value: z.string(),
-          label: z.string(),
-        }, {
-          invalid_type_error: 'Supplier is required',
-          required_error: 'Supplier is required',
-        })
-          .required(),
-        supplierCode: z
-          .string({ required_error: 'Supplier code is required' })
-          .min(1, 'Supplier code is required')
-          .max(255, 'Max length of supplier code is 255'),
-        name: z
-          .string({ required_error: 'Supplier Product Name is required' })
-          .min(1, 'Supplier Product Name is required')
-          .max(255, 'Max length of supplier product name is 255'),
-        active: z.boolean(),
-        manufacturer: z.object({
-          id: z.string(),
-          value: z.string(),
-          label: z.string(),
-        })
-          .optional()
-          .nullable(),
-        ratingTypeCode: z.object({
-          id: z.string(),
-          value: z.string(),
-          label: z.string(),
-        })
-          .optional()
-          .nullable(),
-        manufacturerCode: z
-          .string()
-          .optional(),
-        brandName: z
-          .string()
-          .optional(),
-        defaultPreferenceType: z.object({
-          preferenceType: z.object({
-            id: z.string(),
-            value: z.string(),
-            label: z.string(),
-          })
-            .optional()
-            .nullable(),
-          validityStartDate: z
-            .coerce
-            .date()
-            .optional(),
-          validityEndDate: z
-            .coerce
-            .date()
-            .optional(),
-          bidName: z
-            .string()
-            .optional(),
-        }),
-        productSupplierPreferences: z.array(z.object({
-          destinationParty: z.object({
-            id: z.string(),
-            value: z.string(),
-            label: z.string(),
-          }, {
-            invalid_type_error: 'Site name is required',
-            required_error: 'Site name is required',
-          }).required()
-            .refine(checkDestinationPartyUniqueness, {
-              message: 'Destination party should be unique',
-            }),
-          preferenceType: z.object({
-            id: z.string(),
-            label: z.string(),
-          }, {
-            invalid_type_error: 'Preference type is required',
-            required_error: 'Preference type is required',
-          })
-            .required(),
-          validityEndDate: z
-            .string()
-            .optional()
-            .nullable(),
-          validityStartDate: z
-            .string()
-            .optional()
-            .nullable(),
-          bidName: z
-            .string()
-            .max(255, 'Max length of bid name is 255')
-            .optional()
-            .nullable(),
-        })),
-        uom: z
-          .object({
-            id: z.string(),
-            value: z.string(),
-            label: z.string(),
-          }, {
-            invalid_type_error: 'Default Source Package is required',
-            required_error: 'Default Source Package is required',
-          })
-          .required(),
-        productPackageQuantity: z
-          .number({ required_error: 'Package size is required' })
-          .gte(1),
-        minOrderQuantity: z
-          .number()
-          .gte(1)
-          .optional(),
-        productPackagePrice: z
-          .number()
-          .optional(),
-        // since this is a computed field we want to skip validation by setting it to any
-        eachPrice: z
-          .any()
-          .optional(),
-        contractPricePrice: z
-          .number()
-          .optional(),
-        contractPriceValidUntil: z
-          .coerce
-          .date()
-          .optional(),
-        tieredPricing: z
-          .boolean()
-          .optional(),
+        basicDetails: basicDetailsSchema,
+        additionalDetails: additionalDetailsSchema,
+        defaultPreferenceType: defaultPreferenceTypeSchema,
+        productSupplierPreferences: z.array(productSupplierPreferenceSchema),
+        packageSpecification: packageSpecificationSchema,
+        fixedPrice: fixedPriceSchema,
         attributes: z.object(attributesValidationSchema),
       });
   };

--- a/src/js/hooks/productSupplier/form/useProductSupplierValidation.js
+++ b/src/js/hooks/productSupplier/form/useProductSupplierValidation.js
@@ -20,6 +20,17 @@ const useProductSupplierValidation = () => {
       return groupedData[destinationParty?.id].length === 1;
     };
 
+    const requirePreferenceType = (subsectionData) => {
+      if (
+        subsectionData.validityStartDate
+        || subsectionData.validityEndDate
+        || subsectionData.bidName
+      ) {
+        return !!subsectionData.preferenceType;
+      }
+      return true;
+    };
+
     const attributesValidationSchema = attributes.reduce((acc, attribute) => {
       const errorProps = {
         required_error: `${attribute?.name} is required`,
@@ -116,7 +127,10 @@ const useProductSupplierValidation = () => {
       bidName: z
         .string()
         .optional(),
-    });
+    })
+      .refine(requirePreferenceType, {
+        message: 'Default preference type must also be selected', path: ['preferenceType'],
+      });
 
     const productSupplierPreferenceSchema = z.object({
       destinationParty: z.object({

--- a/src/js/hooks/productSupplier/form/useProductSupplierValidation.js
+++ b/src/js/hooks/productSupplier/form/useProductSupplierValidation.js
@@ -20,14 +20,18 @@ const useProductSupplierValidation = () => {
       return groupedData[destinationParty?.id].length === 1;
     };
 
-    const requirePreferenceType = (subsectionData) => {
+    // preferenceType field should be required
+    // when any other field on default preference type subsection is not empty
+    const checkPreferenceTypeIsRequired = (subsectionData) => {
       if (
         subsectionData.validityStartDate
         || subsectionData.validityEndDate
         || subsectionData.bidName
       ) {
-        return !!subsectionData.preferenceType;
+        // if any other field is not empty in preferenceType field should be required
+        return Boolean(subsectionData.preferenceType);
       }
+      // preferenceType field is valid if all other fields are empty
       return true;
     };
 
@@ -128,7 +132,7 @@ const useProductSupplierValidation = () => {
         .string()
         .optional(),
     })
-      .refine(requirePreferenceType, {
+      .refine(checkPreferenceTypeIsRequired, {
         message: 'Default preference type must also be selected', path: ['preferenceType'],
       });
 

--- a/src/js/utils/propTypes.js
+++ b/src/js/utils/propTypes.js
@@ -1,0 +1,6 @@
+import PropTypes from 'prop-types';
+
+// eslint-disable-next-line import/prefer-default-export
+export const FormErrorPropType = PropTypes.shape({
+  message: PropTypes.string,
+});


### PR DESCRIPTION
There is a bit of a refactor that I did on the validation schema that allowed me to add a custom `refine()` validation on the whole section.
Additionally, I believe that separating our validations schema into smaller subsections will be a lot more readable and maintainable. I believe we already talked about this and since there aren't any tickets that will have conflicts with these changes Id decided to proceed with this refactor.

**So what has changed?**
- I have split all of the fields in the validations schema into smaller subsections just like we have in the UI and imported them in the main schema
```jsx
 z
      .object({
        id: z
          .string()
          .optional(),
        basicDetails: basicDetailsSchema,
        additionalDetails: additionalDetailsSchema,
        defaultPreferenceType: defaultPreferenceTypeSchema,
        productSupplierPreferences: z.array(productSupplierPreferenceSchema),
        packageSpecification: packageSpecificationSchema,
        fixedPrice: fixedPriceSchema,
        attributes: z.object(attributesValidationSchema),
      });
```
- Because of these changes I have modified `getProductSource`, submitted payload and field name attributes accordingly.
- I have created a generic `FormErrorPropType` which is repeated in all of our error props.
- I have also decided to export the whole errors propType object from subsections and import it in the sections, to avoid any propType inconsistencies and code repetition when defining prop types.
- Modified onClear function for the date - it looks like we have to assign `undefined` instead of `null` because we have `.coerce.date()` defined on validation schema for date which parses `null` to some date value like `1970`
- I have also moved out logic for calculating each price into a separate hook `useCalculateEachPrice` which I believe will declutter the main sources form hook