### PR TITLE
OBPIH-6497 Fix comparing invoice quantities in UoM and in standard Uom

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/api/PurchaseOrderApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/PurchaseOrderApiController.groovy
@@ -218,7 +218,7 @@ class PurchaseOrderApiController {
                     orderItem?.quantity,
                     orderItem?.quantityShipped,
                     orderItem?.quantityReceived,
-                    orderItem?.postedQuantityInvoicedInStandardUom,
+                    orderItem?.postedQuantityInvoiced,
                     orderItem?.unitPrice,
                     orderItem?.total,
                     orderItem?.order?.currencyCode,

--- a/grails-app/domain/org/pih/warehouse/order/OrderAdjustment.groovy
+++ b/grails-app/domain/org/pih/warehouse/order/OrderAdjustment.groovy
@@ -108,8 +108,23 @@ class OrderAdjustment implements Serializable, Comparable<OrderAdjustment> {
         return invoiceItems*.invoice.unique()
     }
 
+    /**
+     * Adjustment can be on a regular invoice if it is not canceled or if it is canceled, but has prepayment
+     * */
+    Boolean canBeOnRegularInvoice() {
+        if (canceled) {
+            return hasPrepaymentInvoice
+        }
+
+        return true
+    }
+
     Boolean isInvoiceable() {
-        return hasPrepaymentInvoice && !hasRegularInvoice && order.placed
+        if (canceled) {
+            return hasPrepaymentInvoice && !hasRegularInvoice && order.placed
+        }
+
+        return !hasRegularInvoice && order.placed
     }
 
     Boolean getHasInvoices() {

--- a/grails-app/domain/org/pih/warehouse/shipping/ShipmentItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/shipping/ShipmentItem.groovy
@@ -65,7 +65,7 @@ class ShipmentItem implements Comparable, Serializable {
             "purchaseOrders",
             "orderName",
             "quantityRemainingToShip",
-            "quantityToInvoice",
+            "quantityToInvoiceInStandardUom",
             "quantityPerUom",
             "hasRecalledLot",
             "quantityPicked",
@@ -274,16 +274,22 @@ class ShipmentItem implements Comparable, Serializable {
         return inventoryItem?.lotStatus == LotStatusCode.RECALLED
     }
 
+    // quantity invoiced in uom
     Integer getQuantityInvoiced() {
         return invoiceItems?.sum { it.quantity ?: 0 } ?: 0
     }
 
-    Integer getQuantityToInvoice() {
-        return quantity - quantityInvoiced
+    Integer getQuantityInvoicedInStandardUom() {
+        return quantityInvoiced * quantityPerUom
+    }
+
+    Integer getQuantityToInvoiceInStandardUom() {
+        // ShipmentItem.quantity is in standard uom
+        return quantity - quantityInvoicedInStandardUom
     }
 
     Boolean isInvoiceable() {
-        return quantityToInvoice > 0
+        return quantityToInvoiceInStandardUom > 0
     }
 
     /**

--- a/grails-app/services/org/pih/warehouse/invoice/InvoiceService.groovy
+++ b/grails-app/services/org/pih/warehouse/invoice/InvoiceService.groovy
@@ -347,7 +347,8 @@ class InvoiceService {
     InvoiceItem createFromShipmentItem(ShipmentItem shipmentItem) {
         OrderItem orderItem = shipmentItem.orderItems?.find { it }
         InvoiceItem invoiceItem = new InvoiceItem(
-            quantity: shipmentItem.quantityToInvoice ? (shipmentItem.quantityToInvoice / orderItem?.quantityPerUom) : 0,
+            // InvoiceItem quantity is in UoM not in standard UoM
+            quantity: shipmentItem.quantityToInvoiceInStandardUom ? (shipmentItem.quantityToInvoiceInStandardUom / orderItem?.quantityPerUom) : 0,
             product: shipmentItem.product,
             glAccount: shipmentItem.product.glAccount,
             budgetCode: orderItem?.budgetCode,

--- a/src/js/components/invoice/ConfirmInvoicePage.jsx
+++ b/src/js/components/invoice/ConfirmInvoicePage.jsx
@@ -317,20 +317,22 @@ class ConfirmInvoicePage extends Component {
 
   submitInvoice() {
     const url = `/api/invoices/${this.state.values.id}/submit`;
+    this.props.showSpinner();
     apiClient.post(url)
       .then(() => {
         window.location = INVOICE_URL.show(this.state.values.id);
       })
-      .catch(() => this.props.hideSpinner());
+      .finally(() => this.props.hideSpinner());
   }
 
   postInvoice() {
     const url = `/api/invoices/${this.state.values.id}/post`;
+    this.props.showSpinner();
     apiClient.post(url)
       .then(() => {
         window.location = INVOICE_URL.show(this.state.values.id);
       })
-      .catch(() => this.props.hideSpinner());
+      .finally(() => this.props.hideSpinner());
   }
 
   fetchPrepaymentItems() {

--- a/src/test/groovy/unit/org/pih/warehouse/order/OrderSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/order/OrderSpec.groovy
@@ -14,6 +14,7 @@ class OrderSpec extends Specification implements DomainUnitTest<Order> {
         given:
         OrderAdjustment orderAdjustment = Stub(OrderAdjustment) {
             isInvoiceable() >> true
+            canBeOnRegularInvoice() >> true
         }
         Order order = Spy(Order) {
             getHasPrepaymentInvoice() >> hasPrepaymentInvoice
@@ -37,6 +38,7 @@ class OrderSpec extends Specification implements DomainUnitTest<Order> {
         }
         OrderItem orderItem = Stub(OrderItem)
         OrderAdjustment orderAdjustment = Stub(OrderAdjustment)
+        orderAdjustment.canBeOnRegularInvoice() >> true
         orderAdjustment.isInvoiceable() >> isAdjustmentInvoiceable
         orderItem.addToOrderAdjustments(orderAdjustment)
         order.addToOrderAdjustments(orderAdjustment)
@@ -166,9 +168,11 @@ class OrderSpec extends Specification implements DomainUnitTest<Order> {
             getQuantityRemaining() >> 0
         }
         OrderAdjustment adjustmentItem1 = Stub(OrderAdjustment) {
+            canBeOnRegularInvoice() >> true
             isInvoiceable() >> false
         }
         OrderAdjustment adjustmentItem2 = Stub(OrderAdjustment) {
+            canBeOnRegularInvoice() >> true
             isInvoiceable() >> false
         }
         Order order = new Order(orderItems: [orderItem1, orderItem2], orderAdjustments: [adjustmentItem1, adjustmentItem2])
@@ -180,17 +184,21 @@ class OrderSpec extends Specification implements DomainUnitTest<Order> {
     void "Order.isFullyInvoiceable() should return FALSE when all order items are invoiceable and one adjustment are not"() {
         given: "An order with fully invoicebale order items and one order adjustment not invoiceable"
         OrderItem orderItem1 = Stub(OrderItem) {
+            canBeOnRegularInvoice() >> true
             isInvoiceable() >> true
             getQuantityRemaining() >> 0
         }
         OrderItem orderItem2 = Stub(OrderItem) {
+            canBeOnRegularInvoice() >> true
             isInvoiceable() >> true
             getQuantityRemaining() >> 0
         }
         OrderAdjustment adjustmentItem1 = Stub(OrderAdjustment) {
+            canBeOnRegularInvoice() >> true
             isInvoiceable() >> true
         }
         OrderAdjustment adjustmentItem2 = Stub(OrderAdjustment) {
+            canBeOnRegularInvoice() >> true
             isInvoiceable() >> false
         }
         Order order = new Order(orderItems: [orderItem1, orderItem2], orderAdjustments: [adjustmentItem1, adjustmentItem2])
@@ -202,17 +210,21 @@ class OrderSpec extends Specification implements DomainUnitTest<Order> {
     void "Order.isFullyInvoiceable() should return FALSE when all order adjustments are invoiceable and all order items are not"() {
         given: "An order with fully invoicebale order adjustments and all order items not invoiceable"
         OrderItem orderItem1 = Stub(OrderItem) {
+            canBeOnRegularInvoice() >> true
             isInvoiceable() >> false
             getQuantityRemaining() >> 0
         }
         OrderItem orderItem2 = Stub(OrderItem) {
+            canBeOnRegularInvoice() >> true
             isInvoiceable() >> false
             getQuantityRemaining() >> 0
         }
         OrderAdjustment adjustmentItem1 = Stub(OrderAdjustment) {
+            canBeOnRegularInvoice() >> true
             isInvoiceable() >> true
         }
         OrderAdjustment adjustmentItem2 = Stub(OrderAdjustment) {
+            canBeOnRegularInvoice() >> true
             isInvoiceable() >> true
         }
         Order order = new Order(orderItems: [orderItem1, orderItem2], orderAdjustments: [adjustmentItem1, adjustmentItem2])
@@ -224,17 +236,21 @@ class OrderSpec extends Specification implements DomainUnitTest<Order> {
     void "Order.isFullyInvoiceable() should return FALSE when all order adjustments are invoiceable and one order item is not"() {
         given: "An order with fully invoicebale order adjustments and one order item not invoiceable"
         OrderItem orderItem1 = Stub(OrderItem) {
+            canBeOnRegularInvoice() >> true
             isInvoiceable() >> false
             getQuantityRemaining() >> 0
         }
         OrderItem orderItem2 = Stub(OrderItem) {
+            canBeOnRegularInvoice() >> true
             isInvoiceable() >> true
             getQuantityRemaining() >> 0
         }
         OrderAdjustment adjustmentItem1 = Stub(OrderAdjustment) {
+            canBeOnRegularInvoice() >> true
             isInvoiceable() >> true
         }
         OrderAdjustment adjustmentItem2 = Stub(OrderAdjustment) {
+            canBeOnRegularInvoice() >> true
             isInvoiceable() >> true
         }
         Order order = new Order(orderItems: [orderItem1, orderItem2], orderAdjustments: [adjustmentItem1, adjustmentItem2])
@@ -246,17 +262,21 @@ class OrderSpec extends Specification implements DomainUnitTest<Order> {
     void "Order.isFullyInvoiceable() should return FALSE when at least one order item has quantity remaining is greater than 0"() {
         given: "An order with fully invoiceable items and one order items with quantity remaining more than 0"
         OrderItem orderItem1 = Stub(OrderItem) {
+            canBeOnRegularInvoice() >> true
             isInvoiceable() >> true
             getQuantityRemaining() >> 1
         }
         OrderItem orderItem2 = Stub(OrderItem) {
+            canBeOnRegularInvoice() >> true
             isInvoiceable() >> true
             getQuantityRemaining() >> 0
         }
         OrderAdjustment adjustmentItem1 = Stub(OrderAdjustment) {
+            canBeOnRegularInvoice() >> true
             isInvoiceable() >> true
         }
         OrderAdjustment adjustmentItem2 = Stub(OrderAdjustment) {
+            canBeOnRegularInvoice() >> true
             isInvoiceable() >> true
         }
         Order order = new Order(orderItems: [orderItem1, orderItem2], orderAdjustments: [adjustmentItem1, adjustmentItem2])


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:**
https://pihemr.atlassian.net/browse/OBPIH-6497

**Description:**
This is a fix to issues found during QA. Turned out that we had a few places that were mixing up quantities in UoM and quantities in standard UoM. 


---
### :chart_with_upwards_trend: Test Plan

> *We require that all code changes come paired with a method of testing them. Please select which of the following testing approaches you've included with this change:*

- [ ] Frontend automation tests (unit)
- [X] Backend automation tests ([unit](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3013869579/Backend+Unit+Testing+Standards), [API](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3013738522/Backend+Integration+Testing+Standards), smoke)
- [ ] End-to-end tests ([Playwright](https://pihemr.atlassian.net/wiki/spaces/OB/pages/2942828546/Knowledge+Transfer+on+automated+testing+with+Playwright))
- [x] Manual tests (please describe below)
- [ ] Not Applicable

**Description of test plan (if applicable):**


---
### :white_check_mark: Quality Checks

> *Please confirm and check each of the following to ensure that your change conforms to the coding standards of the project:*

- [X] The pull request title is prefixed with the issue/ticket number (Ex: `[OBS-123]` for Jira, `[#0000]` for GitHub, or `[OBS-123, OBPIH-123]` if there are multiple), or with `[N/A]` if not applicable
- [X] The pull request description has enough information for someone without context to be able to understand the change and why it is needed
- [X] The change has tests that prove the issue is fixed / the feature works as intended
