### PR TITLE
OBPIH-6558 Do not mark inferred items as auto allocated (#4740)

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -1609,7 +1609,7 @@ class StockMovementService {
                         List<AvailableItem> availableItems = pickPageItem.getAvailableItems(inventoryItem)
                         availableItems = applyAllocationRulesOnAvailableItems(availableItems, params.quantity)
                         List<SuggestedItem> suggestedItems = getSuggestedItems(availableItems, params.quantity)
-                        allocateSuggestedItems(pickPageItem.requisitionItem, suggestedItems)
+                        allocateSuggestedItems(pickPageItem.requisitionItem, suggestedItems, false)
                     }
                 }
             }
@@ -2089,7 +2089,7 @@ class StockMovementService {
     }
 
 
-    void allocateSuggestedItems(RequisitionItem requisitionItem, List<SuggestedItem> suggestedItems) {
+    void allocateSuggestedItems(RequisitionItem requisitionItem, List<SuggestedItem> suggestedItems, Boolean isAutoAllocated = true) {
 
         for (SuggestedItem suggestedItem : suggestedItems) {
             createOrUpdatePicklistItem(
@@ -2100,7 +2100,7 @@ class StockMovementService {
                     suggestedItem.quantityPicked?.intValueExact(),
                     null,
                     null,
-                    true
+                    isAutoAllocated
             )
         }
     }


### PR DESCRIPTION
This is a clone PR of https://github.com/openboxes/openboxes/pull/4740 because the former one was accidentally merged to develop.