### PR TITLE
OBPIH-6520 Set up for date localization in DD/Month/YYYY format for Es and Mx locales

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -357,9 +357,9 @@ default.credits.label=Credits
 default.balance.label=Balance
 default.dashboard.label=Dashboard
 default.data.label=Data
-default.date.format=dd/MMM/yyyy hh:mm:ss a z
-custom.date.format=MM/dd/yyyy
-expiry.date.format=MM/yyyy
+datetime.format=dd/MMM/yyyy hh:mm:ss a z
+date.format=MM/dd/yyyy
+monthyear.format=MM/yyyy
 default.date.label=Date
 default.dateCreated.label=Date Created
 default.dateFrom.label=From
@@ -3236,9 +3236,9 @@ react.default.dateInput.placeholder.label=Select a date
 react.default.form.field.required.label=${0} is required
 
 # Date formats
-react.default.defaultDate.format=MM/DD/yyyy hh:mm:ss a z
-react.default.customDate.format=MM/DD/yyyy
-react.default.expiryDate.format=MM/yyyy
+react.default.datetime.format=MM/DD/yyyy hh:mm:ss a z
+react.default.date.format=MM/DD/yyyy
+react.default.monthyear.format=MM/yyyy
 
 # Notifications
 react.notification.connectivity.offline.label=Lost Connection

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -358,6 +358,8 @@ default.balance.label=Balance
 default.dashboard.label=Dashboard
 default.data.label=Data
 default.date.format=dd/MMM/yyyy hh:mm:ss a z
+custom.date.format=MM/dd/yyyy
+expiry.date.format=MM/yyyy
 default.date.label=Date
 default.dateCreated.label=Date Created
 default.dateFrom.label=From
@@ -3232,6 +3234,12 @@ react.default.select.typeToSearch.label=Type to search
 react.default.noOptions.label=No options
 react.default.dateInput.placeholder.label=Select a date
 react.default.form.field.required.label=${0} is required
+
+# Date formats
+react.default.defaultDate.format=MM/DD/yyyy hh:mm:ss a z
+react.default.customDate.format=MM/DD/yyyy
+react.default.expiryDate.format=MM/yyyy
+
 # Notifications
 react.notification.connectivity.offline.label=Lost Connection
 react.notification.connectivity.offline.message=You are now offline. Your changes will be saved when the connection is restored.

--- a/grails-app/i18n/messages_es_MX.properties
+++ b/grails-app/i18n/messages_es_MX.properties
@@ -1,11 +1,11 @@
 default.number.format=\# \# \#, \# \# \#, \# \# \#0.00
 
 # Date formats
-default.date.format=dd/MMM/yyyy hh:mm:ss a z
-custom.date.format=dd/MMM/yyyy
-expiry.date.format=MMM/yyyy
+datetime.format=dd/MMM/yyyy hh:mm:ss a z
+date.format=dd/MMM/yyyy
+monthyear.format=MMM/yyyy
 
 # Date formats (React)
-react.default.defaultDate.format=DD/MMM/yyyy hh:mm:ss a z
-react.default.customDate.format=DD/MMM/yyyy
-react.default.expiryDate.format=MMM/yyyy
+react.default.datetime.format=DD/MMM/yyyy hh:mm:ss a z
+react.default.date.format=DD/MMM/yyyy
+react.default.monthyear.format=MMM/yyyy

--- a/grails-app/i18n/messages_es_MX.properties
+++ b/grails-app/i18n/messages_es_MX.properties
@@ -1,1 +1,11 @@
 default.number.format=\# \# \#, \# \# \#, \# \# \#0.00
+
+# Date formats
+default.date.format=dd/MMM/yyyy hh:mm:ss a z
+custom.date.format=dd/MMM/yyyy
+expiry.date.format=MMM/yyyy
+
+# Date formats (React)
+react.default.defaultDate.format=DD/MMM/yyyy hh:mm:ss a z
+react.default.customDate.format=DD/MMM/yyyy
+react.default.expiryDate.format=MMM/yyyy

--- a/grails-app/taglib/org/pih/warehouse/DateTagLib.groovy
+++ b/grails-app/taglib/org/pih/warehouse/DateTagLib.groovy
@@ -25,7 +25,7 @@ class DateTagLib {
     Closure formatDate = { attrs, body ->
         def formatTagLib = grailsApplication.mainContext.getBean('org.grails.plugins.web.taglib.FormatTagLib')
 
-        if (!attrs.format) {
+        if (!attrs.format && !attrs.formatName) {
             attrs.format = Constants.DEFAULT_DATE_TIME_FORMAT
         }
         if (!attrs.timeZone && session.timezone) {

--- a/grails-app/utils/org/pih/warehouse/DateFormatName.groovy
+++ b/grails-app/utils/org/pih/warehouse/DateFormatName.groovy
@@ -1,5 +1,13 @@
 package org.pih.warehouse
 
+// Enum for storing labels used in dates formatting.
+// In case of adding new format we have to:
+// 1. Add new format in message.properties file
+// 2. Add the newly created label to this enum
+// This enum is used in:
+// 1. G tag - <g:formatDate date={your date} formatName={id of enum property} />
+// 2. LocalizationUtil.formatDate(your date, id of enum property)
+
 enum DateFormatName {
     DEFAULT('default.date.format'),
     CUSTOM('custom.date.format'),

--- a/grails-app/utils/org/pih/warehouse/DateFormatName.groovy
+++ b/grails-app/utils/org/pih/warehouse/DateFormatName.groovy
@@ -1,0 +1,13 @@
+package org.pih.warehouse
+
+enum DateFormatName {
+    DEFAULT('default.date.format'),
+    CUSTOM('custom.date.format'),
+    EXPIRY('expiry.date.format'),
+
+    final String id
+
+    DateFormatName(String id) {
+        this.id = id
+    }
+}

--- a/grails-app/utils/org/pih/warehouse/DateFormatName.groovy
+++ b/grails-app/utils/org/pih/warehouse/DateFormatName.groovy
@@ -5,8 +5,8 @@ package org.pih.warehouse
 // 1. Add new format in message.properties file
 // 2. Add the newly created label to this enum
 // This enum is used in:
-// 1. G tag - <g:formatDate date={your date} formatName={id of enum property} />
-// 2. LocalizationUtil.formatDate(your date, id of enum property)
+// 1. G tag - <g:formatDate date={your date} formatName={enum property} />
+// 2. LocalizationUtil.formatDate(your date, enum property)
 
 enum DateFormatName {
     DATE_TIME('default.date.format'),

--- a/grails-app/utils/org/pih/warehouse/DateFormatName.groovy
+++ b/grails-app/utils/org/pih/warehouse/DateFormatName.groovy
@@ -9,13 +9,13 @@ package org.pih.warehouse
 // 2. LocalizationUtil.formatDate(your date, id of enum property)
 
 enum DateFormatName {
-    DEFAULT('default.date.format'),
-    CUSTOM('custom.date.format'),
-    EXPIRY('expiry.date.format'),
+    DATE_TIME('default.date.format'),
+    FULL_DATE('custom.date.format'),
+    MONTH_YEAR('expiry.date.format'),
 
-    final String id
+    final String property
 
-    DateFormatName(String id) {
-        this.id = id
+    DateFormatName(String property) {
+        this.property = property
     }
 }

--- a/grails-app/utils/org/pih/warehouse/DateFormatName.groovy
+++ b/grails-app/utils/org/pih/warehouse/DateFormatName.groovy
@@ -9,9 +9,9 @@ package org.pih.warehouse
 // 2. LocalizationUtil.formatDate(your date, enum property)
 
 enum DateFormatName {
-    DATE_TIME('default.date.format'),
-    FULL_DATE('custom.date.format'),
-    MONTH_YEAR('expiry.date.format'),
+    DATE_TIME('datetime.format'),
+    FULL_DATE('date.format'),
+    MONTH_YEAR('monthyear.format'),
 
     final String property
 

--- a/grails-app/utils/org/pih/warehouse/LocalizationUtil.groovy
+++ b/grails-app/utils/org/pih/warehouse/LocalizationUtil.groovy
@@ -159,10 +159,10 @@ class LocalizationUtil {
      * @param formatName (property of DateFormatName enum, indicating the desired format of the date)
      * @return return localized date in passed formatName (name of the property in i18n/*.properties file).
      */
-    static String formatDate(Date date, DateFormatName formatName = DateFormatName.DEFAULT) {
+    static String formatDate(Date date, DateFormatName formatName = DateFormatName.DATE_TIME) {
         return applicationTagLib.formatDate(
                 date: date,
-                formatName: formatName.id,
+                formatName: formatName.property,
                 locale: currentLocale
         )
     }

--- a/grails-app/utils/org/pih/warehouse/LocalizationUtil.groovy
+++ b/grails-app/utils/org/pih/warehouse/LocalizationUtil.groovy
@@ -156,7 +156,7 @@ class LocalizationUtil {
 
     /**
      * @param date
-     * @param formatName
+     * @param formatName (property of DateFormatName enum, indicating the desired format of the date)
      * @return return localized date in passed formatName (name of the property in i18n/*.properties file).
      */
     static String formatDate(Date date, DateFormatName formatName = DateFormatName.DEFAULT) {

--- a/grails-app/utils/org/pih/warehouse/LocalizationUtil.groovy
+++ b/grails-app/utils/org/pih/warehouse/LocalizationUtil.groovy
@@ -10,6 +10,7 @@
 package org.pih.warehouse
 
 import grails.util.Holders
+import org.grails.plugins.web.taglib.ApplicationTagLib
 import org.pih.warehouse.core.LocalizationService
 import org.pih.warehouse.inventory.Transaction
 
@@ -59,6 +60,10 @@ class LocalizationUtil {
         Locale defaultLocale = defaultLocaleCode ? new Locale(defaultLocaleCode) : Locale.ENGLISH
         locale.setDefault(defaultLocale)
         return locale
+    }
+
+    static ApplicationTagLib getApplicationTagLib() {
+        return Holders.grailsApplication.mainContext.getBean(ApplicationTagLib)
     }
 
     static List<Locale> getSupportedLocales() {
@@ -147,5 +152,18 @@ class LocalizationUtil {
      */
     static String getDefaultString(String str) {
         return getLocalizedString(str, null)
+    }
+
+    /**
+     * @param date
+     * @param formatName
+     * @return return localized date in passed formatName (name of the property in i18n/*.properties file).
+     */
+    static String formatDate(Date date, DateFormatName formatName = DateFormatName.DEFAULT) {
+        return applicationTagLib.formatDate(
+                date: date,
+                formatName: formatName.id,
+                locale: currentLocale
+        )
     }
 }

--- a/src/js/consts/dateFormatName.js
+++ b/src/js/consts/dateFormatName.js
@@ -6,9 +6,9 @@
 // 1. <FormatDate date={your date} formatName={property of this enum} /> component
 
 const DateFormatName = {
-  DEFAULT: 'react.default.defaultDate.format',
-  CUSTOM: 'react.default.customDate.format',
-  EXPIRY: 'react.default.expiryDate.format',
+  DATE_TIME: 'react.default.defaultDate.format',
+  FULL_DATE: 'react.default.customDate.format',
+  MONTH_YEAR: 'react.default.expiryDate.format',
 };
 
 export default DateFormatName;

--- a/src/js/consts/dateFormatName.js
+++ b/src/js/consts/dateFormatName.js
@@ -1,3 +1,10 @@
+// Enum for storing labels used in dates formatting.
+// In case of adding new format we have to:
+// 1. Add new format in message.properties file
+// 2. Add the newly created label to this enum
+// This enum is used in:
+// 1. <FormatDate date={your date} formatName={property of this enum} /> component
+
 const DateFormatName = {
   DEFAULT: 'react.default.defaultDate.format',
   CUSTOM: 'react.default.customDate.format',

--- a/src/js/consts/dateFormatName.js
+++ b/src/js/consts/dateFormatName.js
@@ -1,0 +1,7 @@
+const DateFormatName = {
+  DEFAULT: 'react.default.defaultDate.format',
+  CUSTOM: 'react.default.customDate.format',
+  EXPIRY: 'react.default.expiryDate.format',
+};
+
+export default DateFormatName;

--- a/src/js/consts/dateFormatName.js
+++ b/src/js/consts/dateFormatName.js
@@ -6,9 +6,9 @@
 // 1. <FormatDate date={your date} formatName={property of this enum} /> component
 
 const DateFormatName = {
-  DATE_TIME: 'react.default.defaultDate.format',
-  FULL_DATE: 'react.default.customDate.format',
-  MONTH_YEAR: 'react.default.expiryDate.format',
+  DATE_TIME: 'react.default.datetime.format',
+  FULL_DATE: 'react.default.date.format',
+  MONTH_YEAR: 'react.default.monthyear.format',
 };
 
 export default DateFormatName;

--- a/src/js/utils/FormatDate.jsx
+++ b/src/js/utils/FormatDate.jsx
@@ -27,5 +27,5 @@ FormatDate.propTypes = {
 
 FormatDate.defaultProps = {
   date: new Date(),
-  formatName: DateFormatName.DEFAULT,
+  formatName: DateFormatName.DATE_TIME,
 };

--- a/src/js/utils/FormatDate.jsx
+++ b/src/js/utils/FormatDate.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+
+import DateFormatName from 'consts/dateFormatName';
+import { formatDate } from 'utils/translation-utils';
+
+const FormatDate = ({ date, formatName }) => {
+  const { translateDate } = useSelector((state) => ({
+    translateDate: formatDate(state.localize),
+  }));
+
+  return (
+    <>
+      {translateDate(date, formatName)}
+    </>
+  );
+};
+
+export default FormatDate;
+
+FormatDate.propTypes = {
+  date: PropTypes.instanceOf(Date),
+  formatName: PropTypes.string,
+};
+
+FormatDate.defaultProps = {
+  date: new Date(),
+  formatName: DateFormatName.DEFAULT,
+};

--- a/src/js/utils/translation-utils.jsx
+++ b/src/js/utils/translation-utils.jsx
@@ -1,8 +1,16 @@
 import _ from 'lodash';
+import moment from 'moment';
+import { getTranslate } from 'react-localize-redux';
 
 const splitTranslation = (data, locale) => {
   const [en, fr] = _.split(data, '|fr:');
   return locale === 'fr' && fr ? fr : en;
+};
+
+export const formatDate = (localize) => (date, formatName) => {
+  const localeCode = localize.languages.find(lang => lang.active)?.code;
+  const dateFormat = getTranslate(localize)(formatName);
+  return moment(date).locale(localeCode).format(dateFormat);
 };
 
 export default splitTranslation;


### PR DESCRIPTION
Usage:
1. G tag
```
<g:formatDate date="${new Date()}" formatName="${org.pih.warehouse.DateFormatName.CUSTOM.id}"/>
<g:formatDate date="${new Date()}" formatName="${org.pih.warehouse.DateFormatName.DEFAULT.id}"/>
<g:formatDate date="${new Date()}" formatName="${org.pih.warehouse.DateFormatName.EXPIRY.id}"/>

```
2. Grails util
```
LocalizationUtil.formatDate(new Date(), DateFormatName.EXPIRY)
LocalizationUtil.formatDate(new Date(), DateFormatName.CUSTOM)
LocalizationUtil.formatDate(new Date(), DateFormatName.DEFAULT)
```
3. React component
```
<FormatDate date={new Date()} formatName={DateFormatName.DEFAULT} />
<FormatDate date={new Date()} formatName={DateFormatName.EXPIRY} />
<FormatDate date={new Date()} formatName={DateFormatName.CUSTOM} />
```