### PR TITLE
OBPIH-6365 Add validation on quantity field

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/picklist/ImportPickCommand.groovy
+++ b/grails-app/controllers/org/pih/warehouse/picklist/ImportPickCommand.groovy
@@ -11,7 +11,9 @@ class ImportPickCommand implements Validateable {
     String lotNumber
     Date expirationDate
     String binLocation
-    String quantity
+    String quantityAsText
+
+    static transients = ['quantity']
 
     static constraints = {
         id(nullable: false, blank: false)
@@ -25,27 +27,18 @@ class ImportPickCommand implements Validateable {
         })
         expirationDate(nullable: true)
         binLocation(nullable: true)
-        quantity(nullable: false, validator: { val, obj ->
+        quantityAsText(nullable: false, validator: { val, obj ->
             if (!NumberUtils.isNumber(val)) {
-                return ['notANumber.error']
+                return ['invalid.error']
             }
             if (Integer.parseInt(val) < 0) {
                 return ['negative.error']
             }
             return true
         })
-        quantityAsNumber(nullable: true)
     }
 
-    void setQuantity(String quantity) {
-        this.quantity = quantity
-    }
-
-    void setQuantity(Integer quantity) {
-        this.quantity = String.valueOf(quantity)
-    }
-
-    Integer getQuantityAsNumber() {
-        return NumberUtils.isNumber(this.quantity) ? Integer.parseInt(this.quantity) : null
+    Integer getQuantity() {
+        return NumberUtils.isNumber(this.quantityAsText) ? Integer.parseInt(this.quantityAsText) : null
     }
 }

--- a/grails-app/controllers/org/pih/warehouse/picklist/ImportPickCommand.groovy
+++ b/grails-app/controllers/org/pih/warehouse/picklist/ImportPickCommand.groovy
@@ -11,7 +11,7 @@ class ImportPickCommand implements Validateable {
     String lotNumber
     Date expirationDate
     String binLocation
-    Integer quantity
+    String quantity
 
     static constraints = {
         id(nullable: false, blank: false)
@@ -25,6 +25,27 @@ class ImportPickCommand implements Validateable {
         })
         expirationDate(nullable: true)
         binLocation(nullable: true)
-        quantity(nullable: false, min: 0)
+        quantity(nullable: false, validator: { val, obj ->
+            if (!NumberUtils.isNumber(val)) {
+                return ['notANumber.error']
+            }
+            if (Integer.parseInt(val) < 0) {
+                return ['negative.error']
+            }
+            return true
+        })
+        quantityAsNumber(nullable: true)
+    }
+
+    void setQuantity(String quantity) {
+        this.quantity = quantity
+    }
+
+    void setQuantity(Integer quantity) {
+        this.quantity = String.valueOf(quantity)
+    }
+
+    Integer getQuantityAsNumber() {
+        return NumberUtils.isNumber(this.quantity) ? Integer.parseInt(this.quantity) : null
     }
 }

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -1884,6 +1884,8 @@ picklistItem.quantity.label=Quantity
 
 #Picklist import
 importPickCommand.lot.scientificNotation.error=Lot numbers must not be specified in scientific notation. Please reformat field with lot number to a number format
+importPickCommand.quantity.notANumber.error=Invalid quantity: "{2}". Please enter a valid number.
+importPickCommand.quantity.negative.error=Invalid quantity: "{2}". Quantity must not be a negative number.
 importPickCommand.requisitionItem.notFound.error=Requisition item with id: {0} not found
 importPickCommand.availableItem.notFound.error=The stock entry you selected: lot "{0}" and bin location "{1}" does not exist. Please review pick.
 importPickCommand.availableItem.notAvailable.error=The stock entry you selected: lot "{0}" and bin location "{1}" is not available. Please review pick.

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -1884,8 +1884,8 @@ picklistItem.quantity.label=Quantity
 
 #Picklist import
 importPickCommand.lot.scientificNotation.error=Lot numbers must not be specified in scientific notation. Please reformat field with lot number to a number format
-importPickCommand.quantity.notANumber.error=Invalid quantity: "{2}". Please enter a valid number.
-importPickCommand.quantity.negative.error=Invalid quantity: "{2}". Quantity must not be a negative number.
+importPickCommand.quantity.invalid.error=Invalid quantity: "{0}". Please enter a valid number.
+importPickCommand.quantity.negative.error=Invalid quantity: "{0}". Quantity must not be a negative number.
 importPickCommand.requisitionItem.notFound.error=Requisition item with id: {0} not found
 importPickCommand.availableItem.notFound.error=The stock entry you selected: lot "{0}" and bin location "{1}" does not exist. Please review pick.
 importPickCommand.availableItem.notAvailable.error=The stock entry you selected: lot "{0}" and bin location "{1}" is not available. Please review pick.

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -1123,7 +1123,7 @@ class StockMovementService {
                         lotNumber: it.lotNumber,
                         expirationDate: it.expirationDate ? new Date(it.expirationDate) : null,
                         binLocation: it.binLocation,
-                        quantity: it.quantity
+                        quantityAsText: it.quantity
                 )
             }
 
@@ -1177,7 +1177,7 @@ class StockMovementService {
                     )
                 }
 
-                Integer itemQuantitySum = picklistItemsGroupedByRequisitionItem[data.id].sum { it.quantityAsNumber }
+                Integer itemQuantitySum = picklistItemsGroupedByRequisitionItem[data.id].sum { it.quantity }
                 if (itemQuantitySum > pickPageItem.requisitionItem.quantity) {
                     Boolean allowsOverPick = stockMovement.origin.supports(ActivityCode.ALLOW_OVERPICK)
                     if (!allowsOverPick) {
@@ -1228,7 +1228,7 @@ class StockMovementService {
                         picklistItem,
                         availableItem.inventoryItem,
                         availableItem.binLocation,
-                        params.quantityAsNumber,
+                        params.quantity,
                         null,
                         null
                 )

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -1123,7 +1123,7 @@ class StockMovementService {
                         lotNumber: it.lotNumber,
                         expirationDate: it.expirationDate ? new Date(it.expirationDate) : null,
                         binLocation: it.binLocation,
-                        quantity: it.quantity.isNumber() ? Integer.parseInt(it.quantity) : null
+                        quantity: it.quantity
                 )
             }
 
@@ -1155,9 +1155,8 @@ class StockMovementService {
                 ApplicationTagLib g = grailsApplication.mainContext.getBean(ApplicationTagLib.class)
 
                 if (!availableItem) {
-
-                    String lotNumberName = data.lotNumber ?: g.message(code: "default.label", default: "Default")
-                    String binLocationName = data.binLocation ?: g.message(code: "default.label", default: "Default")
+                    String lotNumberName = data.lotNumber ?: g.message(code: "default.noLotNumber.label", default: Constants.DEFAULT_LOT_NUMBER)
+                    String binLocationName = data.binLocation ?: g.message(code: "default.noBinLocation.label", default: Constants.DEFAULT_BIN_LOCATION_NAME)
                     data.errors.rejectValue(
                             "id",
                             "importPickCommand.availableItem.notFound.error",
@@ -1166,9 +1165,9 @@ class StockMovementService {
                     )
                 }
 
-                if (availableItem && AvailableItemStatus.listNotAvailable.contains(availableItem.status)) {
-                    String lotNumberName = data.lotNumber ?: g.message(code: "default.label", default: "Default")
-                    String binLocationName = data.binLocation ?: g.message(code: "default.label", default: "Default")
+                if (availableItem && AvailableItemStatus.listUnavailable().contains(availableItem.status)) {
+                    String lotNumberName = data.lotNumber ?: g.message(code: "default.noLotNumber.label", default: Constants.DEFAULT_LOT_NUMBER)
+                    String binLocationName = data.binLocation ?: g.message(code: "default.noBinLocation.label", default: Constants.DEFAULT_BIN_LOCATION_NAME)
 
                     data.errors.rejectValue(
                             "id",
@@ -1178,7 +1177,7 @@ class StockMovementService {
                     )
                 }
 
-                Integer itemQuantitySum = picklistItemsGroupedByRequisitionItem[data.id].sum { it.quantity }
+                Integer itemQuantitySum = picklistItemsGroupedByRequisitionItem[data.id].sum { it.quantityAsNumber }
                 if (itemQuantitySum > pickPageItem.requisitionItem.quantity) {
                     Boolean allowsOverPick = stockMovement.origin.supports(ActivityCode.ALLOW_OVERPICK)
                     if (!allowsOverPick) {
@@ -1229,7 +1228,7 @@ class StockMovementService {
                         picklistItem,
                         availableItem.inventoryItem,
                         availableItem.binLocation,
-                        params.quantity,
+                        params.quantityAsNumber,
                         null,
                         null
                 )

--- a/src/main/groovy/org/pih/warehouse/api/StockMovementItem.groovy
+++ b/src/main/groovy/org/pih/warehouse/api/StockMovementItem.groovy
@@ -380,11 +380,11 @@ class AvailableItem {
 enum AvailableItemStatus {
     AVAILABLE, PICKED, RECALLED, HOLD, NOT_AVAILABLE
 
-    static getList() {
+    static list() {
         [AVAILABLE, PICKED, RECALLED, HOLD, NOT_AVAILABLE]
     }
 
-    static getListNotAvailable() {
+    static listUnavailable() {
         [RECALLED, HOLD, NOT_AVAILABLE]
     }
 }


### PR DESCRIPTION
This PR was created to fix some points mentioned in #4650 

As you can see it's not so straightforward to add a validation of type (not a number) on a quantity, let me explain.

So the case is that a user uploads a file with a potential "invalid" quantity number.
We want our API to process this data and return to the user all of the errors that come up in the File.

Now if we set **quantity** as a type _Integer_, we lose the ability to even get to the custom validators because it will throw an exception something along the lines of `Can't cast String to an Integer` in constructor when assigning `this.quantity = quantity`, which is why I changed the type of the quantity so we can assign the quantity and then our validator can validate the value.

Additionally, I have added a `getQuantityAsNumber` so we don't have to cast String to Integer every time we want to use this value, not sure if you guys will support this solution.

At the moment this is the best I could come up with so if you guys have any ideas then let me know