### PR TITLE
[OBPIH-6679] inferring bin in packing list import based on lot number

### DIFF
--- a/src/main/groovy/org/pih/warehouse/outbound/ImportPackingListItem.groovy
+++ b/src/main/groovy/org/pih/warehouse/outbound/ImportPackingListItem.groovy
@@ -58,7 +58,7 @@ class ImportPackingListItem implements Validateable {
         }
 
         Product product = Product.findByProductCode(source['product'])
-        List<ProductAvailability> items = ProductAvailability.findAllByProductAndLotNumber(product, source['lotNumber'])
+        List<ProductAvailability> items = ProductAvailability.findAllByProductAndLotNumberAndLocation(product, source['lotNumber'], obj.origin)
 
         // infer bin location only if there is a single possible inventory
         if (items.size() == 1) {

--- a/src/main/groovy/org/pih/warehouse/outbound/ImportPackingListItem.groovy
+++ b/src/main/groovy/org/pih/warehouse/outbound/ImportPackingListItem.groovy
@@ -56,6 +56,15 @@ class ImportPackingListItem implements Validateable {
             // returns a dummy location object to add more context in a response of what location was not found
             return new Location(name: source['binLocation'])
         }
+
+        Product product = Product.findByProductCode(source['product'])
+        List<ProductAvailability> items = ProductAvailability.findAllByProductAndLotNumber(product, source['lotNumber'])
+
+        // infer bin location only if there is a single possible inventory
+        if (items.size() == 1) {
+            return items.first().binLocation
+        }
+
         return internalLocation
      })
     Location binLocation


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** [OBPIH-6679](https://pihemr.atlassian.net/browse/OBPIH-6679)

**Description:**
The use case describes a scenario where user did not provide a bin location in the packing list document but provided a lot number, so based on the provided lot nuymber we want to infer the bin location only in cases where there is a single possible bin location for provided lot number

---
### :camera: Screenshots & Recordings (optional)

> *If this PR contains a UI change, consider adding one or more screenshots here or link to a screen recording to help reviewers visualize the change. Otherwise, you can remove this section.*


[OBPIH-6679]: https://pihemr.atlassian.net/browse/OBPIH-6679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ