### PR TITLE
OBPIH-6249 Fix upload of documents to e-requests

### DIFF
--- a/src/main/groovy/org/pih/warehouse/api/StockMovement.groovy
+++ b/src/main/groovy/org/pih/warehouse/api/StockMovement.groovy
@@ -512,4 +512,17 @@ class StockMovement implements Validateable{
         // The requisition status has to be lower than PICKING (so comparing them will return -1)
         return requisition?.approvalRequired && origin?.approvalRequired && RequisitionStatus.compare(requisition.status, RequisitionStatus.PICKING) == -1
     }
+
+    // Function for checking if user in exact location can edit request
+    // (with required approval)
+    Boolean canUserEdit(String userId, Location location) {
+        User user = User.get(userId)
+        Boolean isUserRequestor = user.id == requestedBy?.id
+        Boolean isLocationOrigin = origin?.id == location?.id
+        Boolean isLocationDestination = destination?.id == location?.id
+        return (isUserRequestor &&
+                requisition?.status == RequisitionStatus.PENDING_APPROVAL &&
+                (isLocationDestination || isLocationOrigin)) ||
+                (requisition?.status == RequisitionStatus.APPROVED && isLocationOrigin)
+    }
 }


### PR DESCRIPTION
This method has been missing in the `StockMovement` dto. It has been available only in the `OutboundStockMovement`. The problem was, that when we access the SM show page from the list page, we access it via requisition id (OutboundStockMovement id). 
When we were uploading documents, we were redirected to the SM page, but using the **shipment's id**, hence we were evaluating some stuff from the `StockMovement` dto, not `OutboundStockMovement`, and since this method had been missing, we were getting an exception.