### PR TITLE
[OBPIH-6612] BUGFIX: set amount field when migrating existing final prepayment invoice items

### DIFF
--- a/grails-app/migrations/0.9.x/changelog-2024-08-20-0000-migrate-prepayment-invoices-add-amount-and-inverse-items.groovy
+++ b/grails-app/migrations/0.9.x/changelog-2024-08-20-0000-migrate-prepayment-invoices-add-amount-and-inverse-items.groovy
@@ -36,8 +36,8 @@ databaseChangeLog = {
     }
 
     /*
-     * STEP 2: For every pre-existing prepayment invoice, for every invoice item, add an inverse invoice
-     *         item to the final invoice of the order.
+     * STEP 2: For every pre-existing prepayment invoice, for every invoice item, set the amount field
+     *         and add an inverse invoice item to the final invoice of the order.
      *
      * For existing data from before the partial invoicing feature was introduced, ALL non-prepayment
      * invoices will ALWAYS be the final invoice, meaning every order will have one prepayment invoice
@@ -87,7 +87,7 @@ databaseChangeLog = {
                         continue
                     }
 
-                    prepaymentInvoiceMigrationService.generateInverseInvoiceItems(prepaymentInvoice, regularInvoice)
+                    prepaymentInvoiceMigrationService.migrateFinalInvoice(prepaymentInvoice, regularInvoice)
 
                     totalOrdersMigrated++
                 }

--- a/grails-app/services/org/pih/warehouse/invoice/PrepaymentInvoiceMigrationService.groovy
+++ b/grails-app/services/org/pih/warehouse/invoice/PrepaymentInvoiceMigrationService.groovy
@@ -4,7 +4,6 @@ import grails.gorm.transactions.Transactional
 
 import org.pih.warehouse.order.OrderAdjustment
 import org.pih.warehouse.order.OrderItem
-import org.pih.warehouse.order.OrderItemStatusCode
 
 /**
  * This service exists for the sole purpose of performing data migrations for changelog 0.9.x/2024-08-20-0000.
@@ -18,16 +17,21 @@ class PrepaymentInvoiceMigrationService {
      *
      * Set the amount field for all prepayment invoice items that existed before the partial invoicing
      * feature was introduced.
+     *
+     * We don't need to check for canceled items or adjustment during this step because anything that was canceled
+     * before the prepayment invoice was created wouldn't be included in the prepayment invoice in the first place.
      */
     void updateAmountForPrepaymentInvoiceItems() {
         InvoiceType prepaymentInvoiceType = InvoiceType.findByCode(InvoiceTypeCode.PREPAYMENT_INVOICE)
         List<Invoice> prepaymentInvoices = Invoice.findAllByInvoiceType(prepaymentInvoiceType)
         for (Invoice prepaymentInvoice : prepaymentInvoices) {
-            // The amount field will be null for all pre-existing invoices since the field was not being used.
             for (InvoiceItem prepaymentInvoiceItem : prepaymentInvoice.invoiceItems) {
+                // The amount field will only be null for pre-existing, non-inversed invoices since the field was
+                // not being used before the partial invoicing feature was introduced.
                 if (prepaymentInvoiceItem.amount != null) {
                     continue
                 }
+
                 prepaymentInvoiceItem.amount = computePrepaymentInvoiceItemAmount(prepaymentInvoiceItem)
                 prepaymentInvoiceItem.save(failOnError: true)
             }
@@ -57,6 +61,9 @@ class PrepaymentInvoiceMigrationService {
      * This method assumes that because there is both a prepayment invoice and a final invoice, that the order
      * associated with both invoices has been fully invoiced, and so there's no need to check each item of the
      * prepayment invoice individually, they should ALL need to have inverse items created for them.
+     *
+     * Additionally, we don't need to check for canceled items or adjustments since the inverse is based entirely
+     * off the prepayment line. Even if the items are canceled, we still need to inverse the full prepaid amount.
      */
     Invoice generateInverseInvoiceItems(Invoice prepaymentInvoice, Invoice finalInvoice) {
         for (InvoiceItem prepaymentInvoiceItem : prepaymentInvoice.invoiceItems) {

--- a/grails-app/services/org/pih/warehouse/invoice/PrepaymentInvoiceMigrationService.groovy
+++ b/grails-app/services/org/pih/warehouse/invoice/PrepaymentInvoiceMigrationService.groovy
@@ -40,16 +40,11 @@ class PrepaymentInvoiceMigrationService {
         // If the invoice item is for an adjustment.
         OrderAdjustment orderAdjustment = prepaymentInvoiceItem.orderAdjustment
         if (orderAdjustment) {
-            return (orderAdjustment?.canceled ? 0 : orderAdjustment.totalAdjustments) * prepaymentPercent
+            return orderAdjustment.totalAdjustments * prepaymentPercent
         }
 
-        // Else if the invoice item is for a canceled order item.
+        // Else the invoice item is for an order item.
         OrderItem orderItem = prepaymentInvoiceItem.orderItem
-        if (orderItem.orderItemStatusCode == OrderItemStatusCode.CANCELED) {
-            return 0
-        }
-
-        // Else the invoice item is for a non-canceled order item.
         return (orderItem.quantity ?: 0) * (orderItem.unitPrice ?: 0.0) * prepaymentPercent
     }
 


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6612

**Description:** When migrating existing prepayment invoices, we need to also set the amount field for any existing final invoice items so that the "Total Price" column displays correctly when viewing the final invoice.