### PR TITLE
OBPIH-6716 Sorting issue on invoice confirm page for long list of items 

### DIFF
--- a/src/js/components/invoice/create/ConfirmInvoicePage.jsx
+++ b/src/js/components/invoice/create/ConfirmInvoicePage.jsx
@@ -9,8 +9,8 @@ import InvoiceOptionsForm from 'components/invoice/create/InvoiceOptionsForm';
 import InvoicePrepayedItemsTable from 'components/invoice/create/InvoicePrepayedItemsTable';
 import useConfirmInvoicePage from 'hooks/invoice/useConfirmInvoicePage';
 import useInvoicePrepaidItemsTable from 'hooks/invoice/useInvoicePrepaidItemsTable';
-import Translate from 'utils/Translate';
 import useSpinner from 'hooks/useSpinner';
+import Translate from 'utils/Translate';
 
 const PREPAYMENT_INVOICE = 'PREPAYMENT_INVOICE';
 
@@ -24,6 +24,7 @@ const ConfirmInvoicePage = ({ initialValues, previousPage }) => {
     updateInvoiceItemData,
     refetchData,
     loadMoreRows,
+    invoiceItemsMap,
   } = useConfirmInvoicePage({ initialValues });
 
   const spinner = useSpinner();
@@ -31,6 +32,7 @@ const ConfirmInvoicePage = ({ initialValues, previousPage }) => {
   const invoicePrepaidItemsTableData = useInvoicePrepaidItemsTable({
     invoiceItems: stateValues.invoiceItems,
     invoiceId: stateValues.id,
+    invoiceItemsMap,
     updateInvoiceItemData,
     refetchData,
   });

--- a/src/js/hooks/invoice/useConfirmInvoicePage.jsx
+++ b/src/js/hooks/invoice/useConfirmInvoicePage.jsx
@@ -111,7 +111,7 @@ const useConfirmInvoicePage = ({ initialValues }) => {
     [stateValues.id, pageSize],
   );
 
-  const updateInvoiceItemQuantity = (updateRow) => (invoiceItemId, fieldName) => (value) => {
+  const updateInvoiceItemData = (updateRow) => (invoiceItemId, fieldName) => (value) => {
     updateRow?.(
       invoiceItemId,
       {

--- a/src/js/hooks/invoice/useConfirmInvoicePage.jsx
+++ b/src/js/hooks/invoice/useConfirmInvoicePage.jsx
@@ -22,7 +22,9 @@ const useConfirmInvoicePage = ({ initialValues }) => {
 
   const [stateValues, setStateValues] = useState({
     ...initialValues,
-    invoiceItems: [],
+    // react-virtualize expects a map for checking if an item is already fetched. Using a list
+    // results in fetching the same items range multiple times.
+    invoiceItems: new Map(),
   });
 
   /**
@@ -65,29 +67,31 @@ const useConfirmInvoicePage = ({ initialValues }) => {
       });
   };
 
+  const parseItemsToMap = (items, indexOffset = 0) =>
+    new Map(items.map((item, index) => [index + indexOffset, item]));
+
+  const addToLineItems = (stateData, newItems, firstIndex) => {
+    const items = parseItemsToMap(newItems, firstIndex);
+    return new Map([...Array.from(stateData), ...items]);
+  };
+
   /**
    * Sets state of invoice items after fetch and calls method to fetch next items
    * @param response
    * @param {boolean} overrideInvoiceItems
+   * @param startIndex
    * @public
    */
-  const setInvoiceItems = (response, overrideInvoiceItems = true) => {
+  const setInvoiceItems = (response, overrideInvoiceItems = true, startIndex = 0) => {
     spinner.show();
-    const {
-      data,
-      totalCount,
-    } = response.data;
+    const { data, totalCount } = response.data;
     setStateValues((state) => ({
       ...state,
       invoiceItems: overrideInvoiceItems
-        ? data
-        : [
-          ...state.invoiceItems,
-          ...data,
-        ],
+        ? parseItemsToMap(data)
+        : addToLineItems(state.invoiceItems, data, startIndex),
       totalCount,
     }));
-
     spinner.hide();
   };
 
@@ -97,22 +101,17 @@ const useConfirmInvoicePage = ({ initialValues }) => {
    * @public
    */
   const loadMoreRows = useCallback(
-    ({
-      startIndex,
-      overrideInvoiceItems = false,
-    }) => invoiceApi.getInvoiceItems(stateValues.id, {
-      params: {
-        offset: startIndex,
-        max: pageSize,
-      },
-    })
-      .then((response) => {
-        setInvoiceItems(response, overrideInvoiceItems);
-      }),
+    ({ startIndex, stopIndex, overrideInvoiceItems = false }) =>
+      invoiceApi.getInvoiceItems(stateValues.id, {
+        params: { offset: startIndex, max: stopIndex ? (stopIndex - startIndex + 1) : pageSize },
+      })
+        .then((response) => {
+          setInvoiceItems(response, overrideInvoiceItems, startIndex);
+        }),
     [stateValues.id, pageSize],
   );
 
-  const updateInvoiceItemData = (updateRow) => (invoiceItemId, fieldName) => (value) => {
+  const updateInvoiceItemQuantity = (updateRow) => (invoiceItemId, fieldName) => (value) => {
     updateRow?.(
       invoiceItemId,
       {
@@ -121,16 +120,13 @@ const useConfirmInvoicePage = ({ initialValues }) => {
     );
     setStateValues((state) => ({
       ...state,
-      invoiceItems: state.invoiceItems.map((item) => {
+      invoiceItems: new Map(Array.from(state.invoiceItems).map(([idx, item]) => {
         if (item.id === invoiceItemId) {
-          return {
-            ...item,
-            [fieldName]: value,
-          };
+          return [idx, { ...item, [fieldName]: value }];
         }
 
-        return item;
-      }),
+        return [idx, item];
+      })),
     }));
   };
 
@@ -153,7 +149,12 @@ const useConfirmInvoicePage = ({ initialValues }) => {
 
   return {
     isSuperuser,
-    stateValues,
+    stateValues: {
+      ...stateValues,
+      invoiceItems: Array.from(stateValues.invoiceItems)
+        .map((invoiceItemEntry) => invoiceItemEntry[1]),
+    },
+    invoiceItemsMap: stateValues.invoiceItems,
     fetchInvoiceData,
     totalValue,
     submitInvoice,

--- a/src/js/hooks/invoice/useInvoicePrepaidItemsTable.jsx
+++ b/src/js/hooks/invoice/useInvoicePrepaidItemsTable.jsx
@@ -14,6 +14,7 @@ const useInvoicePrepaidItemsTable = ({
   updateInvoiceItemData,
   invoiceId,
   refetchData,
+  invoiceItemsMap,
 }) => {
   const spinner = useSpinner();
   const translate = useTranslate();
@@ -113,7 +114,7 @@ const useInvoicePrepaidItemsTable = ({
   };
 
   const isRowLoaded = useCallback(
-    ({ index }) => !!invoiceItems[index],
+    ({ index }) => !!invoiceItemsMap.get(index),
     [invoiceItems],
   );
 


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6716

**Description:**
The first fix was to use a map as it is mentioned in the docs:
> InfiniteLoader is not a stateful component, meaning that it does not keep track of which rows it has requested to be loaded. Your component will need to track this information yourself to avoid loading rows multiple times. One way to do this is to to use a map to track the status of each row like so ...

The second fix is to allow react-virtualize to fetch the number of items that the table needs. Previously we were fetching only 10 items each time. So in case of quick scrolling, we missed some items.
