### PR TITLE
OBPIH-6499 Do not create inverse if no quantity to inverse

### DIFF
--- a/grails-app/services/org/pih/warehouse/invoice/PrepaymentInvoiceService.groovy
+++ b/grails-app/services/org/pih/warehouse/invoice/PrepaymentInvoiceService.groovy
@@ -176,13 +176,13 @@ class PrepaymentInvoiceService {
         if (!prepaymentItem) {
             return null
         }
-        InvoiceItem inverseItem = createFromShipmentItem(shipmentItem)
         // For shipment items we have to check if the ordered quantity was edited after prepayment was generated.
         // If that was the case we have to check maximum quantity available to inverse
         Integer quantityInverseable = getQuantityAvailableToInverse(orderItem, prepaymentItem)
         if (!quantityInverseable || quantityInverseable < 0) {
             return null
         }
+        InvoiceItem inverseItem = createFromShipmentItem(shipmentItem)
         Integer quantity = invoiceItem.quantity >= quantityInverseable ? quantityInverseable : invoiceItem.quantity
         inverseItem.quantity = quantity
         inverseItem.inverse = true


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:**
https://pihemr.atlassian.net/browse/OBPIH-6499

**Description:**
Fix for the issue found during QA (If there will be created dangling item due to transactional it will be saved as an orphan and an error is thrown. There is need to change ordering to avoid this issue - first check if there is quantity to inverse and then create inverse item)

---
### :chart_with_upwards_trend: Test Plan

> *We require that all code changes come paired with a method of testing them. Please select which of the following testing approaches you've included with this change:*

- [ ] Frontend automation tests (unit)
- [ ] Backend automation tests ([unit](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3013869579/Backend+Unit+Testing+Standards), [API](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3013738522/Backend+Integration+Testing+Standards), smoke)
- [ ] End-to-end tests ([Playwright](https://pihemr.atlassian.net/wiki/spaces/OB/pages/2942828546/Knowledge+Transfer+on+automated+testing+with+Playwright))
- [X] Manual tests (please describe below)
- [ ] Not Applicable

---
### :white_check_mark: Quality Checks

> *Please confirm and check each of the following to ensure that your change conforms to the coding standards of the project:*

- [X] The pull request title is prefixed with the issue/ticket number (Ex: `[OBS-123]` for Jira, `[#0000]` for GitHub, or `[OBS-123, OBPIH-123]` if there are multiple), or with `[N/A]` if not applicable
- [X] The pull request description has enough information for someone without context to be able to understand the change and why it is needed
- [ ] The change has tests that prove the issue is fixed / the feature works as intended
