### PR TITLE
OBPIH-6676 Fix binding of inferred lot expiration date

### DIFF
--- a/src/main/groovy/org/pih/warehouse/outbound/ImportPackingListItem.groovy
+++ b/src/main/groovy/org/pih/warehouse/outbound/ImportPackingListItem.groovy
@@ -116,16 +116,16 @@ class ImportPackingListItem implements Validateable {
             }
         })
         quantityPicked(min: 1, validator: { Integer quantityPicked, ImportPackingListItem item ->
-            if (!item.binLocationFound) {
-                return ['binLocationNotFound', item.binLocation?.name]
-            }
-            ProductAvailabilityService productAvailabilityService = Holders.grailsApplication.mainContext.getBean(ProductAvailabilityService)
             InventoryItem inventoryItem = item.product?.getInventoryItem(item.lotNumber)
             if (!inventoryItem) {
                 return ['inventoryItemNotFound']
             }
             // Associate inventory item's expiration date with expirationDateToDisplay, to display the date in the table
             item.expirationDateToDisplay = inventoryItem.expirationDate
+            if (!item.binLocationFound) {
+                return ['binLocationNotFound', item.binLocation?.name]
+            }
+            ProductAvailabilityService productAvailabilityService = Holders.grailsApplication.mainContext.getBean(ProductAvailabilityService)
             Integer quantity = productAvailabilityService.getQuantityAvailableToPromiseForProductInBin(item.origin, item.binLocation, inventoryItem)
             if (quantity <= 0) {
                 return ['stockout']


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6676

**Description:**
There was a case where user provided a non existing binLocation and as a result the expiration date for existing lot was not populated. To fix this issue I just changed the order of the validation and if the inventoryItem existing then bind the expiration date and only after that we validate for bin location

---
### :camera: Screenshots & Recordings (optional)

> *If this PR contains a UI change, consider adding one or more screenshots here or link to a screen recording to help reviewers visualize the change. Otherwise, you can remove this section.*
