### PR TITLE
[OBPIH-6585] Facts table seems not to build on staging

### DIFF
--- a/grails-app/domain/org/pih/warehouse/core/LocationType.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/LocationType.groovy
@@ -37,7 +37,7 @@ class LocationType implements Comparable, Serializable {
 
     static constraints = {
         name(nullable: false, maxSize: 255)
-        locationTypeCode(nullable: true)
+        locationTypeCode(nullable: false)
         description(nullable: true, maxSize: 255)
         supportedActivities(nullable: true, display: false)
         sortOrder(nullable: true)

--- a/grails-app/migrations/0.9.x/changelog-2024-07-18-1200-alter-table-location-type-make-location-type-code-non-null.groovy
+++ b/grails-app/migrations/0.9.x/changelog-2024-07-18-1200-alter-table-location-type-make-location-type-code-non-null.groovy
@@ -11,7 +11,7 @@ databaseChangeLog = {
         // bad records instead, but this is the safer option in case those location types are accidentally being used.
         update(tableName: "location_type") {
             column(name: "location_type_code", value: "DEPOT")
-            where("location_type IS NULL")
+            where("location_type_code IS NULL")
         }
 
         addNotNullConstraint(columnDataType: "VARCHAR(100)", columnName: "location_type_code", tableName: "location_type")

--- a/grails-app/migrations/0.9.x/changelog-2024-07-18-1200-alter-table-location-type-make-location-type-code-non-null.groovy
+++ b/grails-app/migrations/0.9.x/changelog-2024-07-18-1200-alter-table-location-type-make-location-type-code-non-null.groovy
@@ -1,12 +1,17 @@
 databaseChangeLog = {
 
-    changeSet(author: "ewaterman", id: "1721321391197-94", objectQuotingStrategy: "LEGACY") {
-        preConditions(onError: "HALT", onFail: "MARK_RAN", onSqlOutput: "IGNORE") {
-            and {
-                columnExists(columnName: "location_type_code", tableName: "location_type")
+    changeSet(author: "ewaterman", id: "180720241200-0", objectQuotingStrategy: "LEGACY") {
 
-                sqlCheck("""SELECT COUNT(*) FROM location_type WHERE location_type_code IS NULL""", expectedResult: "0")
-            }
+        preConditions(onError: "HALT", onFail: "MARK_RAN", onSqlOutput: "IGNORE") {
+            columnExists(columnName: "location_type_code", tableName: "location_type")
+        }
+
+        // It is invalid behaviour for a location type to not have a code, so we shouldn't have any in production, but
+        // we assign any existing ones an arbitrary code (in this case DEPOT) just in case. We could try to delete the
+        // bad records instead, but this is the safer option in case those location types are accidentally being used.
+        update(tableName: "location_type") {
+            column(name: "location_type_code", value: "DEPOT")
+            where("location_type IS NULL")
         }
 
         addNotNullConstraint(columnDataType: "VARCHAR(100)", columnName: "location_type_code", tableName: "location_type")

--- a/grails-app/migrations/0.9.x/changelog-2024-07-18-1200-alter-table-location-type-make-location-type-code-non-null.groovy
+++ b/grails-app/migrations/0.9.x/changelog-2024-07-18-1200-alter-table-location-type-make-location-type-code-non-null.groovy
@@ -1,0 +1,14 @@
+databaseChangeLog = {
+
+    changeSet(author: "ewaterman", id: "1721321391197-94", objectQuotingStrategy: "LEGACY") {
+        preConditions(onError: "HALT", onFail: "MARK_RAN", onSqlOutput: "IGNORE") {
+            and {
+                columnExists(columnName: "location_type_code", tableName: "location_type")
+
+                sqlCheck("""SELECT COUNT(*) FROM location_type WHERE location_type_code IS NULL""", expectedResult: "0")
+            }
+        }
+
+        addNotNullConstraint(columnDataType: "VARCHAR(100)", columnName: "location_type_code", tableName: "location_type")
+    }
+}

--- a/grails-app/migrations/0.9.x/changelog.xml
+++ b/grails-app/migrations/0.9.x/changelog.xml
@@ -13,4 +13,5 @@
     <include file="0.9.x/changelog-2024-04-29-1200-alter-table-picklist-item-add-quantity-picked.groovy" />
     <include file="0.9.x/changelog-2024-05-08-1110-rename-picker-to-pickedBy-column.groovy" />
     <include file="0.9.x/changelog-2024-06-27-1200-add-auto-allocated-column-to-requisition-item.groovy" />
+    <include file="0.9.x/changelog-2024-07-18-1200-alter-table-location-type-make-location-type-code-non-null.groovy" />
 </databaseChangeLog>

--- a/grails-app/views/locationType/create.gsp
+++ b/grails-app/views/locationType/create.gsp
@@ -41,7 +41,6 @@
                             </td>
                             <td valign="top" class="value ${hasErrors(bean: locationTypeInstance, field: 'description', 'errors')}">
                                 <g:select name="locationTypeCode" class="chzn-select-deselect" from="${org.pih.warehouse.core.LocationTypeCode.list()}"
-                                          noSelection="['':'']"
                                           value="${locationTypeInstance?.locationTypeCode}"/>
                             </td>
                         </tr>

--- a/grails-app/views/locationType/edit.gsp
+++ b/grails-app/views/locationType/edit.gsp
@@ -46,7 +46,6 @@
                         class="value ${hasErrors(bean: locationTypeInstance, field: 'description', 'errors')}">
                         <g:select name="locationTypeCode" class="chzn-select-deselect"
                                   from="${org.pih.warehouse.core.LocationTypeCode.list()}"
-                                  noSelection="['': '']"
                                   value="${locationTypeInstance?.locationTypeCode}"/>
                     </td>
                 </tr>


### PR DESCRIPTION
https://pihemr.atlassian.net/browse/OBPIH-6585

`LocationType.locationTypeCode` is currently a nullable field, but `LocationDimension.locationTypeCode` is a non-null field. If we ever have a location type with a null location type code, it causes column constraint failures when generating location dimensions for all locations and causes the whole action to fail.

![Screenshot from 2024-07-17 11-18-21](https://github.com/user-attachments/assets/0f0866ec-6f5b-4df8-b4a9-5864b35af124)

This change is to make `LocationType.locationTypeCode` non-nullable.