### PR TITLE
OBPIH-6324 Fix downloading the product synonyms import template

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
@@ -689,7 +689,7 @@ class ProductController {
      * Export Synonym Template Excel
      */
     def exportSynonymTemplate() {
-        List<Map> objects = [[]]
+        List<Map> objects = [new HashMap<>()]
         // return a template with filled in product code
         if (params.productCode) {
             objects = [ ['product': [ 'productCode': params.productCode ]] ]


### PR DESCRIPTION
The issue at first was difficult to spot, as the error had been throwing in the generic `transformObjects` method in the `DataService` and it is working fine on Grails 1.
It turned out, that this line:
```groovy
 List<Map> objects = [[]]
```
caused the problem, as the `transformObjects` method, and this particular line:
```groovy
value = object.get(element) ?: element.tokenize('.').inject(object) { v, k -> v?."$k" }
```
expects to run the `.get` method on a `Map`, not on a `List`. This variable is even declared as `List<Map>`, but the default value for that is `[[]]`, so "list inside the list", not map inside the list.

To fix that issue I just changed the `[]` to `new HashMap<>()`, not to refactor the generic method in the `transformObjects`, as in my opinion, it should also work when the list is empty, and it doesn't if I leave the `objects` as `List<Map> objects = []`.