### PR TITLE
OBPIH-6253 source pricing not visible when adding new product source on placed PO (manual and import)

### DIFF
--- a/grails-app/services/org/pih/warehouse/order/OrderService.groovy
+++ b/grails-app/services/org/pih/warehouse/order/OrderService.groovy
@@ -867,6 +867,12 @@ class OrderService {
                     orderItem.budgetCode = budgetCode
 
                     order.addToOrderItems(orderItem)
+
+                    if (order.status >= OrderStatus.PLACED) {
+                        updateProductPackage(orderItem)
+                        updateProductUnitPrice(orderItem)
+                    }
+
                     count++
                 }
 

--- a/grails-app/services/org/pih/warehouse/order/OrderService.groovy
+++ b/grails-app/services/org/pih/warehouse/order/OrderService.groovy
@@ -636,23 +636,16 @@ class OrderService {
         BigDecimal packagePrice = orderItem.unitPrice * orderItem?.order?.lookupCurrentExchangeRate()
 
         // If there's no product package already or the existing one changed we create a new one (or update)
-        def uomChanged = orderItem.productPackage?.uom != orderItem.quantityUom
-        def quantityPerUomChanged = orderItem.productPackage?.quantity != orderItem.quantityPerUom
-        if (!orderItem.productPackage || uomChanged || quantityPerUomChanged) {
+        boolean uomChanged = orderItem.productPackage?.uom != orderItem.quantityUom
+        boolean quantityPerUomChanged = orderItem.productPackage?.quantity != orderItem.quantityPerUom
+        boolean productSupplierChanged = orderItem.productPackage?.productSupplier?.id != orderItem.productSupplier?.id
+
+        if (!orderItem.productPackage || productSupplierChanged || uomChanged || quantityPerUomChanged) {
             // Find an existing product package associated with a specific supplier
             ProductPackage productPackage = orderItem?.productSupplier?.productPackages.find { ProductPackage productPackage ->
                 return productPackage.product == orderItem.product &&
                         productPackage.uom == orderItem.quantityUom &&
                         productPackage.quantity == orderItem.quantityPerUom
-            }
-
-            // If not found, then we look for a product package associated with the product
-            if (!productPackage) {
-                productPackage = orderItem.product.packages.find { ProductPackage productPackage1 ->
-                    return productPackage1.product == orderItem.product &&
-                            productPackage1.uom == orderItem.quantityUom &&
-                            productPackage1.quantity == orderItem.quantityPerUom
-                }
             }
 
             // If we cannot find an existing product package, create a new one


### PR DESCRIPTION
The issue that was discovered during QA was that productPackage would not be updated when creating a new product source through manual edit or import on PLACED Purchase Order.

Few things I modified are:
first I added an additional condition on edit `productSupplierChanged` which just like other conditions checks if product Source of the orderItem is the same as the one provided by the package.

Then secondly, after investigating the whole workflow I cam to the conclusion that the chunck of code 
```groovy
// If not found, then we look for a product package associated with the product
if (!productPackage) {
    productPackage = orderItem.product.packages.find { ProductPackage productPackage1 ->
        return productPackage1.product == orderItem.product &&
                productPackage1.uom == orderItem.quantityUom &&
                productPackage1.quantity == orderItem.quantityPerUom
    }
}
```
is causing a bug which caused the product Package to be unassigned from older product source.
I noticed that **ProductPackage** and **ProductSource** have a `1:N` relationship where ProductPackage can only have one Product Source and a single Product source can have many product packages.

When executing anove code


and later
```groovy
orderItem.productSupplier.addToProductPackages(productPackage)

```

we are finding an existing productPackage that is assigned to some other product Source and we are now assigning this package to new Product source which will unassign it from the previous one. I assume this is not an expected behavior.

Lastly, I noticed that when importing `orderitems` we are not updating productPackage like we do on the manual create/edit so I added this chunk of code which in my opinion was missing.
```groovy
 if (order.status >= OrderStatus.PLACED) {
                      updateProductPackage(orderItem)
                      updateProductUnitPrice(orderItem)
                  }
```