### PR TITLE
[OBPIH-6624] Default value on DateCell Component

### DIFF
--- a/src/js/components/DataTable/DateCell.jsx
+++ b/src/js/components/DataTable/DateCell.jsx
@@ -11,6 +11,7 @@ import { formatDate } from 'utils/translation-utils';
 const DateCell = ({
   displayDateFormat,
   displayDateDefaultValue,
+  defaultValue,
   localizeDate,
   formatLocalizedDate,
   formatLocalizedDateToDisplay,
@@ -32,7 +33,7 @@ const DateCell = ({
     <TableCell
       {...row}
       value={getValue()}
-      defaultValue={displayDateDefaultValue}
+      defaultValue={defaultValue ?? displayDateDefaultValue}
     />
   );
 };
@@ -48,11 +49,13 @@ export default connect(mapStateToProps)(DateCell);
 DateCell.defaultProps = {
   localizeDate: false,
   formatLocalizedDate: DateFormat.COMMON,
+  defaultValue: undefined,
 };
 
 DateCell.propTypes = {
   displayDateFormat: PropTypes.string.isRequired,
   displayDateDefaultValue: PropTypes.string.isRequired,
+  defaultValue: PropTypes.string,
   localizeDate: PropTypes.bool,
   formatLocalizedDate: PropTypes.string,
   formatLocalizedDateToDisplay: PropTypes.func.isRequired,

--- a/src/js/components/stock-movement-wizard/outboundImport/subsections/OutboundImportItems.jsx
+++ b/src/js/components/stock-movement-wizard/outboundImport/subsections/OutboundImportItems.jsx
@@ -58,7 +58,7 @@ const OutboundImportItems = ({ data, errors }) => {
       Header: translate('react.outboundImport.table.column.expirationDate.label', 'Expiry'),
       accessor: 'expirationDate',
       width: 120,
-      Cell: (row) => <DateCell {...row} />,
+      Cell: (row) => <DateCell {...row} defaultValue="" />,
     },
     {
       Header: translate('react.outboundImport.table.column.quantityPicked.label', 'Qty Picked'),


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** [OBPIH-6624](https://pihemr.atlassian.net/browse/OBPIH-6624)

**Description:**
This is a small UI change where we want to display an empty cell instead of a default value which is a `"-"`. I noticed that on `DateCell` components we do not have a customizable prop for this value so I implemented it and made appropriate changes to the Full outbound workflow table expiration date column

---
### :camera: Screenshots & Recordings (optional)

> *If this PR contains a UI change, consider adding one or more screenshots here or link to a screen recording to help reviewers visualize the change. Otherwise, you can remove this section.*
![image](https://github.com/user-attachments/assets/7d783ad0-4969-4191-8364-5b9f258c9451)

---
### :chart_with_upwards_trend: Test Plan

> *We require that all code changes come paired with a method of testing them. Please select which of the following testing approaches you've included with this change:*

- [ ] Frontend automation tests (unit)
- [ ] Backend automation tests ([unit](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3013869579/Backend+Unit+Testing+Standards), [API](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3013738522/Backend+Integration+Testing+Standards), smoke)
- [ ] End-to-end tests ([Playwright](https://pihemr.atlassian.net/wiki/spaces/OB/pages/2942828546/Knowledge+Transfer+on+automated+testing+with+Playwright))
- [ ] Manual tests (please describe below)
- [X] Not Applicable

**Description of test plan (if applicable):**


---
### :white_check_mark: Quality Checks

> *Please confirm and check each of the following to ensure that your change conforms to the coding standards of the project:*

- [X] The pull request title is prefixed with the issue/ticket number (Ex: `[OBS-123]` for Jira, `[#0000]` for GitHub, or `[OBS-123, OBPIH-123]` if there are multiple), or with `[N/A]` if not applicable
- [X] The pull request description has enough information for someone without context to be able to understand the change and why it is needed
- [ ] The change has tests that prove the issue is fixed / the feature works as intended


[OBPIH-6624]: https://pihemr.atlassian.net/browse/OBPIH-6624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ