### PR TITLE
OBPIH-6153 Fix assigning bidirectional association between Picklist a…

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -1299,6 +1299,7 @@ class StockMovementService {
         if (!picklist) {
             picklist = new Picklist()
             picklist.requisition = requisition
+            requisition.picklist = picklist
         }
 
         // If one does not exist create it and add it to the list


### PR DESCRIPTION
…nd Requisition

TL:DR - we've been living with this bug forever, but it has not been yet noticed, because we have not returned the `picklist` in the `toJson` of the `StockMovement`, that I've added recently.
The problem is that the 1:1 association between requisition and picklist has been missing one part - we set the requisition for the picklist, but we don't set the picklist for the requisition - that caused an issue that when serializing the stock movement (in toJson), the requisition's picklist is in fact `null`.
The missing association is obviously detected and added automatically by Hibernate, but after the session is closed, so after refreshing the page and re-fetching the SM, everything works correctly, because the association is added, but it didn't work (picklist was treated as null) when returning the SM from the initial request. 

If anyone is interested in details of that issue, let me know, so I can explain it in more details or record a video with the debugger, but I hope it is kinda self-explanatory. 