### PR TITLE
OBPIH-6726 Bugfix to allow pre-migration prepayment invoices to be edited

### DIFF
--- a/grails-app/domain/org/pih/warehouse/invoice/InvoiceItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/invoice/InvoiceItem.groovy
@@ -86,7 +86,7 @@ class InvoiceItem implements Serializable {
             // If the invoice is a prepayment or the item is an order adjustment,
             // the validation below doesn't make sense, because
             // we do not have shipmentItem at this point.
-            if (obj.invoice?.isPrepaymentInvoice || obj.orderAdjustment) {
+            if (obj.invoice?.isPrepaymentInvoice || obj.orderAdjustment || obj.inverse) {
                 return true
             }
 

--- a/grails-app/services/org/pih/warehouse/invoice/PrepaymentInvoiceService.groovy
+++ b/grails-app/services/org/pih/warehouse/invoice/PrepaymentInvoiceService.groovy
@@ -174,7 +174,7 @@ class PrepaymentInvoiceService {
         return inverseItem
     }
 
-    private InvoiceItem createInverseItemForShipmentItem(ShipmentItem shipmentItem, InvoiceItem invoiceItem) {
+    InvoiceItem createInverseItemForShipmentItem(ShipmentItem shipmentItem, InvoiceItem invoiceItem) {
         OrderItem orderItem = shipmentItem.orderItems?.find { it }
         InvoiceItem prepaymentItem = orderItem.invoiceItems.find { it.isPrepaymentInvoice }
         if (!prepaymentItem) {


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6726

**Description:** See ticket for the full breakdown. This fix is to ensure that when migrating existing invoices we're properly creating an inverse invoice item for each matching *shipment* item in a regular invoice. Previously we were only checking the prepayment invoice item, which is based on *order item* and so had no shipment association. This worked fine for cancelled items and adjustments, but for orders with shipments, the invoice needs to be built off of the regular invoice item (which itself is built from shipment items).

A diagram to help me understand the complex relationships going on here:

![image](https://github.com/user-attachments/assets/a755bdc3-4726-49aa-ad40-d3781438f5ff)

