### PR TITLE
OBPIH-6636 Trigger order summary refresh after editing existing item quantity

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/order/OrderController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/order/OrderController.groovy
@@ -766,6 +766,10 @@ class OrderController {
             if (!orderService.isOrderEditable(orderItem.order, session.user)) {
                 throw new UnsupportedOperationException("${warehouse.message(code: 'errors.noPermissions.label')}")
             }
+            if (params.quantity && orderItem.quantity != (params.quantity as Integer)) {
+                // if existing item's quantity is edited we have to trigger the order summary refresh
+                orderItem.disableRefresh = false
+            }
             orderItem.properties = params
             orderItem.refreshPendingShipmentItemRecipients()
         }


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:**
https://pihemr.atlassian.net/browse/OBPIH-6636

**Description:**
The order summary materialized view was not refreshing when the order items quantity was edited.

---
### :chart_with_upwards_trend: Test Plan

- [ ] Frontend automation tests (unit)
- [ ] Backend automation tests ([unit](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3013869579/Backend+Unit+Testing+Standards), [API](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3013738522/Backend+Integration+Testing+Standards), smoke)
- [ ] End-to-end tests ([Playwright](https://pihemr.atlassian.net/wiki/spaces/OB/pages/2942828546/Knowledge+Transfer+on+automated+testing+with+Playwright))
- [X] Manual tests (please describe below)
- [ ] Not Applicable

**Description of test plan (if applicable):**
According to the reproduction steps

---
### :white_check_mark: Quality Checks

- [X] The pull request title is prefixed with the issue/ticket number (Ex: `[OBS-123]` for Jira, `[#0000]` for GitHub, or `[OBS-123, OBPIH-123]` if there are multiple), or with `[N/A]` if not applicable
- [X] The pull request description has enough information for someone without context to be able to understand the change and why it is needed
- [ ] The change has tests that prove the issue is fixed / the feature works as intended
