### PR TITLE
[OBPIH-6455] slack notification when github onchange job fails

### DIFF
--- a/.github/workflows/on-change.yml
+++ b/.github/workflows/on-change.yml
@@ -11,5 +11,3 @@ jobs:
 
   run-backend-tests:
     uses: ./.github/workflows/backend-tests.yml
-
-#TODO: Send a email or slack notification if either job fails: https://pihemr.atlassian.net/browse/OBPIH-6455

--- a/.github/workflows/slack-notifier.yml
+++ b/.github/workflows/slack-notifier.yml
@@ -1,0 +1,23 @@
+name: Slack Notification on Failures
+
+# Sends a Slack notification whenever the on-change job fails or times out.
+on:
+  workflow_run:
+    workflows: [On Change]
+    types: [completed]
+
+jobs:
+  slack-notify:
+    runs-on: ubuntu-latest
+
+    if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out'
+
+    steps:
+      - uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ github.event.workflow_run.conclusion }}
+          notification_title: "${{github.event.workflow_run.name}} - ${{github.event.workflow_run.conclusion}} on ${{github.event.workflow_run.head_branch}} - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>"
+          message_format: "{emoji} *${{github.event.workflow_run.name}}* ${{github.event.workflow_run.conclusion}} on commit <{commit_url}|{commit_sha}>"
+          footer: "<${{github.server_url}}/${{github.repository}}|${{github.repository}}>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_BUILD_STATUS_WEBHOOK }}


### PR DESCRIPTION
Jira ticket: https://pihemr.atlassian.net/browse/OBPIH-6455

When the onchange job (https://github.com/openboxes/openboxes/actions/workflows/on-change.yml) fails, send a slack notification to the #build-status channel so that we can immediately be alerted to the failure.

I've tested the job already in a fork of the repo and it outputs the following:

![Screenshot from 2024-06-20 21-57-59](https://github.com/openboxes/openboxes/assets/6844376/20bf09f2-9f5f-4998-b8cb-276dcb4d2d80)

Mainly this review is to see if there's any other info that you'd like included in the message