### PR TITLE
[OBPIH-6673] Fix searchTerm variable typo on Person search method

### DIFF
--- a/grails-app/domain/org/pih/warehouse/core/Person.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Person.groovy
@@ -68,10 +68,10 @@ class Person implements Comparable, Serializable {
         String[] searchTerms = searchTerm?.split(Constants.SPACE_SEPARATOR)
         // If search term contains two words, try to search by first name or last name first
         if (searchTerms?.length == 2) {
-            return findByFirstNameAndLastName(searchTerm[0], searchTerm[1])
+            return findByFirstNameAndLastName(searchTerms[0], searchTerms[1])
         }
         if (searchTerms?.length == 1) {
-            return findByEmail(searchTerm[0])
+            return findByEmail(searchTerms[0])
         }
         return null
     }


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** [OBPIH-6673](https://pihemr.atlassian.net/browse/OBPIH-6673)

**Description:**
After #4829 was merged there was a typo in `searchTerm` variable or rather a wrong variable was used as an argument in a query search.

---
### :camera: Screenshots & Recordings (optional)

> *If this PR contains a UI change, consider adding one or more screenshots here or link to a screen recording to help reviewers visualize the change. Otherwise, you can remove this section.*


[OBPIH-6673]: https://pihemr.atlassian.net/browse/OBPIH-6673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ