### PR TITLE
OBPIH-6108 Trigger validation on default preference type clearing (Fixes after QA)

### DIFF
--- a/src/js/components/productSupplier/create/styles.scss
+++ b/src/js/components/productSupplier/create/styles.scss
@@ -60,6 +60,10 @@
   .rt-tbody {
     max-height: 275px;
   }
+
+  .input-wrapper-error-message {
+    min-height: unset;
+  }
 }
 
 .basic-details-active-switch {

--- a/src/js/components/productSupplier/create/subsections/AdditionalDetails.jsx
+++ b/src/js/components/productSupplier/create/subsections/AdditionalDetails.jsx
@@ -33,7 +33,7 @@ const AdditionalDetails = ({ control, errors }) => {
       title={{ label: 'react.productSupplier.form.subsection.additionalDetails', defaultMessage: 'Additional Details' }}
     >
       <div className="row">
-        <div className="col-lg-4 col-md-6 p-2">
+        <div className="col-lg-4 col-md-6 px-2 pt-2">
           <Controller
             name="additionalDetails.manufacturer"
             control={control}
@@ -50,7 +50,7 @@ const AdditionalDetails = ({ control, errors }) => {
             )}
           />
         </div>
-        <div className="col-lg-4 col-md-6 p-2">
+        <div className="col-lg-4 col-md-6 px-2 pt-2">
           <Controller
             name="additionalDetails.ratingTypeCode"
             control={control}
@@ -70,7 +70,7 @@ const AdditionalDetails = ({ control, errors }) => {
             )}
           />
         </div>
-        <div className="col-lg-4 col-md-6 p-2">
+        <div className="col-lg-4 col-md-6 px-2 pt-2">
           <Controller
             name="additionalDetails.manufacturerCode"
             control={control}
@@ -83,7 +83,7 @@ const AdditionalDetails = ({ control, errors }) => {
             )}
           />
         </div>
-        <div className="col-lg-4 col-md-6 p-2">
+        <div className="col-lg-4 col-md-6 px-2 pt-2">
           <Controller
             name="additionalDetails.brandName"
             control={control}

--- a/src/js/components/productSupplier/create/subsections/BasicDetails.jsx
+++ b/src/js/components/productSupplier/create/subsections/BasicDetails.jsx
@@ -32,7 +32,7 @@ const BasicDetails = ({ control, errors }) => {
       collapsable={false}
     >
       <div className="row">
-        <div className="col-lg-4 col-md-6 p-2">
+        <div className="col-lg-4 col-md-6 px-2 pt-2">
           <Controller
             name="basicDetails.code"
             control={control}
@@ -52,7 +52,7 @@ const BasicDetails = ({ control, errors }) => {
             )}
           />
         </div>
-        <div className="col-lg-4 col-md-6 p-2">
+        <div className="col-lg-4 col-md-6 px-2 pt-2">
           <Controller
             name="basicDetails.product"
             control={control}
@@ -79,7 +79,7 @@ const BasicDetails = ({ control, errors }) => {
             )}
           />
         </div>
-        <div className="col-lg-4 col-md-6 p-2">
+        <div className="col-lg-4 col-md-6 px-2 pt-2">
           <Controller
             name="basicDetails.legacyCode"
             control={control}
@@ -96,7 +96,7 @@ const BasicDetails = ({ control, errors }) => {
             )}
           />
         </div>
-        <div className="col-lg-4 col-md-6 p-2">
+        <div className="col-lg-4 col-md-6 px-2 pt-2">
           <Controller
             name="basicDetails.supplier"
             control={control}
@@ -115,7 +115,7 @@ const BasicDetails = ({ control, errors }) => {
             )}
           />
         </div>
-        <div className="col-lg-4 col-md-6 p-2">
+        <div className="col-lg-4 col-md-6 px-2 pt-2">
           <Controller
             name="basicDetails.supplierCode"
             control={control}
@@ -133,7 +133,7 @@ const BasicDetails = ({ control, errors }) => {
             )}
           />
         </div>
-        <div className="col-lg-4 col-md-6 p-2">
+        <div className="col-lg-4 col-md-6 px-2 pt-2">
           <Controller
             name="basicDetails.name"
             control={control}
@@ -151,7 +151,7 @@ const BasicDetails = ({ control, errors }) => {
             )}
           />
         </div>
-        <div className="col-lg-4 col-md-6 p-2">
+        <div className="col-lg-4 col-md-6 px-2 pt-2">
           <Controller
             name="basicDetails.dateCreated"
             control={control}
@@ -165,7 +165,7 @@ const BasicDetails = ({ control, errors }) => {
             )}
           />
         </div>
-        <div className="col-lg-4 col-md-6 p-2">
+        <div className="col-lg-4 col-md-6 px-2 pt-2">
           <Controller
             name="basicDetails.lastUpdated"
             control={control}
@@ -179,7 +179,7 @@ const BasicDetails = ({ control, errors }) => {
             )}
           />
         </div>
-        <div className="col-lg-4 col-md-6 p-2">
+        <div className="col-lg-4 col-md-6 px-2 pt-2">
           <Controller
             name="basicDetails.active"
             control={control}

--- a/src/js/components/productSupplier/create/subsections/DefaultPreferenceType.jsx
+++ b/src/js/components/productSupplier/create/subsections/DefaultPreferenceType.jsx
@@ -33,17 +33,18 @@ const DefaultPreferenceType = ({
 
   const emptyPreferenceType = {
     bidName: '',
-    validityStartDate: '',
-    validityEndDate: '',
+    validityStartDate: undefined,
+    validityEndDate: undefined,
     preferenceType: null,
-  };
-
-  const afterDelete = () => {
-    setValue('defaultPreferenceType', emptyPreferenceType);
   };
 
   const triggerValidationOnPreferenceType = () => {
     triggerValidation('defaultPreferenceType.preferenceType');
+  };
+
+  const afterDelete = () => {
+    setValue('defaultPreferenceType', emptyPreferenceType);
+    triggerValidationOnPreferenceType();
   };
 
   const {

--- a/src/js/components/productSupplier/create/subsections/DefaultPreferenceType.jsx
+++ b/src/js/components/productSupplier/create/subsections/DefaultPreferenceType.jsx
@@ -65,7 +65,7 @@ const DefaultPreferenceType = ({
       }}
     >
       <div className="row">
-        <div className="col-lg col-md-6 p-2">
+        <div className="col-lg col-md-6 px-2 pt-2">
           <Controller
             name="defaultPreferenceType.preferenceType"
             control={control}
@@ -88,7 +88,7 @@ const DefaultPreferenceType = ({
             )}
           />
         </div>
-        <div className="col-lg col-md-6 p-2">
+        <div className="col-lg col-md-6 px-2 pt-2">
           <Controller
             name="defaultPreferenceType.validityStartDate"
             control={control}
@@ -112,7 +112,7 @@ const DefaultPreferenceType = ({
             )}
           />
         </div>
-        <div className="col-lg col-md-6 p-2">
+        <div className="col-lg col-md-6 px-2 pt-2">
           <Controller
             name="defaultPreferenceType.validityEndDate"
             control={control}
@@ -162,6 +162,7 @@ const DefaultPreferenceType = ({
         </div>
         <div className="p-2 d-flex align-items-center">
           <Tooltip
+            className="d-flex align-items-center"
             html={(
               <span className="p-1">
                 <Translate
@@ -173,7 +174,7 @@ const DefaultPreferenceType = ({
           >
             <RiDeleteBinLine
               onClick={() => !isPreferenceTypeEmpty && openConfirmationModal()}
-              className={`preference-type-bin mt-3 ${isPreferenceTypeEmpty ? 'disabled' : 'active'}`}
+              className={`preference-type-bin ${isPreferenceTypeEmpty ? 'disabled' : 'active'}`}
             />
           </Tooltip>
         </div>

--- a/src/js/components/productSupplier/create/subsections/FixedPrice.jsx
+++ b/src/js/components/productSupplier/create/subsections/FixedPrice.jsx
@@ -18,7 +18,7 @@ const FixedPrice = ({ control, errors }) => (
     collapsable={false}
   >
     <div className="row">
-      <div className="col-lg-4 p-2">
+      <div className="col-lg-4 px-2 pt-2">
         <Controller
           name="fixedPrice.contractPricePrice"
           control={control}
@@ -40,7 +40,7 @@ const FixedPrice = ({ control, errors }) => (
           )}
         />
       </div>
-      <div className="col-lg-4 p-2">
+      <div className="col-lg-4 px-2 pt-2">
         <Controller
           name="fixedPrice.contractPriceValidUntil"
           control={control}
@@ -56,7 +56,7 @@ const FixedPrice = ({ control, errors }) => (
           )}
         />
       </div>
-      <div className="col-lg-4 p-2">
+      <div className="col-lg-4 px-2 pt-2">
         <Controller
           name="fixedPrice.tieredPricing"
           control={control}

--- a/src/js/components/productSupplier/create/subsections/PackageSpecification.jsx
+++ b/src/js/components/productSupplier/create/subsections/PackageSpecification.jsx
@@ -22,7 +22,7 @@ const PackageSpecification = ({ control, errors, setProductPackageQuantity }) =>
       collapsable={false}
     >
       <div className="row">
-        <div className="col-lg col-md-6 p-2">
+        <div className="col-lg col-md-6 px-2 pt-2">
           <Controller
             name="packageSpecification.uom"
             control={control}
@@ -50,7 +50,7 @@ const PackageSpecification = ({ control, errors, setProductPackageQuantity }) =>
             )}
           />
         </div>
-        <div className="col-lg col-md-6 p-2">
+        <div className="col-lg col-md-6 px-2 pt-2">
           <Controller
             name="packageSpecification.productPackageQuantity"
             control={control}
@@ -74,7 +74,7 @@ const PackageSpecification = ({ control, errors, setProductPackageQuantity }) =>
             )}
           />
         </div>
-        <div className="col-lg col-md-6 p-2">
+        <div className="col-lg col-md-6 px-2 pt-2">
           <Controller
             name="packageSpecification.minOrderQuantity"
             control={control}
@@ -96,7 +96,7 @@ const PackageSpecification = ({ control, errors, setProductPackageQuantity }) =>
             )}
           />
         </div>
-        <div className="col-lg col-md-6 p-2">
+        <div className="col-lg col-md-6 px-2 pt-2">
           <Controller
             name="packageSpecification.productPackagePrice"
             control={control}
@@ -118,7 +118,7 @@ const PackageSpecification = ({ control, errors, setProductPackageQuantity }) =>
             )}
           />
         </div>
-        <div className="col-lg col-md-6 p-2">
+        <div className="col-lg col-md-6 px-2 pt-2">
           <Controller
             name="packageSpecification.eachPrice"
             control={control}

--- a/src/js/hooks/productSupplier/form/useProductSupplierForm.js
+++ b/src/js/hooks/productSupplier/form/useProductSupplierForm.js
@@ -107,12 +107,14 @@ const useProductSupplierForm = () => {
       },
       attributes,
       defaultPreferenceType: {
-        ...defaultPreferenceType,
         preferenceType: !_.isEmpty(defaultPreferenceType) ? {
           id: defaultPreferenceType?.preferenceType?.id,
           label: defaultPreferenceType?.preferenceType?.name,
           value: defaultPreferenceType?.preferenceType?.id,
         } : undefined,
+        validityStartDate: defaultPreferenceType?.validityStartDate ?? undefined,
+        validityEndDate: defaultPreferenceType?.validityEndDate ?? undefined,
+        bidName: defaultPreferenceType?.bidName ?? undefined,
       },
     };
   };

--- a/src/js/hooks/productSupplier/form/useProductSupplierValidation.js
+++ b/src/js/hooks/productSupplier/form/useProductSupplierValidation.js
@@ -130,6 +130,7 @@ const useProductSupplierValidation = () => {
         .optional(),
       bidName: z
         .string()
+        .nullable()
         .optional(),
     })
       .refine(checkPreferenceTypeIsRequired, {

--- a/src/js/wrappers/style.scss
+++ b/src/js/wrappers/style.scss
@@ -41,6 +41,9 @@
   .input-wrapper-error-message {
     order: 2;
     color: var(--color-red);
+    font-size: 12px;
+    line-height: 18px;
+    min-height: 18px;
   }
 }
 


### PR DESCRIPTION
- trigger validation on preferrence type select when clearing default preference type subsection
- on edit page of product sources, assign `undefined` instead of `null` on **validityStartDate**, **validityEndDate** and **bidName** because API returns `null` and Zod parses `null` to some date value when using `coerce.date()` 
- fix padding on form inputs and prevent inputs from jumping when errors appear under inputs (I have added `minHeight` on error message to prevent this height change when error appears)