### PR TITLE
OBPIH-6675 Errors cached despite leaving outbound import workflow

### DIFF
--- a/src/js/hooks/outboundImport/useOutboundImportForm.js
+++ b/src/js/hooks/outboundImport/useOutboundImportForm.js
@@ -267,8 +267,16 @@ const useOutboundImportForm = ({ next }) => {
     }
   };
 
+  const handleLoadCachedData = () => {
+    if (OutboundImportStep.CONFIRM === queryParams?.step) {
+      loadCachedData();
+      return;
+    }
+    clearCachedData();
+  };
+
   useEffect(() => {
-    loadCachedData();
+    handleLoadCachedData();
 
     if (currentLocation) {
       setValue('origin', {

--- a/src/js/hooks/outboundImport/useOutboundImportForm.js
+++ b/src/js/hooks/outboundImport/useOutboundImportForm.js
@@ -67,8 +67,6 @@ const useOutboundImportForm = ({ next }) => {
         values.trackingNumber = sendingOptions?.trackingNumber;
         values.comments = sendingOptions?.comments;
         values.expectedDeliveryDate = sendingOptions?.expectedDeliveryDate;
-      } else {
-        clearCachedData();
       }
     }
 


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket: https://pihemr.atlassian.net/browse/OBPIH-6675?atlOrigin=eyJpIjoiZDA1OTBlNmVjN2U5NDk5ZmFhOGY1YWE3MmFkMmYwOTMiLCJwIjoiaiJ9**

**Description:**

The problem here was that the cached data was cleared, but two `useEffects` were affecting themselves, hence before they were cleared, the cached data was sent for validation, as it was not empty yet.
To fix that, we want to load the cached data only if we are on the confirm step.


