### PR TITLE
OBPIH-6761 Sorting issue on invoice confirm page for long list of items (fix after QA)

### DIFF
--- a/src/js/components/invoice/create/InvoicePrepayedItemsTable.jsx
+++ b/src/js/components/invoice/create/InvoicePrepayedItemsTable.jsx
@@ -8,7 +8,7 @@ import { Tooltip } from 'react-tippy';
 import ArrayField from 'components/form-elements/ArrayField';
 import LabelField from 'components/form-elements/LabelField';
 import TextInput from 'components/form-elements/v2/TextInput';
-import { ORDER_URL, STOCK_MOVEMENT_URL } from 'consts/applicationUrls';
+import { STOCK_MOVEMENT_URL } from 'consts/applicationUrls';
 import ContextMenu from 'utils/ContextMenu';
 import { renderFormField } from 'utils/form-utils';
 import { getInvoiceDescription } from 'utils/form-values-utils';

--- a/src/js/hooks/invoice/useConfirmInvoicePage.jsx
+++ b/src/js/hooks/invoice/useConfirmInvoicePage.jsx
@@ -139,6 +139,7 @@ const useConfirmInvoicePage = ({ initialValues }) => {
       await fetchInvoiceData();
       await loadMoreRows({
         startIndex: 0,
+        stopIndex: stateValues.totalCount,
         overrideInvoiceItems,
       });
     } finally {
@@ -151,8 +152,7 @@ const useConfirmInvoicePage = ({ initialValues }) => {
     isSuperuser,
     stateValues: {
       ...stateValues,
-      invoiceItems: Array.from(stateValues.invoiceItems)
-        .map((invoiceItemEntry) => invoiceItemEntry[1]),
+      invoiceItems: Array.from(stateValues.invoiceItems.values()),
     },
     invoiceItemsMap: stateValues.invoiceItems,
     fetchInvoiceData,


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6716

**Description:**
The issue was caused by the behavior of fetching implemented in react-virtualize - the stop index passed by the react table when deleting an item is 10 (our default page size). So when we deleted an item in the middle of the table, the react-virtualize started fetching the items again, and the sent requests were: (startIndex: 0, stopIndex: 10), and the next one is, for example (startIndex: 16, stopIndex: 40). So because of that we are missing 6 items, and then when scrolling through the table we are fetching those missing items, and they are placed at the end of the table when we are on their indexes. Our implementation of the react-virtualize causes it so it's better not to touch the code here to avoid risky regressions in our tables. As a fix, I decided to fetch the table full table content after deletion, because when we are deleting items, at for example index 40 out of 70, we need all of the 40 items + current page size. + This fix removes a different behavior of blinking items because of building the rows once again.

