### PR TITLE
[OBPIH-6516] [Fix after QA] Add origin location to Product Availability search condition

### DIFF
--- a/src/main/groovy/org/pih/warehouse/outbound/ImportPackingListItem.groovy
+++ b/src/main/groovy/org/pih/warehouse/outbound/ImportPackingListItem.groovy
@@ -32,11 +32,11 @@ class ImportPackingListItem implements Validateable {
         // otherwise infer inventory item based on provided bin-location
         Location internalLocation = Location.findByNameAndParentLocation(source['binLocation'], obj.origin)
         Product product = Product.findByProductCode(source['product'])
-        List<ProductAvailability> items = ProductAvailability.findAllByProductAndBinLocation(product, internalLocation)
+        List<ProductAvailability> items = ProductAvailability.findAllByProductAndBinLocationAndLocation(product, internalLocation, obj.origin)
 
         // infer lot-number only if there is a single possible inventory
         if (items.size() == 1) {
-            return items.first().lotNumber
+            return items.first().inventoryItem?.lotNumber
         }
 
         return null


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:**

**Description:**
The query was missing an additional condition which was the origin location for Product Availability.
Without it, it would search for all PA in all available locations.

Additionally retuned lotNumber from inventory Item object because there is a difference in displaying these values.
InventoryItem object for default lot number has lotNumber as null while the property on ProductAvailability has a string value "DEFAULT".
QA requested to unify this display as in other similar places and not show any text for default lots

---
### :camera: Screenshots & Recordings (optional)

> *If this PR contains a UI change, consider adding one or more screenshots here or link to a screen recording to help reviewers visualize the change. Otherwise, you can remove this section.*


---
### :chart_with_upwards_trend: Test Plan

> *We require that all code changes come paired with a method of testing them. Please select which of the following testing approaches you've included with this change:*

- [ ] Frontend automation tests (unit)
- [ ] Backend automation tests ([unit](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3013869579/Backend+Unit+Testing+Standards), [API](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3013738522/Backend+Integration+Testing+Standards), smoke)
- [ ] End-to-end tests ([Playwright](https://pihemr.atlassian.net/wiki/spaces/OB/pages/2942828546/Knowledge+Transfer+on+automated+testing+with+Playwright))
- [ ] Manual tests (please describe below)
- [X] Not Applicable

**Description of test plan (if applicable):**


---
### :white_check_mark: Quality Checks

> *Please confirm and check each of the following to ensure that your change conforms to the coding standards of the project:*

- [x] The pull request title is prefixed with the issue/ticket number (Ex: `[OBS-123]` for Jira, `[#0000]` for GitHub, or `[OBS-123, OBPIH-123]` if there are multiple), or with `[N/A]` if not applicable
- [x] The pull request description has enough information for someone without context to be able to understand the change and why it is needed
- [ ] The change has tests that prove the issue is fixed / the feature works as intended
