### PR TITLE
OBPIH-6548 Fix wrong product availability data lookup on internal stock transfer

### DIFF
--- a/grails-app/services/org/pih/warehouse/stockTransfer/StockTransferService.groovy
+++ b/grails-app/services/org/pih/warehouse/stockTransfer/StockTransferService.groovy
@@ -417,7 +417,7 @@ class StockTransferService {
 
     def setQuantityOnHand(StockTransfer stockTransfer) {
         stockTransfer?.stockTransferItems?.each { StockTransferItem stockTransferItem ->
-            ProductAvailability pa = ProductAvailability.findByInventoryItemAndBinLocation(stockTransferItem.inventoryItem, stockTransferItem.originBinLocation)
+            ProductAvailability pa = ProductAvailability.findByInventoryItemAndBinLocationAndLocation(stockTransferItem.inventoryItem, stockTransferItem.originBinLocation, stockTransferItem.location)
             stockTransferItem.quantityOnHand = pa ? pa.quantityOnHand : 0
             stockTransferItem.quantityNotPicked = pa && pa.quantityNotPicked > 0 ? pa.quantityNotPicked: 0
             stockTransferItem.productAvailabilityId = pa ? pa.id : stockTransferItem.id


### PR DESCRIPTION
The issue here was an incomplete criteria on Product Avaialability lookup.
So there was a case where a single product had two similar Product Availability records in two different locations.
The similarity is in binLocation being `DEFAULT` and lotNumber being exact same as in the previous location.
So when we did a lookup
```groovy
ProductAvailability pa = ProductAvailability.findByInventoryItemAndBinLocation(stockTransferItem.inventoryItem,
```
it would find the first best one and return it, so doing an internal transfer on location `A` we would get quantity of location`B`, but when doing a transfer in location `B` we could have receive a correct one because it happens that the order of ProductAvaialability had quantity from location `B` first.

To fix this I just needed to fix the query and look for a specific ProductAvaialability in a location 