### PR TITLE
OBPIH-6558 Do not mark inferred items as auto allocated

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -1609,7 +1609,7 @@ class StockMovementService {
                         List<AvailableItem> availableItems = pickPageItem.getAvailableItems(inventoryItem)
                         availableItems = applyAllocationRulesOnAvailableItems(availableItems, params.quantity)
                         List<SuggestedItem> suggestedItems = getSuggestedItems(availableItems, params.quantity)
-                        allocateSuggestedItems(pickPageItem.requisitionItem, suggestedItems)
+                        allocateSuggestedItems(pickPageItem.requisitionItem, suggestedItems, false)
                     }
                 }
             }
@@ -2089,7 +2089,7 @@ class StockMovementService {
     }
 
 
-    void allocateSuggestedItems(RequisitionItem requisitionItem, List<SuggestedItem> suggestedItems) {
+    void allocateSuggestedItems(RequisitionItem requisitionItem, List<SuggestedItem> suggestedItems, Boolean isAutoAllocated = true) {
 
         for (SuggestedItem suggestedItem : suggestedItems) {
             createOrUpdatePicklistItem(
@@ -2100,7 +2100,7 @@ class StockMovementService {
                     suggestedItem.quantityPicked?.intValueExact(),
                     null,
                     null,
-                    true
+                    isAutoAllocated
             )
         }
     }


### PR DESCRIPTION
This service function is executed on the import picklist controller, which should not mark the requisition item as `autoAllocated=true`.
In the import of picklist Items we have a case where we find the exact candidate and proceed with it or otherwise we don't find it, and the system tries to infer the candidate based on for example inventory item (eg. user provides only lot number).
Previously I mistakenly set this as `isAutoAllocated = true` which is not true for this case.