### PR TITLE
OBPIH-6660 Fix roles removal after submitting full outbound import ac…

### DIFF
--- a/src/js/components/stock-movement-wizard/outboundImport/OutboundImport.jsx
+++ b/src/js/components/stock-movement-wizard/outboundImport/OutboundImport.jsx
@@ -9,6 +9,7 @@ import OutboundImportDetails from 'components/stock-movement-wizard/outboundImpo
 import WizardStepsV2 from 'components/wizard/v2/WizardStepsV2';
 import OutboundImportStep from 'consts/OutboundImportStep';
 import useOutboundImportForm from 'hooks/outboundImport/useOutboundImportForm';
+import useOutboundImportValidation from 'hooks/outboundImport/useOutboundImportValidation';
 import useSessionStorage from 'hooks/useSessionStorage';
 import useTranslate from 'hooks/useTranslate';
 import useTranslation from 'hooks/useTranslation';
@@ -66,6 +67,12 @@ const OutboundImport = () => {
     trigger,
   } = useOutboundImportForm({ next });
 
+  const {
+    requestedBySchema,
+    originSchema,
+    destinationSchema,
+  } = useOutboundImportValidation();
+
   /** Redirect to first step if there is no cached data */
   useEffect(() => {
     if (_.isEmpty(cachedData) && !is(OutboundImportStep.DETAILS)) {
@@ -89,8 +96,14 @@ const OutboundImport = () => {
    * Related ticket OBPIH-6627 (Keep filled form progress when refreshing the page)
    */
   const handleConfirmSubmitForm = (submitMethod) => (event) => {
+    const values = getValues();
+    const requestedBy = requestedBySchema.parse(values.requestedBy);
+    const origin = originSchema.parse(values.origin);
+    const destination = destinationSchema.parse(values.destination);
     event.preventDefault();
-    submitMethod(getValues());
+    submitMethod({
+      ...values, requestedBy, origin, destination,
+    });
   };
 
   const redoImport = () => {

--- a/src/js/hooks/outboundImport/useOutboundImportValidation.js
+++ b/src/js/hooks/outboundImport/useOutboundImportValidation.js
@@ -5,36 +5,40 @@ import { validateDateIsSameOrAfter, validateFutureDate } from 'utils/form-utils'
 
 const useOutboundImportValidation = () => {
   const translate = useTranslate();
+  const requestedBySchema = z.object({
+    id: z.string(),
+    label: z.string(),
+    name: z.string(),
+  }, {
+    invalid_type_error: translate('react.outboundImport.validation.requestedBy.required.label', 'Requested by is required'),
+    required_error: translate('react.outboundImport.validation.requestedBy.required.label', 'Requested by is required'),
+  }).required();
+  const originSchema = z.object({
+    id: z.string(),
+    label: z.string(),
+    name: z.string(),
+  }, {
+    invalid_type_error: translate('react.outboundImport.validation.origin.required.label', 'Origin is required'),
+    required_error: translate('react.outboundImport.validation.origin.required.label', 'Origin is required'),
+  }).required();
+  const destinationSchema = z.object({
+    id: z.string(),
+    label: z.string(),
+    name: z.string(),
+  }, {
+    invalid_type_error: translate('react.outboundImport.validation.destination.required.label', 'Destination is required'),
+    required_error: translate('react.outboundImport.validation.destination.required.label', 'Destination is required'),
+  }).required();
+
   const validationSchema = (data) => z.object({
     description: z
       .string({
         required_error: translate('react.outboundImport.validation.description.required.label', 'Description is required'),
       })
       .min(1, translate('react.outboundImport.validation.description.required.label', 'Description is required')),
-    origin: z.object({
-      id: z.string(),
-      label: z.string(),
-      name: z.string(),
-    }, {
-      invalid_type_error: translate('react.outboundImport.validation.origin.required.label', 'Origin is required'),
-      required_error: translate('react.outboundImport.validation.origin.required.label', 'Origin is required'),
-    }).required(),
-    destination: z.object({
-      id: z.string(),
-      label: z.string(),
-      name: z.string(),
-    }, {
-      invalid_type_error: translate('react.outboundImport.validation.destination.required.label', 'Destination is required'),
-      required_error: translate('react.outboundImport.validation.destination.required.label', 'Destination is required'),
-    }).required(),
-    requestedBy: z.object({
-      id: z.string(),
-      label: z.string(),
-      name: z.string(),
-    }, {
-      invalid_type_error: translate('react.outboundImport.validation.requestedBy.required.label', 'Requested by is required'),
-      required_error: translate('react.outboundImport.validation.requestedBy.required.label', 'Requested by is required'),
-    }).required(),
+    origin: originSchema,
+    destination: destinationSchema,
+    requestedBy: requestedBySchema,
     dateRequested: z.string({
       required_error: translate('react.outboundImport.validation.dateRequested.required.label', 'Date requested is required'),
       invalid_type_error: translate('react.outboundImport.validation.dateRequested.required.label', 'Date requested is required'),
@@ -76,6 +80,9 @@ const useOutboundImportValidation = () => {
 
   return {
     validationSchema,
+    destinationSchema,
+    originSchema,
+    requestedBySchema,
   };
 };
 


### PR DESCRIPTION
After latest changes to saving progress in full outbound import, there was one regression connected to the `handleConfirmSubmitForm` - the form values that are handled automaically were first parsed by the Zod schema, whereas the `getValues()` used in this method, were returning whole objects, in this case - instead of returning only `id`, `name`, `label` for a user and passing it to the backend, we were sending whole user object including roles, that were not parsed correctly.
