### PR TITLE
OBPIH-6577 Prevent only document types with template document codes to be uploaded on stockmovement, shipment, po and invoice add document endpoint

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/core/DocumentController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/core/DocumentController.groovy
@@ -38,7 +38,6 @@ class DocumentController {
     def shipmentService
     GrailsApplication grailsApplication
     TemplateService templateService
-    DocumentService documentService
     StockMovementService stockMovementService
     OutboundStockMovementService outboundStockMovementService
 
@@ -194,9 +193,12 @@ class DocumentController {
         def requestInstance = Requisition.get(command.requestId)
         def productInstance = Product.get(command.productId)
         def invoiceInstance = Invoice.get(command.invoiceId)
-        def stockMovement = outboundStockMovementService.getStockMovement(command.stockMovementId)
-        if (!stockMovement) {
-            stockMovement =  stockMovementService.getStockMovement(command.stockMovementId)
+        def stockMovement = null
+        if (command.stockMovementId) {
+            stockMovement = outboundStockMovementService.getStockMovement(command.stockMovementId)
+            if (!stockMovement) {
+                stockMovement =  stockMovementService.getStockMovement(command.stockMovementId)
+            }
         }
 
         // file must not be empty and must be less than 10MB
@@ -222,8 +224,8 @@ class DocumentController {
 
             documentInstance.validate()
 
-            List<DocumentType> nonTemplateDocumentTypes = documentService.getNonTemplateDocumentTypes()
-            if (!nonTemplateDocumentTypes.contains(documentType)) {
+            List<DocumentCode> forbiddenDocumentCodes = DocumentCode.templateList()
+            if (documentType && forbiddenDocumentCodes.contains(documentType.documentCode)) {
                 documentInstance.errors.reject("documentType", "Template types are not allowed for this document upload")
             }
 


### PR DESCRIPTION
This is a fix to the change I made recently. Apparently I have missed the case for uploading documents without specified document types, so when checking  `if (!nonTemplateDocumentTypes.contains(null))` it would fail on this step since null is not a part of nonTemplateDocumesTypes

I decided to go a little different route this time and instead of fetching all of the document Types with template document codes I figured we can just check if the document type that we are applying has a template document code