### PR TITLE
OBPIH-6689 Rely on unit price instead amount while calculating inverse items

### DIFF
--- a/grails-app/domain/org/pih/warehouse/invoice/InvoiceItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/invoice/InvoiceItem.groovy
@@ -246,7 +246,7 @@ class InvoiceItem implements Serializable {
                 inverse: inverse,
                 isCanceled: orderItem?.canceled ?: orderAdjustment?.canceled,
                 quantityAvailableToInvoice: quantityAvailableToInvoice,
-                amountAvailableToInvoice: orderAdjustment?.amountAvailableToInvoice,
+                unitPriceAvailableToInvoice: orderAdjustment?.unitPriceAvailableToInvoice,
                 // Total amount and total prepayment amount are deprecated and amount field
                 // should be used instead (OBPIH-6398, OBPIH-6499)
                 totalAmount: totalAmount,

--- a/src/js/hooks/invoice/useInvoicePrepaidItemsTable.jsx
+++ b/src/js/hooks/invoice/useInvoicePrepaidItemsTable.jsx
@@ -133,10 +133,10 @@ const useInvoicePrepaidItemsTable = ({
 
   // validation for order adjustments
   const validateUnitPrice = (row) => {
-    const amountAvailableToInvoice =
-      Math.abs(row?.amountAvailableToInvoice) + Math.abs(row?.amount);
+    const unitPriceAvailableToInvoice =
+      Math.abs(row?.unitPriceAvailableToInvoice) + Math.abs(row?.unitPrice);
     if (
-      row?.unitPrice === 0 || amountAvailableToInvoice < Math.abs(row.unitPrice)
+      row?.unitPrice === 0 || unitPriceAvailableToInvoice < Math.abs(row.unitPrice)
     ) {
       setInvalidRows((rows) => ([...rows, row?.id]));
       return translate('react.invoice.errors.unitPrice.label', 'Wrong amount to invoice value');

--- a/src/test/groovy/unit/org/pih/warehouse/invoice/PrepaymentInvoiceServiceSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/invoice/PrepaymentInvoiceServiceSpec.groovy
@@ -347,47 +347,50 @@ class PrepaymentInvoiceServiceSpec extends Specification implements ServiceUnitT
         thrown(Exception)
     }
 
-    void 'getAmountToInverse should calculate amount to inverse #amountToInverse when amount invoiced is #amountInvoiced and amount inverseable is #amountInverseable'() {
+    void 'getUnitPriceToInverse should calculate unitPrice to inverse #unitPriceToInverse when unitPrice invoiced is #unitPriceInvoiced and unitPrice inverseable is #unitPriceInverseable'() {
         when:
-        BigDecimal amountToInverseCalc = service.getAmountToInverse(amountInvoiced, amountInversable)
+        BigDecimal unitPriceToInverseCalc = service.getUnitPriceToInverse(unitPriceInvoiced, unitPriceInversable)
 
         then:
-        assert amountToInverseCalc == amountToInverse
+        assert unitPriceToInverseCalc == unitPriceToInverse
 
         where:
-        amountInvoiced   | amountInversable   | amountToInverse
-        1.0              | 1.0                | 1.0
-        -1.0             | -1.0               | -1.0
-        1.0              | 0.0                | 0.0
-        0.0              | 1.0                | 0.0
-        -1.0             | 0.0                | 0.0
-        0.0              | -1.0               | 0.0
+        unitPriceInvoiced   | unitPriceInversable   | unitPriceToInverse
+        1.0                 | 1.0                   | 1.0
+        -1.0                | -1.0                  | -1.0
+        1.0                 | 0.0                   | 0.0
+        0.0                 | 1.0                   | 0.0
+        -1.0                | 0.0                   | 0.0
+        0.0                 | -1.0                  | 0.0
     }
 
-    void 'getAmountAvailableToInverse should calculate amount available to inverse #availableToInverse when amount on prepayment item is #preapymentItemAmount and inversed amount is #inversedAmount'() {
+    void 'getUnitPriceAvailableToInverse should calculate unit price available to inverse #unitPriceAvailableToInverse when unit price on prepayment item is #preapymentItemUnitPrice and inversed unit price is #inversedUnitPrice'() {
         given:
         InvoiceItem prepaymentItem = new InvoiceItem()
-        prepaymentItem.amount = preapymentItemAmount
+        prepaymentItem.unitPrice = preapymentItemUnitPrice
         OrderAdjustment orderAdjustment = Spy(OrderAdjustment) {
-            getInversedAmount() >> inversedAmount
+            getInversedUnitPrice() >> inversedUnitPrice
         }
 
         when:
-        BigDecimal amountAvailableToInverseCalc = service.getAmountAvailableToInverse(orderAdjustment, prepaymentItem)
+        BigDecimal unitPriceAvailableToInverseCalc = service.getUnitPriceAvailableToInverse(
+                prepaymentItem.unitPrice,
+                orderAdjustment.inversedUnitPrice
+        )
 
         then:
-        assert amountAvailableToInverseCalc == amountAvailableToInverse
+        assert unitPriceAvailableToInverseCalc == unitPriceAvailableToInverse
 
         where:
-        preapymentItemAmount   | inversedAmount   | amountAvailableToInverse
-        1.0                    | -1.0             | 0.0
-        -1.0                   | 1.0              | 0.0
-        1.0                    | 0.0              | 1.0
-        -1.0                   | 0.0              | -1.0
-        0.0                    | 0.0              | 0.0
-        10                     | -3               | 7
-        -5                     | 2                | -3
-        -5                     | 5                | 0
+        preapymentItemUnitPrice | inversedUnitPrice | unitPriceAvailableToInverse
+        1.0                     | 1.0               | 0.0
+        -1.0                    | -1.0              | 0.0
+        1.0                     | 0.0               | 1.0
+        -1.0                    | 0.0               | -1.0
+        0.0                     | 0.0               | 0.0
+        10                      | 3                 | 7
+        -5                      | -2                | -3
+        -5                      | -5                | 0
     }
 
     private Set<InvoiceItem> getInvoiceItemsOnOrderItems(Invoice invoice) {

--- a/src/test/groovy/unit/org/pih/warehouse/invoice/PrepaymentInvoiceServiceSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/invoice/PrepaymentInvoiceServiceSpec.groovy
@@ -364,10 +364,10 @@ class PrepaymentInvoiceServiceSpec extends Specification implements ServiceUnitT
         0.0                 | -1.0                  | 0.0
     }
 
-    void 'getUnitPriceAvailableToInverse should calculate unit price available to inverse #unitPriceAvailableToInverse when unit price on prepayment item is #preapymentItemUnitPrice and inversed unit price is #inversedUnitPrice'() {
+    void 'getUnitPriceAvailableToInverse should calculate unit price available to inverse #unitPriceAvailableToInverse when unit price on prepayment item is #prepaymentItemUnitPrice and inversed unit price is #inversedUnitPrice'() {
         given:
         InvoiceItem prepaymentItem = new InvoiceItem()
-        prepaymentItem.unitPrice = preapymentItemUnitPrice
+        prepaymentItem.unitPrice = prepaymentItemUnitPrice
         OrderAdjustment orderAdjustment = Spy(OrderAdjustment) {
             getInversedUnitPrice() >> inversedUnitPrice
         }
@@ -382,7 +382,7 @@ class PrepaymentInvoiceServiceSpec extends Specification implements ServiceUnitT
         assert unitPriceAvailableToInverseCalc == unitPriceAvailableToInverse
 
         where:
-        preapymentItemUnitPrice | inversedUnitPrice | unitPriceAvailableToInverse
+        prepaymentItemUnitPrice | inversedUnitPrice | unitPriceAvailableToInverse
         1.0                     | 1.0               | 0.0
         -1.0                    | -1.0              | 0.0
         1.0                     | 0.0               | 1.0

--- a/src/test/groovy/unit/org/pih/warehouse/order/OrderAdjustmentSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/order/OrderAdjustmentSpec.groovy
@@ -14,9 +14,9 @@ class OrderAdjustmentSpec extends Specification implements DomainUnitTest<OrderA
         OrderAdjustment orderAdjustment = Spy(OrderAdjustment) {
             getHasRegularInvoice() >> hasRegularInvoice
             getHasPrepaymentInvoice() >> true
-            getInvoicedQuantity() >> 0
+//            getInvoicedQuantity() >> 0
             getTotalAdjustments() >> 4
-            getInvoicedAmount() >> 3
+            getInvoicedUnitPrice() >> 3
         }
         orderAdjustment.canceled = canceled
         orderAdjustment.order = Spy(Order)
@@ -35,14 +35,14 @@ class OrderAdjustmentSpec extends Specification implements DomainUnitTest<OrderA
     }
 
 
-    void 'OrderAdjustment.getIsInvoiceable() should return #isInvoiceable when trying to invoice #amountInvoiced out of 4 adjustments'() {
+    void 'OrderAdjustment.getIsInvoiceable() should return #isInvoiceable when trying to invoice #unitPriceInvoiced out of 4 adjustments'() {
         given:
         OrderAdjustment orderAdjustment = Spy(OrderAdjustment) {
             getHasRegularInvoice() >> hasRegularInvoice
             getHasPrepaymentInvoice() >> true
-            getInvoicedQuantity() >> 0
+//            getInvoicedQuantity() >> 0
             getTotalAdjustments() >> 4
-            getInvoicedAmount() >> amountInvoiced
+            getInvoicedUnitPrice() >> unitPriceInvoiced
         }
         orderAdjustment.canceled = canceled
         orderAdjustment.order = Spy(Order)
@@ -52,12 +52,12 @@ class OrderAdjustmentSpec extends Specification implements DomainUnitTest<OrderA
         orderAdjustment.invoiceable == isInvoiceable
 
         where:
-        hasRegularInvoice  | canceled   | amountInvoiced || isInvoiceable
-        false              | true       | 3              || true
-        false              | true       | 4              || false
-        false              | false      | 3              || true
-        false              | false      | 4              || false
-        true               | false      | 3              || true
-        true               | false      | 4              || false
+        hasRegularInvoice  | canceled   | unitPriceInvoiced || isInvoiceable
+        false              | true       | 3                 || true
+        false              | true       | 4                 || false
+        false              | false      | 3                 || true
+        false              | false      | 4                 || false
+        true               | false      | 3                 || true
+        true               | false      | 4                 || false
     }
 }

--- a/src/test/groovy/unit/org/pih/warehouse/order/OrderAdjustmentSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/order/OrderAdjustmentSpec.groovy
@@ -14,7 +14,6 @@ class OrderAdjustmentSpec extends Specification implements DomainUnitTest<OrderA
         OrderAdjustment orderAdjustment = Spy(OrderAdjustment) {
             getHasRegularInvoice() >> hasRegularInvoice
             getHasPrepaymentInvoice() >> true
-//            getInvoicedQuantity() >> 0
             getTotalAdjustments() >> 4
             getInvoicedUnitPrice() >> 3
         }
@@ -40,7 +39,6 @@ class OrderAdjustmentSpec extends Specification implements DomainUnitTest<OrderA
         OrderAdjustment orderAdjustment = Spy(OrderAdjustment) {
             getHasRegularInvoice() >> hasRegularInvoice
             getHasPrepaymentInvoice() >> true
-//            getInvoicedQuantity() >> 0
             getTotalAdjustments() >> 4
             getInvoicedUnitPrice() >> unitPriceInvoiced
         }


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:**
https://pihemr.atlassian.net/browse/OBPIH-6689

**Description:**
This is basically a changing approach to determining inverse items. Previously we were relying on the amount field, which while comparing to unit prices could have different sign and could be reduced by prepayment percentage. To simplify things we should always rely on the unit price all the time while determining inverse items. 

