### PR TITLE
OBPIH-6422 Change the placement of crowdin's login modal

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -1606,3 +1606,7 @@ div.search-input:focus-within {
 .resizable-false {
   resize: none;
 }
+
+.jipt-login-dialog {
+  inset: 0 auto 0 !important;
+}


### PR DESCRIPTION
Since there are some random behaviors in the placement of the crowdin modal, I've overwritten the style that is responsible for that behavior and made the crowdin modal always appear in the same place.

![Screenshot from 2024-05-27 12-43-40](https://github.com/openboxes/openboxes/assets/93163821/db193f56-9bcf-418f-9cb7-d1e765fad707)

