### PR TITLE
OBPIH-6253 Fixed regression on defaultProductPackage on show page and old list page

### DIFF
--- a/grails-app/views/product/_productSuppliers.gsp
+++ b/grails-app/views/product/_productSuppliers.gsp
@@ -46,7 +46,7 @@
 
                     <g:each var="productSupplier" in="${productInstance?.productSuppliers.findAll{ it.active }.sort()}" status="status">
 
-                        <g:set var="defaultProductPackage" value="${productSupplier.defaultProductPackage}"/>
+                        <g:set var="defaultProductPackage" value="${productSupplier.defaultProductPackageDerived}"/>
 
                         <tr class="prop ${status%2==0?'odd':'even'}">
                             <td>${fieldValue(bean: productSupplier, field: "code")?:g.message(code:'default.none.label')}</td>

--- a/grails-app/views/productSupplier/list.gsp
+++ b/grails-app/views/productSupplier/list.gsp
@@ -140,13 +140,13 @@
                                     </g:else>
                                 </td>
                                 <td>
-                                    <g:if test="${productSupplierInstance?.defaultProductPackage}">
-                                        ${fieldValue(bean: productSupplierInstance?.defaultProductPackage?.uom, field: "code")}/${fieldValue(bean: productSupplierInstance?.defaultProductPackage, field: "quantity")}
+                                    <g:if test="${productSupplierInstance?.defaultProductPackageDerived}">
+                                        ${fieldValue(bean: productSupplierInstance?.defaultProductPackageDerived?.uom, field: "code")}/${fieldValue(bean: productSupplierInstance?.defaultProductPackage, field: "quantity")}
                                     </g:if>
                                 </td>
                                 <td>
                                     <g:hasRoleFinance onAccessDenied="${g.message(code:'errors.blurred.message', args: [g.message(code:'default.none.label')])}">
-                                        ${g.formatNumber(number: productSupplierInstance?.defaultProductPackage?.productPrice?.price?:0.0)}
+                                        ${g.formatNumber(number: productSupplierInstance?.defaultProductPackageDerived?.productPrice?.price?:0.0)}
                                     </g:hasRoleFinance>
                                 </td>
                                 <td><g:checkBox onclick="return false;" value="${productSupplierInstance.active}" name="active"/></td>


### PR DESCRIPTION
I looked through the whole project and one other case where `defaultProductPackage` was used instead of `defaultProductPackageDerived` was on old sources list page.

I decided to also fix that because I am not sure about the future of these files, should they be deleted since we have a working react list page for sources already?