### PR TITLE
OBPIH-6388 github action for autogenerating release notes on new tag

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+# Specifies the format of GitHub's auto-generated release notes
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+
+  categories:
+    - title: 🚀 Features
+      labels:
+        - 'type:feature'
+
+    - title: 🐛 Bugfixes
+      labels:
+        - 'type:bug'
+
+    - title: 🛠️ Maintenance
+      labels:
+        - 'type:maintenance'
+
+    - title: 🎈 Miscellaneous
+      labels:
+        - '*'

--- a/.github/templates/release-notes-template.md
+++ b/.github/templates/release-notes-template.md
@@ -1,0 +1,7 @@
+## Release Notes 📓
+
+Add a link to the release notes document or community post here
+
+## What's Changed 🚀
+
+List our JIRA tickets for the release here as per: https://docs.openboxes.com/en/develop/developer-guide/release/document/

--- a/.github/templates/release-notes-template.md
+++ b/.github/templates/release-notes-template.md
@@ -1,7 +1,3 @@
-## Release Notes 📓
+## Release Notes
 
-Add a link to the release notes document or community post here
-
-## What's Changed 🚀
-
-List our JIRA tickets for the release here as per: https://docs.openboxes.com/en/develop/developer-guide/release/document/
+https://community.openboxes.com/c/announcements/

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -1,7 +1,6 @@
 name: Build and Publish Release
 
 on:
-
   # We want releases to be triggered automatically whenever we push a new tag that starts with vX.Y.Z
   push:
     tags:
@@ -36,33 +35,17 @@ jobs:
         with:
           java-version: ${{env.JAVA_VERSION}}
           distribution: zulu
-
-      - name: Cache gradle
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      # TODO: Remove the "-unit" once we use test containers in our integration tests.
-      - name: Run all tests
-        run: ./grailsw test-app -unit --no-daemon
+          cache: 'gradle'
 
       - name: Build WAR file
-        run: ./grailsw war --info --no-daemon --plain-output
+        run: ./grailsw war --info --no-daemon
 
-      # Takes the artifacts generated from the build and creates a release. Releases only contain the most
-      # recently uploaded artifacts for that version, so old artifacts of the same version will be removed.
-      # This avoids confusion about which artifacts should be used when deploying any given version.
-      - uses: ncipollo/release-action@v1
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
         with:
           name: Release ${{env.TAG_NAME}}
-          tag: ${{env.TAG_NAME}}
-          artifacts: ./build/libs/openboxes.war
-          artifactContentType: application/java-archive
-          artifactErrorsFailBuild: true
-          bodyFile: ./.github/release-notes-template.md
-          replacesArtifacts: true
-          allowUpdates: true
-          generateReleaseNotes: true  # Adds the "Full Changelog" line at the end of the release notes.
+          tag_name: ${{env.TAG_NAME}}
+          files: ./build/libs/openboxes.war
+          fail_on_unmatched_files: true
+          body_path: ./.github/release-notes-template.md
+          generate_release_notes: true  # Adds GitHub's auto-generated release notes from release.yml

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -1,0 +1,68 @@
+name: Build and Publish Release
+
+on:
+
+  # We want releases to be triggered automatically whenever we push a new tag that starts with vX.Y.Z
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+**'
+
+  # And let us trigger this manually if we ever need to.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The tag associated with the release
+        required: true
+        default: v0.0.0
+
+env:
+  JAVA_VERSION: 8
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  TAG_NAME: ${{ (contains(github.ref, 'tag') && github.ref_name) || github.event.inputs.tag }}
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # Needed for publishing the release
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{env.JAVA_VERSION}}
+          distribution: zulu
+
+      - name: Cache gradle
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      # TODO: Remove the "-unit" once we use test containers in our integration tests.
+      - name: Run all tests
+        run: ./grailsw test-app -unit --no-daemon
+
+      - name: Build WAR file
+        run: ./grailsw war --info --no-daemon --plain-output
+
+      # Takes the artifacts generated from the build and creates a release. Releases only contain the most
+      # recently uploaded artifacts for that version, so old artifacts of the same version will be removed.
+      # This avoids confusion about which artifacts should be used when deploying any given version.
+      - uses: ncipollo/release-action@v1
+        with:
+          name: Release ${{env.TAG_NAME}}
+          tag: ${{env.TAG_NAME}}
+          artifacts: ./build/libs/openboxes.war
+          artifactContentType: application/java-archive
+          artifactErrorsFailBuild: true
+          bodyFile: ./.github/release-notes-template.md
+          replacesArtifacts: true
+          allowUpdates: true
+          generateReleaseNotes: true  # Adds the "Full Changelog" line at the end of the release notes.


### PR DESCRIPTION
JIRA Ticket: https://pihemr.atlassian.net/browse/OBPIH-6388

Discovery Document: https://pihemr.atlassian.net/wiki/spaces/OB/pages/3056828417/DISCOVERY%3A+OBPIH-6388+Investigate+new+CI+solution

Adds a new GitHub Action that auto-generates the release notes whenever a new tag is pushed to the repo.

Notes:
- only runs if the tag starts with "vX.Y.Z" (Ex: 0.9.2, 0.9.2-hotfix...)
- The action can also be run manually in case it fails for any reason.
- If the job is re-run, it will replace the existing artifacts in the release

An example of running the Action manually:
![Screenshot from 2024-05-20 20-05-49](https://github.com/openboxes/openboxes/assets/6844376/b08e740d-fa94-4a49-adac-a24bc2a1ede8)

The release notes that are auto-generated once the action completes:
![Screenshot from 2024-05-20 19-16-12](https://github.com/openboxes/openboxes/assets/6844376/37aaa380-1b53-49d8-904c-a9fc92a560d9)
