### PR TITLE
OBPIH-6725 Fix validation discrepancy when changing a location during…

### DIFF
--- a/src/js/hooks/outboundImport/useOutboundImportForm.js
+++ b/src/js/hooks/outboundImport/useOutboundImportForm.js
@@ -256,25 +256,38 @@ const useOutboundImportForm = ({ next }) => {
     }
   };
 
-  const loadCachedData = async () => {
+  const loadCachedData = async (origin) => {
     if (!_.isEmpty(cachedData)) {
+      // We need to update the origin after changing a location,
+      // so that the potential cached data doesn't contain stale data (origin)
+      const updatedCachedData = {
+        ...cachedData,
+        fulfillmentDetails: {
+          ...cachedData.fulfillmentDetails,
+          origin: origin?.id,
+        },
+        packingList: cachedData.packingList.map((item) => ({
+          ...item,
+          origin: origin?.id,
+        })),
+      };
       spinner.show();
-      setPackingListData(cachedData.packingList);
-      await validateOutboundData(cachedData);
+      setPackingListData(updatedCachedData.packingList);
+      await validateOutboundData(updatedCachedData);
       spinner.hide();
     }
   };
 
-  const handleLoadCachedData = () => {
+  const handleLoadCachedData = (origin) => {
     if (OutboundImportStep.CONFIRM === queryParams?.step) {
-      loadCachedData();
+      loadCachedData(origin);
       return;
     }
     clearCachedData();
   };
 
   useEffect(() => {
-    handleLoadCachedData();
+    handleLoadCachedData(currentLocation);
 
     if (currentLocation) {
       setValue('origin', {


### PR DESCRIPTION
… outbound import process

### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:**

**Description:**
The problem was that when the location changed, in the `useEffect` we were only setting the newly chosen location as origin in the `setValue` of `react-hook-form`, but the cached data still contained the old location, hence we had a situation that we sent the old origin for validation, but would send a new one for saving.
To fix the issue I just make sure each time the cached data is supposed to be sent, we send it with the current location.

---
### :camera: Screenshots & Recordings (optional)

> *If this PR contains a UI change, consider adding one or more screenshots here or link to a screen recording to help reviewers visualize the change. Otherwise, you can remove this section.*
