### PR TITLE
OBPIH-6499 Do not create inverse items for order item and adjustment …

### DIFF
--- a/grails-app/services/org/pih/warehouse/invoice/PrepaymentInvoiceService.groovy
+++ b/grails-app/services/org/pih/warehouse/invoice/PrepaymentInvoiceService.groovy
@@ -58,7 +58,9 @@ class PrepaymentInvoiceService {
                 InvoiceItem invoiceItem = createFromOrderItem(orderItem)
                 InvoiceItem inverseItem = createInverseItemForCanceledOrderItem(orderItem)
                 invoice.addToInvoiceItems(invoiceItem)
-                invoice.addToInvoiceItems(inverseItem)
+                if (inverseItem) {
+                    invoice.addToInvoiceItems(inverseItem)
+                }
                 return
             }
 
@@ -76,7 +78,9 @@ class PrepaymentInvoiceService {
             InvoiceItem invoiceItem = createFromOrderAdjustment(orderAdjustment)
             InvoiceItem inverseItem = createInverseItemForOrderAdjustment(orderAdjustment)
             invoice.addToInvoiceItems(invoiceItem)
-            invoice.addToInvoiceItems(inverseItem)
+            if (inverseItem) {
+                invoice.addToInvoiceItems(inverseItem)
+            }
         }
 
         return invoice.save()
@@ -152,6 +156,9 @@ class PrepaymentInvoiceService {
 
     private InvoiceItem createInverseItemForCanceledOrderItem(OrderItem orderItem) {
         InvoiceItem prepaymentItem = orderItem.invoiceItems.find { it.isPrepaymentInvoice }
+        if (!prepaymentItem) {
+            return null
+        }
         InvoiceItem inverseItem = createFromOrderItem(orderItem)
         // For canceled order item take quantity from prepayment item
         inverseItem.quantity = prepaymentItem.quantity
@@ -166,6 +173,9 @@ class PrepaymentInvoiceService {
         OrderItem orderItem = shipmentItem.orderItems?.find { it }
         BigDecimal prepaymentPercent = (orderItem.order.paymentTerm?.prepaymentPercent ?: Constants.DEFAULT_PAYMENT_PERCENT) / 100
         InvoiceItem prepaymentItem = orderItem.invoiceItems.find { it.isPrepaymentInvoice }
+        if (!prepaymentItem) {
+            return null
+        }
         InvoiceItem inverseItem = createFromShipmentItem(shipmentItem)
         // For shipment items we have to check if the ordered quantity was edited after prepayment was generated.
         // If that was the case we have to check maximum quantity available to inverse
@@ -185,6 +195,9 @@ class PrepaymentInvoiceService {
 
     private InvoiceItem createInverseItemForOrderAdjustment(OrderAdjustment orderAdjustment) {
         InvoiceItem prepaymentItem = orderAdjustment.invoiceItems.find { it.isPrepaymentInvoice }
+        if (!prepaymentItem) {
+            return null
+        }
         InvoiceItem inverseItem = createFromOrderAdjustment(orderAdjustment)
         // For order adjustment invoiceItem.quantity is 1 or 0, but for inverse should be for now 1
         inverseItem.quantity = 1


### PR DESCRIPTION
…if there is no prepayment

### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:**
https://pihemr.atlassian.net/browse/OBPIH-6499

**Description:**
Improvement in generating inverse items (I already skipped generating inverse items for shipment items if there is not prepayment, but I forgot about order items and adjustment)

---
### :chart_with_upwards_trend: Test Plan

> *We require that all code changes come paired with a method of testing them. Please select which of the following testing approaches you've included with this change:*

- [ ] Frontend automation tests (unit)
- [ ] Backend automation tests ([unit](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3013869579/Backend+Unit+Testing+Standards), [API](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3013738522/Backend+Integration+Testing+Standards), smoke)
- [ ] End-to-end tests ([Playwright](https://pihemr.atlassian.net/wiki/spaces/OB/pages/2942828546/Knowledge+Transfer+on+automated+testing+with+Playwright))
- [X] Manual tests (please describe below)
- [ ] Not Applicable

**Description of test plan (if applicable):**


---
### :white_check_mark: Quality Checks

> *Please confirm and check each of the following to ensure that your change conforms to the coding standards of the project:*

- [X] The pull request title is prefixed with the issue/ticket number (Ex: `[OBS-123]` for Jira, `[#0000]` for GitHub, or `[OBS-123, OBPIH-123]` if there are multiple), or with `[N/A]` if not applicable
- [X] The pull request description has enough information for someone without context to be able to understand the change and why it is needed
- [ ] The change has tests that prove the issue is fixed / the feature works as intended
