### PR TITLE
OBPIH-6387 Run MySQL in a testcontainer for integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -753,13 +753,10 @@ dependencies {
     compile 'org.yaml:snakeyaml:1.33'
     console 'org.yaml:snakeyaml:1.33'
 
-    // testcontainers
-    // included to avoid a dependency conflict with another dependency
-    testCompile 'org.apache.commons:commons-compress:1.21'
+    // For integration tests
+    testCompile 'org.apache.commons:commons-compress:1.21'  // Needed to avoid a dependency conflict
     testCompile "org.testcontainers:mysql:1.17.3"
     testCompile "org.testcontainers:spock:1.17.3"
-
-    // For integration tests
     testCompile 'org.springframework:spring-test'
     testCompile 'io.rest-assured:rest-assured:3.2.0'
     testCompile "org.grails.plugins:build-test-data:3.3.1"

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -269,9 +269,9 @@ environments:
             logAbandoned: true
             logSql: false
             logSlowQueries: false
-            username: "openboxes"
-            password: "openboxes"
-            url: jdbc:tc:mysql:///openboxes?serverTimezone=UTC&useSSL=false  # https://java.testcontainers.org/modules/databases/jdbc/
+            # https://java.testcontainers.org/modules/databases/jdbc/
+            # Note that testcontainers auto-disable SSL when connecting via jdbc https://github.com/testcontainers/testcontainers-java/pull/561
+            url: jdbc:tc:mysql:5.7.44:///openboxes?TC_MY_CNF=testcontainers
             driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
     production:
         dataSource:

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -271,7 +271,8 @@ environments:
             logSlowQueries: false
             username: "openboxes"
             password: "openboxes"
-            url: jdbc:mysql://localhost:3306/openboxes?serverTimezone=UTC&useSSL=false
+            url: jdbc:tc:mysql:///openboxes?serverTimezone=UTC&useSSL=false  # https://java.testcontainers.org/modules/databases/jdbc/
+            driverClassName: org.testcontainers.jdbc.ContainerDatabaseDriver
     production:
         dataSource:
             dumpQueriesOnException: false

--- a/src/integration-test/groovy/org/pih/warehouse/component/base/ApiSpec.groovy
+++ b/src/integration-test/groovy/org/pih/warehouse/component/base/ApiSpec.groovy
@@ -40,9 +40,6 @@ import org.pih.warehouse.util.common.ResponseSpecUtil
  * As such, it's important to note that tests do *not* automatically cleanup their data. While we should try to add a
  * clean up step to our test suites, it's not enforceable that this actually happens, and so tests should always assume
  * the database is in a dirty state before running.
- *
- * This will hopefully become simpler once we introduce testcontainers, where we can more easily bring the db to
- * a clean, known state for each test.
  */
 @Integration
 abstract class ApiSpec extends Specification implements TestDataBuilder {

--- a/src/test/resources/testcontainers/my.cnf
+++ b/src/test/resources/testcontainers/my.cnf
@@ -1,0 +1,7 @@
+# https://java.testcontainers.org/modules/databases/mysql/
+# Used to specify a custom config when starting up the testcontainers db for integration tests. We do this to
+# ensure our test environment settings match what we have in production. testcontainers use the following default values:
+# https://github.com/testcontainers/testcontainers-java/blob/main/modules/mysql/src/main/resources/mysql-default-conf/my.cnf
+
+[mysqld]
+default-time-zone = "UTC"


### PR DESCRIPTION
The bulk of the leg work to get testcontainers set up was done by Justin, this is just to actually hook it up.

There's two methods of wiring up the test database to use testcontainers. You can do it directly via jdbc url, or via annotations. I chose via url because it's the smallest change, it automatically picks up the db config we have set in application.yml, and it immediately applies to all integration tests without issue.

More info here: https://java.testcontainers.org/modules/databases/jdbc/

If we wanted to do it the annotation way, it'd look something like this:

```
@Testcontainers
class Test extends Specification {

    @Shared // Marking it shared allows us to preserve the database across tests.
    MySQLContainer mySQLContainer = new MySQLContainer(DockerImageName.parse("mysql:5.7"))
            .withLogConsumer(new Slf4jLogConsumer(logger))
            .withDatabaseName('openboxes')
            .withUsername('openboxes')
            .withPassword('openboxes')

    void setupSpec() {
        mySQLContainer.start()
        assert mySQLContainer.isCreated()
        assert mySQLContainer.isRunning()
    }

    void cleanupSpec() {
        mySQLContainer.stop()
    }
}
```