### PR TITLE
OBPIH-6679 Fix inferring bin location when providing a lot number

### DIFF
--- a/src/main/groovy/org/pih/warehouse/outbound/ImportPackingListItem.groovy
+++ b/src/main/groovy/org/pih/warehouse/outbound/ImportPackingListItem.groovy
@@ -59,12 +59,6 @@ class ImportPackingListItem implements Validateable {
                 return items.first().binLocation
             }
 
-            // If default bin is in stock then return it
-            if (items.size() > 0 && items.any { it.binLocation == null }) {
-                // null value assumes that this is a default bin location
-                return null
-            }
-
             // Any attempt at inferring bin location failed and bin location was not located
             return null
         }
@@ -151,7 +145,7 @@ class ImportPackingListItem implements Validateable {
             // Associate inventory item's expiration date with expirationDateToDisplay, to display the date in the table
             item.expirationDateToDisplay = inventoryItem.expirationDate
             if (!item.binLocationFound) {
-                return ['binLocationNotFound', item.binLocation?.name]
+                return ['binLocationNotFound', item.binLocation.name]
             }
             ProductAvailabilityService productAvailabilityService = Holders.grailsApplication.mainContext.getBean(ProductAvailabilityService)
             Integer quantity = productAvailabilityService.getQuantityAvailableToPromiseForProductInBin(item.origin, item.binLocation, inventoryItem)


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** [OBPIH-6679](https://pihemr.atlassian.net/browse/OBPIH-6679)

**Description:** Had to modify the inferring bin location logic a bit due to following problem.
- inferring would work on out of stock bins, which is why I had to sue the product availability service which handles this search properly
- Were some issues with inferring default bin location
- providing a wrong bin location with correct lot would result in the algorithm trying to infer the bin location based on lot which we do not want in this situation and want to display the incorrect bin

---
### :camera: Screenshots & Recordings (optional)

> *If this PR contains a UI change, consider adding one or more screenshots here or link to a screen recording to help reviewers visualize the change. Otherwise, you can remove this section.*


[OBPIH-6679]: https://pihemr.atlassian.net/browse/OBPIH-6679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ