### PR TITLE
[OBPIH-6659] Display quantity of invoiced items only after invoice has been posted

### DIFF
--- a/grails-app/domain/org/pih/warehouse/order/OrderItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/order/OrderItem.groovy
@@ -411,7 +411,7 @@ class OrderItem implements Serializable, Comparable<OrderItem> {
 
     // Check quantity (standard uom) in posted invoices
     Integer getPostedQuantityInvoicedInStandardUom() {
-        return postedQuantityInvoiced * (quantityPerUom?:1)
+        return postedQuantityInvoiced * (quantityPerUom ?: 1)
     }
 
     def getInvoices() {
@@ -433,7 +433,7 @@ class OrderItem implements Serializable, Comparable<OrderItem> {
     Integer getPostedQuantityInvoiced() {
         return allInvoiceItems?.findAll {
             it?.invoice?.datePosted != null && !it?.invoice?.isPrepaymentInvoice && !it.inverse
-        }?.collect {  it.quantity }?.sum() ?: 0
+        }?.sum { it.quantity } ?: 0
     }
 
     Set<ShipmentItem> getInvoiceableShipmentItems() {

--- a/grails-app/views/order/_itemStatus.gsp
+++ b/grails-app/views/order/_itemStatus.gsp
@@ -78,7 +78,7 @@
                         ${orderItem?.quantityReceived}
                     </td>
                     <td class="right">
-                        ${orderItem?.quantityInvoicedInStandardUom}
+                        ${orderItem?.postedQuantityInvoicedInStandardUom}
                     </td>
                     <td class="">
                         <g:formatNumber number="${orderItem?.unitPrice?:0}" />


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** [OBPIH-6659](https://pihemr.atlassian.net/browse/OBPIH-6659)

**Description:**
Issue was that when user would generate a partial invoice but "save & exit" instead of posting, it would display invoiced quantity on Item statuses. The expected behavior is that the quantity invoiced should display only after the the invoice has been posted

---
### :camera: Screenshots & Recordings (optional)

> *If this PR contains a UI change, consider adding one or more screenshots here or link to a screen recording to help reviewers visualize the change. Otherwise, you can remove this section.*


---
### :chart_with_upwards_trend: Test Plan

> *We require that all code changes come paired with a method of testing them. Please select which of the following testing approaches you've included with this change:*

- [ ] Frontend automation tests (unit)
- [ ] Backend automation tests ([unit](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3013869579/Backend+Unit+Testing+Standards), [API](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3013738522/Backend+Integration+Testing+Standards), smoke)
- [ ] End-to-end tests ([Playwright](https://pihemr.atlassian.net/wiki/spaces/OB/pages/2942828546/Knowledge+Transfer+on+automated+testing+with+Playwright))
- [ ] Manual tests (please describe below)
- [X] Not Applicable

**Description of test plan (if applicable):**


---
### :white_check_mark: Quality Checks

> *Please confirm and check each of the following to ensure that your change conforms to the coding standards of the project:*

- [X] The pull request title is prefixed with the issue/ticket number (Ex: `[OBS-123]` for Jira, `[#0000]` for GitHub, or `[OBS-123, OBPIH-123]` if there are multiple), or with `[N/A]` if not applicable
- [X] The pull request description has enough information for someone without context to be able to understand the change and why it is needed
- [ ] The change has tests that prove the issue is fixed / the feature works as intended


[OBPIH-6659]: https://pihemr.atlassian.net/browse/OBPIH-6659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ