### PR TITLE
OBPIH-6265 Fix issue with removing user roles while exporting a recei…

### DIFF
--- a/src/js/components/receiving/PartialReceivingPage.jsx
+++ b/src/js/components/receiving/PartialReceivingPage.jsx
@@ -759,6 +759,9 @@ class PartialReceivingPage extends Component {
         ...container,
         shipmentItems: container?.shipmentItems?.map?.((item) => _.omit(item, 'product.displayNames')),
       })),
+      recipient: {
+        id: values.recipient?.id,
+      },
     };
     apiClient.post(url, flattenRequest(valuesWithoutDisplayNames))
       .then((response) => {


### PR DESCRIPTION
…ving template

The issue was that we were sending a recipient with details, e.g. with roles, that was then bound via 
```groovy
// Bind the partial receipt
bindData(partialReceipt, jsonObject)
```
To fix that I just send the id of the recipient instead of its full representation. 
The tricky part was to understand why sometimes only a few roles are deleted and some are not - it's because we were sending the roles by its name, e.g. `ROLE_SUPERUSER`, and if a role's id is not equal to the name, then it is not bound.
In my case, it was `ROLE_REQUISITION_APPROVER` and `ROLE_PRODUCT_MANAGER` that had it also as the `id`, hence they were bound properly.