### PR TITLE
OBPIH-6641 Allow invoicing uncanceled order adjustments (even if it w…

### DIFF
--- a/grails-app/domain/org/pih/warehouse/order/OrderAdjustment.groovy
+++ b/grails-app/domain/org/pih/warehouse/order/OrderAdjustment.groovy
@@ -137,7 +137,7 @@ class OrderAdjustment implements Serializable, Comparable<OrderAdjustment> {
      * Adjustment is invoiceable on regular invoice if:
      *  - if adjustment is canceled, we can invoice if it has prepayment, does not have regular already and order is placed
      *  - if adjustment is not canceled, and it was previously invoiced as canceled on regular invoice
-     *  - if adjustment has no reguler invoice yet and order is placed
+     *  - if adjustment has no regular invoice yet and order is placed
      * */
     Boolean isInvoiceable() {
         if (canceled) {

--- a/grails-app/services/org/pih/warehouse/invoice/PrepaymentInvoiceService.groovy
+++ b/grails-app/services/org/pih/warehouse/invoice/PrepaymentInvoiceService.groovy
@@ -197,6 +197,10 @@ class PrepaymentInvoiceService {
         if (!prepaymentItem) {
             return null
         }
+        if (orderAdjustment.inversedQuantity > 0) {
+            return null
+        }
+
         InvoiceItem inverseItem = createFromOrderAdjustment(orderAdjustment)
         // For order adjustment invoiceItem.quantity is 1 or 0, but for inverse should be for now 1
         inverseItem.quantity = 1

--- a/src/test/groovy/unit/org/pih/warehouse/order/OrderAdjustmentSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/order/OrderAdjustmentSpec.groovy
@@ -9,12 +9,14 @@ import spock.lang.Unroll
 
 @Unroll
 class OrderAdjustmentSpec extends Specification implements DomainUnitTest<OrderAdjustment> {
-    void 'OrderAdjustment.getIsInvoiceable() should return #isInvoiceable when the status of order is: #orderStatus and has regular invoice: #hasRegularInvoice'() {
+    void 'OrderAdjustment.getIsInvoiceable() should return #isInvoiceable when canceled: #canceled, the status of order is: #orderStatus and has regular invoice: #hasRegularInvoice'() {
         given:
         OrderAdjustment orderAdjustment = Spy(OrderAdjustment) {
             getHasRegularInvoice() >> hasRegularInvoice
             getHasPrepaymentInvoice() >> true
+            getInvoicedQuantity() >> 0
         }
+        orderAdjustment.canceled = canceled
         orderAdjustment.order = Spy(Order)
         orderAdjustment.order.status = orderStatus
 
@@ -22,10 +24,11 @@ class OrderAdjustmentSpec extends Specification implements DomainUnitTest<OrderA
         orderAdjustment.invoiceable == isInvoiceable
 
         where:
-        orderStatus         | hasRegularInvoice  || isInvoiceable
-        OrderStatus.PENDING | false              || false
-        OrderStatus.PLACED  | false              || true
-        OrderStatus.PENDING | false              || false
-        OrderStatus.PLACED  | true               || false
+        orderStatus         | hasRegularInvoice  |  canceled || isInvoiceable
+        OrderStatus.PENDING | false              |  true     || false
+        OrderStatus.PLACED  | false              |  true     || true
+        OrderStatus.PENDING | false              |  false    || false
+        OrderStatus.PLACED  | true               |  true     || false
+        OrderStatus.PLACED  | true               |  false    || true
     }
 }


### PR DESCRIPTION
…as already invoiced as a canceled)

### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:**
https://pihemr.atlassian.net/browse/OBPIH-6641

**Description:**
If the adjustment was canceled -> invoiced (as canceled, with quantity 0) -> uncanceled, then it should be possible to invoice it again with full (1) quantity.

---
### :chart_with_upwards_trend: Test Plan

- [ ] Frontend automation tests (unit)
- [X] Backend automation tests ([unit](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3013869579/Backend+Unit+Testing+Standards), [API](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3013738522/Backend+Integration+Testing+Standards), smoke)
- [ ] End-to-end tests ([Playwright](https://pihemr.atlassian.net/wiki/spaces/OB/pages/2942828546/Knowledge+Transfer+on+automated+testing+with+Playwright))
- [X] Manual tests (please describe below)
- [ ] Not Applicable

---
### :white_check_mark: Quality Checks

- [X] The pull request title is prefixed with the issue/ticket number (Ex: `[OBS-123]` for Jira, `[#0000]` for GitHub, or `[OBS-123, OBPIH-123]` if there are multiple), or with `[N/A]` if not applicable
- [X] The pull request description has enough information for someone without context to be able to understand the change and why it is needed
- [X] The change has tests that prove the issue is fixed / the feature works as intended
