### PR TITLE
OBPIH-6644 Fix calculating inverse item after reducing ordered quantity

### DIFF
--- a/grails-app/services/org/pih/warehouse/invoice/PrepaymentInvoiceService.groovy
+++ b/grails-app/services/org/pih/warehouse/invoice/PrepaymentInvoiceService.groovy
@@ -182,7 +182,13 @@ class PrepaymentInvoiceService {
             return null
         }
         InvoiceItem inverseItem = createFromShipmentItem(shipmentItem)
-        Integer quantity = invoiceItem.quantity >= quantityInverseable ? quantityInverseable : invoiceItem.quantity
+        Integer quantity
+        if (orderItem.isCompletelyFulfilled() && orderItem.isFullyInvoiced()) {
+            // If quantity if fully shipped and fully invoiced set full inverse quantity
+            quantity = quantityInverseable
+        } else {
+            quantity = invoiceItem.quantity >= quantityInverseable ? quantityInverseable : invoiceItem.quantity
+        }
         inverseItem.quantity = quantity
         inverseItem.inverse = true
         inverseItem.unitPrice = prepaymentItem.unitPrice


### PR DESCRIPTION
### :sparkles: Description of Change
**Link to GitHub issue or Jira ticket:**
https://pihemr.atlassian.net/browse/OBPIH-6644

**Description:**
When an order item had quantity reduced after making a prepayment, then it was not fully inversed. There was a need for a fix while calculating inverse quantity to take a look if the ordered item is both fully shipped and fully invoiced, and then add inverse item with quantity available to inverse.

---
### :chart_with_upwards_trend: Test Plan
- [ ] Frontend automation tests (unit)
- [ ] Backend automation tests ([unit](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3013869579/Backend+Unit+Testing+Standards), [API](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3013738522/Backend+Integration+Testing+Standards), smoke)
- [ ] End-to-end tests ([Playwright](https://pihemr.atlassian.net/wiki/spaces/OB/pages/2942828546/Knowledge+Transfer+on+automated+testing+with+Playwright))
- [X] Manual tests (please describe below)
- [ ] Not Applicable

**Description of test plan (if applicable):**
According to reproduction steps

---
### :white_check_mark: Quality Checks
- [X] The pull request title is prefixed with the issue/ticket number (Ex: `[OBS-123]` for Jira, `[#0000]` for GitHub, or `[OBS-123, OBPIH-123]` if there are multiple), or with `[N/A]` if not applicable
- [X] The pull request description has enough information for someone without context to be able to understand the change and why it is needed
- [ ] The change has tests that prove the issue is fixed / the feature works as intended
