### PR TITLE
OBPIH-5813 Items statuses before fulfilment - Approvals statuses

### DIFF
--- a/grails-app/domain/org/pih/warehouse/requisition/RequisitionItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/requisition/RequisitionItem.groovy
@@ -194,6 +194,37 @@ class RequisitionItem implements Comparable<RequisitionItem>, Serializable {
         }
     }
 
+    RequisitionItemStatus getDisplayStatus() {
+        if (isParentRequisitionPending()) {
+            return RequisitionItemStatus.PENDING
+        }
+
+        if (isParentRequisitionRejected()) {
+            return RequisitionItemStatus.CANCELED
+        }
+
+        if (isApproved() || parentRequisitionItem) {
+            return RequisitionItemStatus.APPROVED
+        }
+
+        if (isSubstituted()) {
+            return RequisitionItemStatus.SUBSTITUTED
+        }
+
+        if (isChanged()) {
+            return RequisitionItemStatus.CHANGED
+        }
+
+        if (isCanceled()) {
+            return RequisitionItemStatus.CANCELED
+        }
+
+        if (isCompleted()) {
+            return RequisitionItemStatus.COMPLETED
+        }
+
+        return RequisitionItemStatus.PENDING
+    }
 
     /**
      * We currently only support quantity change and substitution so there will be,
@@ -493,6 +524,13 @@ class RequisitionItem implements Comparable<RequisitionItem>, Serializable {
         return !(isApproved() || isSubstituted() || isChanged() || isCanceled())
     }
 
+    Boolean isParentRequisitionPending() {
+        return requisition.status in [RequisitionStatus.PENDING, RequisitionStatus.PENDING_APPROVAL]
+    }
+
+    Boolean isParentRequisitionRejected() {
+        return requisition.status == RequisitionStatus.REJECTED
+    }
 
     /**
      * @return true if this child requisition item's parent is canceled and the child product and product package is different from its parent

--- a/grails-app/domain/org/pih/warehouse/requisition/RequisitionItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/requisition/RequisitionItem.groovy
@@ -181,30 +181,6 @@ class RequisitionItem implements Comparable<RequisitionItem>, Serializable {
     def getStatus() {
         if (isApproved() || parentRequisitionItem) {
             return RequisitionItemStatus.APPROVED
-        } else if (isSubstituted()) {
-            return RequisitionItemStatus.SUBSTITUTED
-        } else if (isChanged()) {
-            return RequisitionItemStatus.CHANGED
-        } else if (isCanceled()) {
-            return RequisitionItemStatus.CANCELED
-        } else if (isCompleted()) {
-            return RequisitionItemStatus.COMPLETED
-        } else {
-            return RequisitionItemStatus.PENDING
-        }
-    }
-
-    RequisitionItemStatus getDisplayStatus() {
-        if (isParentRequisitionPending()) {
-            return RequisitionItemStatus.PENDING
-        }
-
-        if (isParentRequisitionRejected()) {
-            return RequisitionItemStatus.CANCELED
-        }
-
-        if (isApproved() || parentRequisitionItem) {
-            return RequisitionItemStatus.APPROVED
         }
 
         if (isSubstituted()) {
@@ -224,6 +200,18 @@ class RequisitionItem implements Comparable<RequisitionItem>, Serializable {
         }
 
         return RequisitionItemStatus.PENDING
+    }
+
+    RequisitionItemStatus getDisplayStatus() {
+        if (isParentRequisitionPending()) {
+            return RequisitionItemStatus.PENDING
+        }
+
+        if (isParentRequisitionRejected()) {
+            return RequisitionItemStatus.CANCELED
+        }
+
+        return getStatus()
     }
 
     /**

--- a/grails-app/views/requisition/_showRequisitionItem.gsp
+++ b/grails-app/views/requisition/_showRequisitionItem.gsp
@@ -44,7 +44,7 @@
                 <format:metadata obj="${requisitionItem?.requisition?.status}"/>
             </g:elseif>
             <g:else>
-                <format:metadata obj="${requisitionItem?.status}"/>
+                <format:metadata obj="${requisitionItem?.displayStatus}"/>
             </g:else>
         </div>
     </td>

--- a/src/test/groovy/unit/org/pih/warehouse/requisition/RequisitionItemSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/requisition/RequisitionItemSpec.groovy
@@ -59,8 +59,8 @@ class RequisitionItemSpec extends Specification implements DomainUnitTest<Requis
 
         where:
             quantity | quantityApproved || isApproved | status
-            2        | 2                || true | RequisitionItemStatus.APPROVED
-            1        | 0                || false | RequisitionItemStatus.PENDING
+            2        | 2                || true       | RequisitionItemStatus.APPROVED
+            1        | 0                || false      | RequisitionItemStatus.PENDING
     }
 
     void 'RequisitionItem.getDisplayStatus() should return: #status when item has child item and the quantity cancelled is #quantityCancelled and RequisitionItem.isChanged() is #isChanged'() {

--- a/src/test/groovy/unit/org/pih/warehouse/requisition/RequisitionItemSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/requisition/RequisitionItemSpec.groovy
@@ -1,0 +1,99 @@
+package unit.org.pih.warehouse.requisition
+
+import grails.testing.gorm.DomainUnitTest
+import org.pih.warehouse.product.Product
+import org.pih.warehouse.requisition.Requisition
+import org.pih.warehouse.requisition.RequisitionItem
+import org.pih.warehouse.requisition.RequisitionItemStatus
+import org.pih.warehouse.requisition.RequisitionItemType
+import org.pih.warehouse.requisition.RequisitionStatus
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class RequisitionItemSpec extends Specification implements DomainUnitTest<RequisitionItem> {
+
+    void 'RequisitionItem.getDisplayStatus() should return: #requisitionItemStatus for requisition status #requisitionStatus'() {
+        when:
+        domain.requisition = new Requisition()
+        domain.requisition.status = requisitionStatus
+
+        then:
+        domain.displayStatus == requisitionItemStatus
+
+        where:
+        requisitionItemStatus          || requisitionStatus
+        RequisitionItemStatus.PENDING  || RequisitionStatus.PENDING_APPROVAL
+        RequisitionItemStatus.PENDING  || RequisitionStatus.PENDING
+        RequisitionItemStatus.CANCELED || RequisitionStatus.REJECTED
+    }
+
+    void 'RequisitionItem.getDisplayStatus() should return: #status when at least one child item is type of #childItemType and RequisitionItem.isSubstituted() should return: #isSubstituted'() {
+        when:
+        RequisitionItem item = new RequisitionItem()
+        item.requisitionItemType = childItemType
+        domain.requisition = new Requisition()
+        domain.requisition.status = RequisitionStatus.CHECKING
+        domain.addToRequisitionItems(item)
+
+        then:
+        domain.isSubstituted() == isSubstituted
+        domain.displayStatus == status
+
+        where:
+        status                            || childItemType                    | isSubstituted
+        RequisitionItemStatus.SUBSTITUTED || RequisitionItemType.SUBSTITUTION | true
+        RequisitionItemStatus.PENDING     || null                             | false
+    }
+
+    void 'RequisitionItem.getDisplayStatus() should return: #status when qty is #quantity and the qty approved is #quantityApproved and RequisitionItem.isApproved() should return: #isApproved'() {
+        when:
+        domain.requisition = new Requisition()
+        domain.requisition.status = RequisitionStatus.CHECKING
+        domain.quantity = quantity
+        domain.quantityApproved = quantityApproved
+
+        then:
+        domain.isApproved() == isApproved
+        domain.displayStatus == status
+
+        where:
+        status                         || quantity | quantityApproved | isApproved
+        RequisitionItemStatus.APPROVED || 2        | 2                | true
+        RequisitionItemStatus.PENDING  || 1        | 0                | false
+    }
+
+    void 'RequisitionItem.getDisplayStatus() should return: #status when item has child item and the quantity cancelled is #quantityCancelled and RequisitionItem.isChanged() is #isChanged'() {
+        when:
+        domain.requisition = new Requisition()
+        domain.requisition.status = RequisitionStatus.CHECKING
+        domain.quantityCanceled = quantityCancelled
+        domain.modificationItem = new RequisitionItem()
+
+        then:
+        domain.isChanged() == isChanged
+        domain.displayStatus == status
+
+        where:
+        status                        || quantityCancelled | isChanged
+        RequisitionItemStatus.CHANGED || 1                 | true
+        RequisitionItemStatus.PENDING || 0                 | false
+    }
+
+    void 'RequisitionItem.getDisplayStatus() should return: #status when item has quantity cancelled #quantityCancelled and quantity #quantity and RequisitionItem.isCancelled() is #isCancelled'() {
+        when:
+            domain.requisition = new Requisition()
+            domain.requisition.status = RequisitionStatus.CHECKING
+            domain.quantityCanceled = quantityCancelled
+            domain.quantity = quantity
+
+        then:
+            domain.isCanceled() == isCancelled
+            domain.displayStatus == status
+
+        where:
+            status                          || quantity | quantityCancelled | isCancelled
+            RequisitionItemStatus.CANCELED  || 1        | 1                 | true
+            RequisitionItemStatus.PENDING   || 2        | 1                 | false
+    }
+}

--- a/src/test/groovy/unit/org/pih/warehouse/requisition/RequisitionItemSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/requisition/RequisitionItemSpec.groovy
@@ -14,86 +14,86 @@ import spock.lang.Unroll
 class RequisitionItemSpec extends Specification implements DomainUnitTest<RequisitionItem> {
 
     void 'RequisitionItem.getDisplayStatus() should return: #requisitionItemStatus for requisition status #requisitionStatus'() {
-        when:
-        domain.requisition = new Requisition()
-        domain.requisition.status = requisitionStatus
+        given:
+            domain.requisition = new Requisition()
+            domain.requisition.status = requisitionStatus
 
-        then:
-        domain.displayStatus == requisitionItemStatus
+        expect:
+            domain.displayStatus == requisitionItemStatus
 
         where:
-        requisitionItemStatus          || requisitionStatus
-        RequisitionItemStatus.PENDING  || RequisitionStatus.PENDING_APPROVAL
-        RequisitionItemStatus.PENDING  || RequisitionStatus.PENDING
-        RequisitionItemStatus.CANCELED || RequisitionStatus.REJECTED
+            requisitionStatus                   || requisitionItemStatus
+            RequisitionStatus.PENDING_APPROVAL  || RequisitionItemStatus.PENDING
+            RequisitionStatus.PENDING           || RequisitionItemStatus.PENDING
+            RequisitionStatus.REJECTED          || RequisitionItemStatus.CANCELED
     }
 
     void 'RequisitionItem.getDisplayStatus() should return: #status when at least one child item is type of #childItemType and RequisitionItem.isSubstituted() should return: #isSubstituted'() {
-        when:
-        RequisitionItem item = new RequisitionItem()
-        item.requisitionItemType = childItemType
-        domain.requisition = new Requisition()
-        domain.requisition.status = RequisitionStatus.CHECKING
-        domain.addToRequisitionItems(item)
+        given:
+            RequisitionItem item = new RequisitionItem()
+            item.requisitionItemType = childItemType
+            domain.requisition = new Requisition()
+            domain.requisition.status = RequisitionStatus.CHECKING
+            domain.addToRequisitionItems(item)
 
-        then:
-        domain.isSubstituted() == isSubstituted
-        domain.displayStatus == status
+        expect:
+            domain.isSubstituted() == isSubstituted
+            domain.displayStatus == status
 
         where:
-        status                            || childItemType                    | isSubstituted
-        RequisitionItemStatus.SUBSTITUTED || RequisitionItemType.SUBSTITUTION | true
-        RequisitionItemStatus.PENDING     || null                             | false
+            childItemType                    || isSubstituted | status
+            RequisitionItemType.SUBSTITUTION || true          | RequisitionItemStatus.SUBSTITUTED
+            null                             || false         | RequisitionItemStatus.PENDING
     }
 
     void 'RequisitionItem.getDisplayStatus() should return: #status when qty is #quantity and the qty approved is #quantityApproved and RequisitionItem.isApproved() should return: #isApproved'() {
-        when:
-        domain.requisition = new Requisition()
-        domain.requisition.status = RequisitionStatus.CHECKING
-        domain.quantity = quantity
-        domain.quantityApproved = quantityApproved
+        given:
+            domain.requisition = new Requisition()
+            domain.requisition.status = RequisitionStatus.CHECKING
+            domain.quantity = quantity
+            domain.quantityApproved = quantityApproved
 
-        then:
-        domain.isApproved() == isApproved
-        domain.displayStatus == status
+        expect:
+            domain.isApproved() == isApproved
+            domain.displayStatus == status
 
         where:
-        status                         || quantity | quantityApproved | isApproved
-        RequisitionItemStatus.APPROVED || 2        | 2                | true
-        RequisitionItemStatus.PENDING  || 1        | 0                | false
+            quantity | quantityApproved || isApproved | status
+            2        | 2                || true | RequisitionItemStatus.APPROVED
+            1        | 0                || false | RequisitionItemStatus.PENDING
     }
 
     void 'RequisitionItem.getDisplayStatus() should return: #status when item has child item and the quantity cancelled is #quantityCancelled and RequisitionItem.isChanged() is #isChanged'() {
-        when:
-        domain.requisition = new Requisition()
-        domain.requisition.status = RequisitionStatus.CHECKING
-        domain.quantityCanceled = quantityCancelled
-        domain.modificationItem = new RequisitionItem()
+        given:
+            domain.requisition = new Requisition()
+            domain.requisition.status = RequisitionStatus.CHECKING
+            domain.quantityCanceled = quantityCancelled
+            domain.modificationItem = new RequisitionItem()
 
-        then:
-        domain.isChanged() == isChanged
-        domain.displayStatus == status
+        expect:
+            domain.isChanged() == isChanged
+            domain.displayStatus == status
 
         where:
-        status                        || quantityCancelled | isChanged
-        RequisitionItemStatus.CHANGED || 1                 | true
-        RequisitionItemStatus.PENDING || 0                 | false
+            quantityCancelled || isChanged | status
+            1                 || true      | RequisitionItemStatus.CHANGED
+            0                 || false     | RequisitionItemStatus.PENDING
     }
 
     void 'RequisitionItem.getDisplayStatus() should return: #status when item has quantity cancelled #quantityCancelled and quantity #quantity and RequisitionItem.isCancelled() is #isCancelled'() {
-        when:
+        given:
             domain.requisition = new Requisition()
             domain.requisition.status = RequisitionStatus.CHECKING
             domain.quantityCanceled = quantityCancelled
             domain.quantity = quantity
 
-        then:
+        expect:
             domain.isCanceled() == isCancelled
             domain.displayStatus == status
 
         where:
-            status                          || quantity | quantityCancelled | isCancelled
-            RequisitionItemStatus.CANCELED  || 1        | 1                 | true
-            RequisitionItemStatus.PENDING   || 2        | 1                 | false
+            quantity | quantityCancelled || isCancelled | status
+            1        | 1                 || true        | RequisitionItemStatus.CANCELED
+            2        | 1                 || false       | RequisitionItemStatus.PENDING
     }
 }


### PR DESCRIPTION
I decided to avoid modifying the original function for getting statuses because it can introduce regression (as I saw it was in calculating line items in requisition, in this case, we based on our previous "APPROVED" status)