### PR TITLE
OBPIH-6328 Dashboard indicator for items with backdated shipments (disable string truncation)

### DIFF
--- a/grails-app/conf/runtime.groovy
+++ b/grails-app/conf/runtime.groovy
@@ -1148,7 +1148,7 @@ openboxes {
                     }
                 }
                 columnsSize {
-                    name = '100px'
+                    name = 'auto'
                 }
                 truncationLength {
                     value = 100

--- a/grails-app/conf/runtime.groovy
+++ b/grails-app/conf/runtime.groovy
@@ -1141,10 +1141,10 @@ openboxes {
                 endpoint = "/api/dashboard/itemsWithBackdatedShipments"
                 colors {
                     datasets {
-                        state5 = ["first"]
-                        state4 = ["second"]
-                        state3 = ["third"]
-                        state2 = ["fourth"]
+                        state3 = ["first"]
+                        state5 = ["second"]
+                        state1 = ["third"]
+                        state9 = ["fourth"]
                     }
                 }
                 columnsSize {

--- a/grails-app/conf/runtime.groovy
+++ b/grails-app/conf/runtime.groovy
@@ -1154,6 +1154,9 @@ openboxes {
                     value = 100
                     number = 5
                 }
+                disableTruncation {
+                    name = true
+                }
             }
         }
     }

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -3135,6 +3135,14 @@ dataImport.label=Data Import
 dataMigration.label=Data Migration
 email.label=Email
 
+# Indicator
+indicator.itemsWithBackdatedShipments.shipment.subtitle={0} shipment
+indicator.itemsWithBackdatedShipments.shipments.subtitle={0} shipments
+indicator.itemsWithBackdatedShipments.moreShipment.subtitle={0} or more
+indicator.itemsWithBackdatedShipments.item.label=Item
+indicator.itemsWithBackdatedShipments.shipments.label=Shipments
+indicator.itemsWithBackdatedShipments.lastCount.label=Last Count
+
 #React
 react.default.yes.label=Yes
 react.default.no.label=No

--- a/grails-app/services/org/pih/warehouse/dashboard/IndicatorDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/dashboard/IndicatorDataService.groovy
@@ -1249,7 +1249,7 @@ class IndicatorDataService {
         ColorNumber oneDelayedShipment = new ColorNumber(value: amountOfItemsWithBackdatedShipments[Constants.ONE], subtitle: '1 shipment', order: 1)
         ColorNumber twoDelayedShipments = new ColorNumber(value: amountOfItemsWithBackdatedShipments[Constants.TWO], subtitle: '2 shipments', order: 2)
         ColorNumber threeDelayedShipments = new ColorNumber(value: amountOfItemsWithBackdatedShipments[Constants.THREE], subtitle: '3 shipments', order: 3)
-        ColorNumber fourOrMoreDelayedShipments = new ColorNumber(value: amountOfItemsWithBackdatedShipments[Constants.FOUR_OR_MORE], subtitle: '4 or more shipments', order: 4)
+        ColorNumber fourOrMoreDelayedShipments = new ColorNumber(value: amountOfItemsWithBackdatedShipments[Constants.FOUR_OR_MORE], subtitle: '4 or more', order: 4)
 
         NumbersIndicator numbersIndicator = new NumbersIndicator(
                 oneDelayedShipment,

--- a/grails-app/services/org/pih/warehouse/dashboard/IndicatorDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/dashboard/IndicatorDataService.groovy
@@ -36,6 +36,10 @@ class IndicatorDataService {
     GrailsApplication grailsApplication
     def messageService
 
+    ApplicationTagLib getApplicationTagLib() {
+        return Holders.grailsApplication.mainContext.getBean(ApplicationTagLib)
+    }
+
     @Cacheable(value = "dashboardCache", key = { "getExpirationSummaryData-${location?.id}${params?.querySize}" })
     Map getExpirationSummaryData(Location location, def params) {
         // querySize = value of the date filter (1 month, 3 months, etc.)
@@ -1244,12 +1248,49 @@ class IndicatorDataService {
             amountOfItemsWithBackdatedShipments[it[1] as String] += 1
         }
 
-        Table table = new Table("Item", "Shipments", "Last Count", tableData.toList())
+        Table table = new Table(
+                applicationTagLib.message(code: 'indicator.itemsWithBackdatedShipments.item.label', default: 'Item'),
+                applicationTagLib.message(code: 'indicator.itemsWithBackdatedShipments.shipments.label', default: 'Shipments'),
+                applicationTagLib.message(code: 'indicator.itemsWithBackdatedShipments.lastCount.label', default: 'Last Count'),
+                tableData.toList()
+        )
 
-        ColorNumber oneDelayedShipment = new ColorNumber(value: amountOfItemsWithBackdatedShipments[Constants.ONE], subtitle: '1 shipment', order: 1)
-        ColorNumber twoDelayedShipments = new ColorNumber(value: amountOfItemsWithBackdatedShipments[Constants.TWO], subtitle: '2 shipments', order: 2)
-        ColorNumber threeDelayedShipments = new ColorNumber(value: amountOfItemsWithBackdatedShipments[Constants.THREE], subtitle: '3 shipments', order: 3)
-        ColorNumber fourOrMoreDelayedShipments = new ColorNumber(value: amountOfItemsWithBackdatedShipments[Constants.FOUR_OR_MORE], subtitle: '4 or more', order: 4)
+        ColorNumber oneDelayedShipment = new ColorNumber(
+                value: amountOfItemsWithBackdatedShipments[Constants.ONE],
+                subtitle: applicationTagLib.message(
+                        code: 'indicator.itemsWithBackdatedShipments.shipment.subtitle',
+                        default: '1 shipment',
+                        args: ['1']
+                ),
+                order: 1
+        )
+        ColorNumber twoDelayedShipments = new ColorNumber(
+                value: amountOfItemsWithBackdatedShipments[Constants.TWO],
+                subtitle: applicationTagLib.message(
+                        code: 'indicator.itemsWithBackdatedShipments.shipments.subtitle',
+                        default:'2 shipments',
+                        args: ['2']
+                ),
+                order: 2
+        )
+        ColorNumber threeDelayedShipments = new ColorNumber(
+                value: amountOfItemsWithBackdatedShipments[Constants.THREE],
+                subtitle: applicationTagLib.message(
+                        code: 'indicator.itemsWithBackdatedShipments.shipments.subtitle',
+                        default: '3 shipments',
+                        args: [3]
+                ),
+                order: 3
+        )
+        ColorNumber fourOrMoreDelayedShipments = new ColorNumber(
+                value: amountOfItemsWithBackdatedShipments[Constants.FOUR_OR_MORE],
+                subtitle: applicationTagLib.message(
+                        code: 'indicator.itemsWithBackdatedShipments.moreShipment.subtitle',
+                        default: '4 or more',
+                        args: ['4']
+                ),
+                order: 4
+        )
 
         NumbersIndicator numbersIndicator = new NumbersIndicator(
                 oneDelayedShipment,

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -308,6 +308,7 @@ function fetchGraphIndicator(
           colors: indicatorConfig.colors,
           columnsSize: indicatorConfig.columnsSize,
           truncationLength: indicatorConfig.truncationLength,
+          disableTruncation: indicatorConfig.disableTruncation,
         },
         size: indicatorConfig.size,
       },

--- a/src/js/components/dashboard/ColorPalette.scss
+++ b/src/js/components/dashboard/ColorPalette.scss
@@ -24,6 +24,7 @@ $state-5 : #0288d1;
 $state-6 : #303f9f;
 $state-7 : #7b1fa2;
 $state-8 : #b80d57;
+$state-9 : var(--color-red);
 
 $dark-state-1 : #e65100;
 $dark-state-2 : #bc5b10;
@@ -79,6 +80,7 @@ $light-error : #ef5350;
   state6: $state-6;
   state7: $state-7;
   state8: $state-8;
+  state9: $state-9;
 
   darkState1: $dark-state-1;
   darkState2: $dark-state-2;

--- a/src/js/components/dashboard/Dashboard.scss
+++ b/src/js/components/dashboard/Dashboard.scss
@@ -508,6 +508,10 @@
           overflow-wrap: anywhere;
         }
 
+        .last {
+          text-wrap: nowrap;
+        }
+
         td,
         th {
           border-bottom: 1px solid #dddddd;
@@ -681,6 +685,10 @@
 
   .indicator-item-href {
     color: inherit;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 
   .disabled-indicator-item-href {

--- a/src/js/components/dashboard/Dashboard.scss
+++ b/src/js/components/dashboard/Dashboard.scss
@@ -678,6 +678,16 @@
       }
     }
   }
+
+  .indicator-item-href {
+    color: inherit;
+  }
+
+  .disabled-indicator-item-href {
+    color: inherit;
+    pointer-events: none;
+    cursor: default;
+  }
 }
 
 @media (min-width: 460px) {

--- a/src/js/components/dashboard/NumbersTableCard.jsx
+++ b/src/js/components/dashboard/NumbersTableCard.jsx
@@ -15,6 +15,7 @@ const NumbersTableCard = props => (
         data={props.data.tableData}
         columnsSize={props.options.columnsSize}
         truncationLength={props.options.truncationLength}
+        disableTruncation={props.options.disableTruncation}
       />
     </div>
   </div>
@@ -56,6 +57,11 @@ NumbersTableCard.propTypes = {
       name: PropTypes.number,
       number: PropTypes.number,
       value: PropTypes.number,
+    }),
+    disableTruncation: PropTypes.shape({
+      name: PropTypes.bool,
+      number: PropTypes.bool,
+      value: PropTypes.bool,
     }),
   }).isRequired,
 };

--- a/src/js/components/dashboard/TableCard.jsx
+++ b/src/js/components/dashboard/TableCard.jsx
@@ -4,7 +4,44 @@ import PropTypes from 'prop-types';
 
 /* global _ */
 const TableCard = (props) => {
-  const { columnsSize, truncationLength, disableTruncation } = props;
+  const {
+    columnsSize,
+    truncationLength,
+    disableTruncation,
+    data,
+  } = props;
+
+  const displayItemData = ({
+    truncate,
+    item,
+    link,
+    defaultTruncationLength,
+  }) => (
+    <a
+      href={link}
+      className={link ? 'indicator-item-href' : 'disabled-indicator-item-href'}
+      rel="noreferrer"
+      target="_blank"
+    >
+      {!truncate ? item : _.truncate(item, {
+        length: truncationLength ?? defaultTruncationLength,
+      })}
+    </a>
+  );
+
+  const displayListItemsData = (items, links) =>
+    items?.map((item, index) => (
+      <a
+        href={links[index]}
+        className="indicator-item-href"
+        rel="noreferrer"
+        target="_blank"
+      >
+        {item}
+        {' '}
+        <br />
+      </a>
+    ));
 
   return (
     <div className="table-card">
@@ -12,19 +49,19 @@ const TableCard = (props) => {
         <thead>
           <tr>
             <th style={{ width: columnsSize?.number }}>
-              {props.data.number}
+              {data.number}
             </th>
-            { props.data.body.find((item) => item.icon) ? <td /> : null }
+            {data.body.find((item) => item.icon) ? <td /> : null }
             <th style={{ width: columnsSize?.name }} className="mid">
-              {_.truncate(props.data.name, { length: 50 })}
+              {_.truncate(data.name, { length: 50 })}
             </th>
             <th style={{ width: columnsSize?.value }}>
-              {_.truncate(props.data.value, { length: 50 })}
+              {_.truncate(data.value, { length: 50 })}
             </th>
           </tr>
         </thead>
         <tbody>
-          {props.data.body.map((item) => (
+          {data.body.map((item) => (
             <tr
               onClick={() => {
                 if (item.link) {
@@ -35,19 +72,30 @@ const TableCard = (props) => {
               className={item.link ? 'table-link' : ''}
             >
               <td style={{ width: columnsSize?.number }}>
-                {disableTruncation?.number ? item.number : _.truncate(item.number, {
-                  length: truncationLength?.number ?? 80,
+                {displayItemData({
+                  truncate: disableTruncation?.number,
+                  item: item.number,
+                  link: item?.numberLink,
+                  defaultTruncationLength: 80,
                 })}
               </td>
               { item.icon ? <td><img alt="" src={item.icon} width="20" height="20" /></td> : null }
               <td className="mid" style={{ width: columnsSize?.name }}>
-                {disableTruncation?.name ? item.name : _.truncate(item.name, {
-                  length: truncationLength?.name ?? 80,
-                })}
+                {item.name
+                  ? displayItemData({
+                    truncate: disableTruncation?.name,
+                    item: item.name,
+                    link: item?.nameLink,
+                    defaultTruncationLength: 80,
+                  })
+                  : displayListItemsData(item.nameDataList, item.nameLinksList)}
               </td>
               <td style={{ width: columnsSize?.value }}>
-                {disableTruncation?.value ? item.value : _.truncate(item.value, {
-                  length: truncationLength?.value ?? 10,
+                {displayItemData({
+                  truncate: disableTruncation?.value,
+                  item: item.value,
+                  link: item?.valueLink,
+                  defaultTruncationLength: 10,
                 })}
               </td>
             </tr>
@@ -64,6 +112,11 @@ TableCard.propTypes = {
     name: PropTypes.string,
     value: PropTypes.string,
     body: PropTypes.arrayOf(PropTypes.shape({})),
+    numberLink: PropTypes.string,
+    valueLink: PropTypes.string,
+    nameLink: PropTypes.string,
+    nameDataList: PropTypes.arrayOf(PropTypes.string),
+    nameLinksList: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
   columnsSize: PropTypes.shape({
     name: PropTypes.string,

--- a/src/js/components/dashboard/TableCard.jsx
+++ b/src/js/components/dashboard/TableCard.jsx
@@ -39,7 +39,6 @@ const TableCard = (props) => {
       >
         {item}
         {' '}
-        <br />
       </a>
     ));
 
@@ -90,7 +89,7 @@ const TableCard = (props) => {
                   })
                   : displayListItemsData(item.nameDataList, item.nameLinksList)}
               </td>
-              <td style={{ width: columnsSize?.value }}>
+              <td className="last" style={{ width: columnsSize?.value }}>
                 {displayItemData({
                   truncate: disableTruncation?.value,
                   item: item.value,

--- a/src/js/components/dashboard/TableCard.jsx
+++ b/src/js/components/dashboard/TableCard.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 /* global _ */
 const TableCard = (props) => {
-  const { columnsSize, truncationLength } = props;
+  const { columnsSize, truncationLength, disableTruncation } = props;
 
   return (
     <div className="table-card">
@@ -35,14 +35,20 @@ const TableCard = (props) => {
               className={item.link ? 'table-link' : ''}
             >
               <td style={{ width: columnsSize?.number }}>
-                {_.truncate(item.number, { length: truncationLength?.number ?? 80 })}
+                {disableTruncation?.number ? item.number : _.truncate(item.number, {
+                  length: truncationLength?.number ?? 80,
+                })}
               </td>
               { item.icon ? <td><img alt="" src={item.icon} width="20" height="20" /></td> : null }
               <td className="mid" style={{ width: columnsSize?.name }}>
-                {_.truncate(item.name, { length: truncationLength?.name ?? 80 })}
+                {disableTruncation?.name ? item.name : _.truncate(item.name, {
+                  length: truncationLength?.name ?? 80,
+                })}
               </td>
               <td style={{ width: columnsSize?.value }}>
-                {_.truncate(item.value, { length: truncationLength?.value ?? 10 })}
+                {disableTruncation?.value ? item.value : _.truncate(item.value, {
+                  length: truncationLength?.value ?? 10,
+                })}
               </td>
             </tr>
           ))}
@@ -69,6 +75,11 @@ TableCard.propTypes = {
     number: PropTypes.number,
     value: PropTypes.number,
   }),
+  disableTruncation: PropTypes.shape({
+    name: PropTypes.bool,
+    number: PropTypes.bool,
+    value: PropTypes.bool,
+  }),
 };
 
 TableCard.defaultProps = {
@@ -81,6 +92,11 @@ TableCard.defaultProps = {
     name: null,
     number: null,
     value: null,
+  },
+  disableTruncation: {
+    name: undefined,
+    number: undefined,
+    value: undefined,
   },
 };
 

--- a/src/js/consts/dataFormat/customGraphConfig.jsx
+++ b/src/js/consts/dataFormat/customGraphConfig.jsx
@@ -1,7 +1,12 @@
 import { getColorByName } from 'consts/dataFormat/colorMapping';
 
 function loadNumbersOptions(payload) {
-  const { colors, columnsSize, truncationLength } = payload.config;
+  const {
+    colors,
+    columnsSize,
+    truncationLength,
+    disableTruncation,
+  } = payload.config;
   const palette = (colors && colors.palette) ? colors.palette : 'default';
 
   const options = {
@@ -12,6 +17,7 @@ function loadNumbersOptions(payload) {
     },
     columnsSize,
     truncationLength,
+    disableTruncation,
   };
 
   if (colors && colors.datasets) {

--- a/src/main/groovy/org/pih/warehouse/dashboard/TableData.groovy
+++ b/src/main/groovy/org/pih/warehouse/dashboard/TableData.groovy
@@ -3,10 +3,15 @@ package org.pih.warehouse.dashboard
 class TableData implements Serializable {
 
     String number
-    String name
+    String name // Single value for displaying in the middle column of the table
+    List<String> nameDataList // List of values, displaying each value in a new line within the same row
     String value
-    String link
+    String link // Link redirecting on clicking on the whole row
     String icon
+    String valueLink // Link redirecting only on the value text
+    String numberLink // Link redirecting only on the number text
+    String nameLink // Link redirecting only on the name text
+    List<String> nameLinksList // List of links applied to the nameDataList, matched by index
 
     TableData(String number, String name, String value = null, String link = null, String icon = null) {
         this.number = number
@@ -16,13 +21,31 @@ class TableData implements Serializable {
         this.icon = icon
     }
 
+    TableData(Map args) {
+        this.number = args.number
+        this.name = args.name
+        this.value = args.value
+        this.link = args.link
+        this.icon = args.icon
+        this.valueLink = args.valueLink
+        this.numberLink = args.numberLink
+        this.nameLink = args.nameLink
+        this.nameDataList = args.listNameData
+        this.nameLinksList = args.nameLinksList
+    }
+
     Map toJson() {
         [
-                "name"   : name.toJson(),
-                "number" : number.toJson(),
-                "value"  : value.toJson(),
-                "link"   : link.toJson(),
-                "icon"   : icon.toJson(),
+                "name"          : name.toJson(),
+                "number"        : number.toJson(),
+                "value"         : value.toJson(),
+                "link"          : link.toJson(),
+                "icon"          : icon.toJson(),
+                "valueLink"     : valueLink ? valueLink.toJson() : null,
+                "numberLink"    : numberLink ? numberLink.toJson() : null,
+                "nameLink"      : nameLink ? nameLink.toJson() : null,
+                "listNameData"  : nameDataList ? nameDataList.toJson() : null,
+                "nameLinksList" : nameLinksList ? nameLinksList.toJson() : null,
         ]
     }
 }


### PR DESCRIPTION
Things added after Manon's request:
- colours: green (1 shipment) > blue > orange > red (4+)
- instead of "4 or more shipments", just "4 or more"
- hyperlink the shipment IDs and the product codes
- date format: should be 31-Aug-2021
- narrowing columns