### PR TITLE
OBPIH-6747 support empty lot number in import that matches inventory item defined as null

### DIFF
--- a/grails-app/services/org/pih/warehouse/fulfillment/FulfillmentService.groovy
+++ b/grails-app/services/org/pih/warehouse/fulfillment/FulfillmentService.groovy
@@ -393,11 +393,11 @@ class FulfillmentService {
 
         // If bin location is not provided then first check if inventory with default lot number is available
         if (!binLocationName) {
-            AvailableItem itemsWithDefaultLot = productAvailabilityService
+            AvailableItem itemWithDefaultLot = productAvailabilityService
                     .getAvailableItemWithDefaultLots(obj.origin, productCode)
             // only infer if there is one possible value
-            if (itemsWithDefaultLot) {
-                return itemsWithDefaultLot?.inventoryItem?.lotNumber
+            if (itemWithDefaultLot) {
+                return itemWithDefaultLot?.inventoryItem?.lotNumber
             }
         }
 

--- a/grails-app/services/org/pih/warehouse/fulfillment/FulfillmentService.groovy
+++ b/grails-app/services/org/pih/warehouse/fulfillment/FulfillmentService.groovy
@@ -45,8 +45,6 @@ import org.pih.warehouse.shipping.Shipment
 import org.pih.warehouse.shipping.ShipmentItem
 import org.pih.warehouse.shipping.ShipmentStatusCode
 import org.pih.warehouse.shipping.ShipmentStatusTransitionEvent
-import util.StringUtil
-
 
 @Transactional
 class FulfillmentService {
@@ -403,7 +401,7 @@ class FulfillmentService {
 
         // otherwise try to infer lotNumber based on provided binLocation
         AvailableItem availableItem = productAvailabilityService
-                .inferAvailableItemByBinLocation(obj.origin, productCode, binLocationName)
+                .getAvailableItemByBinLocation(obj.origin, productCode, binLocationName)
 
         return availableItem?.inventoryItem?.lotNumber
     }
@@ -440,7 +438,7 @@ class FulfillmentService {
 
         // otherwise try to infer based on existing lot
         AvailableItem availableItem = productAvailabilityService
-                .inferAvailableItemByLotNumber(obj.origin, productCode, lotNumber)
+                .getAvailableItemByLotNumber(obj.origin, productCode, lotNumber)
 
         return availableItem?.binLocation
     }

--- a/grails-app/services/org/pih/warehouse/fulfillment/FulfillmentService.groovy
+++ b/grails-app/services/org/pih/warehouse/fulfillment/FulfillmentService.groovy
@@ -413,8 +413,6 @@ class FulfillmentService {
         String productCode = source['product']
         String binLocationName = source['binLocation']
 
-        ProductAvailabilityService productAvailabilityService = Holders.grailsApplication.mainContext.getBean(ProductAvailabilityService)
-
         // if binLocation is provided then look for one available in stock
         if (binLocationName) {
             Location binLocation = productAvailabilityService

--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -743,6 +743,17 @@ class ProductAvailabilityService {
         return availableBinLocations
     }
 
+    AvailableItem getAvailableItemWithDefaultLots(List<AvailableItem> availableItems ) {
+        List<AvailableItem> itemsWithDefaultLot = availableItems.findAll {
+            !it?.inventoryItem?.lotNumber // Null or empty lot number
+        }
+        // only infer if there is one possible value
+        if (itemsWithDefaultLot.size() == 1) {
+            return itemsWithDefaultLot.first()
+        }
+        return null
+    }
+
     /**
      * Sorting used by first expiry, first out algorithm
      */

--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -23,7 +23,6 @@ import org.hibernate.criterion.Projections
 import org.hibernate.criterion.Restrictions
 import org.hibernate.criterion.Subqueries
 import org.hibernate.SQLQuery
-import org.hibernate.sql.JoinType
 import org.hibernate.type.StandardBasicTypes
 import org.pih.warehouse.PaginatedList
 import org.pih.warehouse.api.AllocatedItem
@@ -757,7 +756,7 @@ class ProductAvailabilityService {
         return null
     }
 
-    AvailableItem inferAvailableItemByBinLocation(Location origin, String productCode, String binLocationName) {
+    AvailableItem getAvailableItemByBinLocation(Location origin, String productCode, String binLocationName) {
         Product product = Product.findByProductCode(productCode)
         List<AvailableItem> availableItems = getAvailableBinLocations(origin, product?.id)
 
@@ -774,7 +773,7 @@ class ProductAvailabilityService {
         return null
     }
 
-    AvailableItem inferAvailableItemByLotNumber(Location origin, String productCode, String lotNumber) {
+    AvailableItem getAvailableItemByLotNumber(Location origin, String productCode, String lotNumber) {
         Product product = Product.findByProductCode(productCode)
         List<AvailableItem> availableItems = getAvailableBinLocations(origin, product?.id)
 

--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -783,7 +783,7 @@ class ProductAvailabilityService {
         List<AvailableItem> availableItemsWithProvidedLotNumber = availableItems.findAll {
             it?.inventoryItem?.lotNumber == lotNumber
         }
-        if(availableItemsWithProvidedLotNumber.size() == 1) {
+        if (availableItemsWithProvidedLotNumber.size() == 1) {
             return availableItemsWithProvidedLotNumber.first()
         }
 

--- a/src/main/groovy/org/pih/warehouse/outbound/ImportPackingListItem.groovy
+++ b/src/main/groovy/org/pih/warehouse/outbound/ImportPackingListItem.groovy
@@ -22,7 +22,7 @@ class ImportPackingListItem implements Validateable {
     @BindUsing({ obj, source -> Product.findByProductCode(source['product']) })
     Product product
 
-    @BindUsing({ obj, source  ->
+    @BindUsing({ obj, source ->
         FulfillmentService fulfillmentService = Holders.grailsApplication.mainContext.getBean(FulfillmentService)
         return fulfillmentService.bindOrInferLotNumber(obj as ImportPackingListItem, source as Map)
     })
@@ -30,7 +30,7 @@ class ImportPackingListItem implements Validateable {
 
     Location origin
 
-    @BindUsing({ obj, source  ->
+    @BindUsing({  obj, source ->
         FulfillmentService fulfillmentService = Holders.grailsApplication.mainContext.getBean(FulfillmentService)
         return fulfillmentService.bindOrInferBinLocation(obj as ImportPackingListItem, source as Map)
      })

--- a/src/main/groovy/org/pih/warehouse/outbound/ImportPackingListItem.groovy
+++ b/src/main/groovy/org/pih/warehouse/outbound/ImportPackingListItem.groovy
@@ -43,12 +43,11 @@ class ImportPackingListItem implements Validateable {
 
         // If bin location is not provided then first check if inventory with default lot number is available
         if (!binLocationName) {
-            List<AvailableItem> itemsWithDefaultBin = availableItems.findAll {
-                !it?.inventoryItem?.lotNumber // Null or empty lot number
-            }
+            AvailableItem itemsWithDefaultLot = productAvailabilityService
+                    .getAvailableItemWithDefaultLots(availableItems)
             // only infer if there is one possible value
-            if (itemsWithDefaultBin.size() == 1) {
-                return itemsWithDefaultBin.first()?.inventoryItem?.lotNumber
+            if (itemsWithDefaultLot) {
+                return itemsWithDefaultLot?.inventoryItem?.lotNumber
             }
         }
 
@@ -107,11 +106,11 @@ class ImportPackingListItem implements Validateable {
         } else {
             // if bin location is not provided and lot number is not provided
             // then check if we have default lot
-            List<AvailableItem> availableItemsWithDefaultLot = availableItems.findAll {
-                !it?.inventoryItem?.lotNumber // Null or empty lot number
-            }
-            if(availableItemsWithDefaultLot.size() == 1) {
-                return availableItemsWithDefaultLot.first()?.binLocation
+            AvailableItem itemsWithDefaultLot = productAvailabilityService
+                    .getAvailableItemWithDefaultLots(availableItems)
+            // only infer if there is one possible value
+            if (itemsWithDefaultLot) {
+                return itemsWithDefaultLot?.binLocation
             }
         }
 

--- a/src/test/groovy/unit/org/pih/warehouse/fulfillment/FulfillmentServiceSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/fulfillment/FulfillmentServiceSpec.groovy
@@ -1,0 +1,267 @@
+package unit.org.pih.warehouse.fulfillment
+
+import grails.testing.gorm.DataTest
+import grails.testing.services.ServiceUnitTest
+import org.pih.warehouse.api.AvailableItem
+import org.pih.warehouse.core.Location
+import org.pih.warehouse.fulfillment.FulfillmentService
+import org.pih.warehouse.inventory.InventoryItem
+import org.pih.warehouse.inventory.ProductAvailabilityService
+import org.pih.warehouse.outbound.ImportPackingListItem
+import org.pih.warehouse.product.Product
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class FulfillmentServiceSpec extends Specification implements ServiceUnitTest<FulfillmentService>, DataTest {
+
+    void setup() {
+        service.productAvailabilityService = new ProductAvailabilityService()
+
+        mockDomain(Product)
+        GroovyMock(Product, global: true)
+        Product.findByProductCode("product-code-123") >> new Product(productCode: "product-code-123")
+    }
+
+    void 'bindOrInferLotNumber should return exact lotNumber string when lotNumber was provided'() {
+        given:
+        Map data = [
+                lotNumber: "fake-lot-number",
+                binLocation: null
+        ]
+        ImportPackingListItem importedFile = new ImportPackingListItem()
+
+        when:
+        String boundLotNumber = service.bindOrInferLotNumber(importedFile, data)
+
+        then:
+        boundLotNumber == data.lotNumber
+    }
+
+    void 'bindOrInferLotNumber should return default lot when lotNumber is not provided (default lot is empty string)'() {
+        given:
+        Map data = [
+                product: "product-code-123",
+                lotNumber: null,
+                binLocation: null
+        ]
+        ImportPackingListItem importedFile = new ImportPackingListItem()
+        Location location = new Location(id: "fake-location")
+        importedFile.origin = location
+
+        ProductAvailabilityService productAvailabilityServiceSpy = Spy(service.productAvailabilityService)
+
+        productAvailabilityServiceSpy.getAvailableBinLocations(_, _) >> [
+                new AvailableItem(inventoryItem: new InventoryItem(lotNumber: ""))
+        ]
+
+        service.productAvailabilityService = productAvailabilityServiceSpy
+
+        when:
+        String inferredLotNumber = service.bindOrInferLotNumber(importedFile, data)
+
+        then:
+        inferredLotNumber == ""
+    }
+
+    void 'bindOrInferLotNumber should return default lot when lotNumber is not provided (default lot is null)'() {
+        given:
+        Map data = [
+                product: "product-code-123",
+                lotNumber: null,
+                binLocation: null
+        ]
+        ImportPackingListItem importedFile = new ImportPackingListItem()
+        Location location = new Location(id: "fake-location")
+        importedFile.origin = location
+
+        ProductAvailabilityService productAvailabilityServiceSpy = Spy(service.productAvailabilityService)
+
+        productAvailabilityServiceSpy.getAvailableBinLocations(_, _) >> [
+                new AvailableItem(inventoryItem: new InventoryItem(lotNumber: null))
+        ]
+
+        service.productAvailabilityService = productAvailabilityServiceSpy
+
+        when:
+        String inferredLotNumber = service.bindOrInferLotNumber(importedFile, data)
+
+        then:
+        inferredLotNumber == null
+    }
+
+    void 'bindOrInferLotNumber should return null if there are multiple stocks with default lot'() {
+        given:
+        Map data = [
+                product: "product-code-123",
+                lotNumber: null,
+                binLocation: null
+        ]
+        ImportPackingListItem importedFile = new ImportPackingListItem()
+        Location location = new Location(id: "fake-location")
+        importedFile.origin = location
+
+        InventoryItem defaultLot = new InventoryItem(lotNumber: "")
+
+        ProductAvailabilityService productAvailabilityServiceSpy = Spy(service.productAvailabilityService)
+
+        productAvailabilityServiceSpy.getAvailableBinLocations(_, _) >> [
+                new AvailableItem(inventoryItem: defaultLot, binLocation: new Location(name: "first-bin")),
+                new AvailableItem(inventoryItem: defaultLot, binLocation: new Location(name: "second-bin")),
+        ]
+
+        service.productAvailabilityService = productAvailabilityServiceSpy
+
+        when:
+        String inferredLotNumber = service.bindOrInferLotNumber(importedFile, data)
+
+        then:
+        inferredLotNumber == null
+    }
+
+    void 'bindOrInferLotNumber should return proper lotNumber when binLocation is provided and is available'() {
+        given:
+        String binLocation = "fake-bin-location"
+        Map data = [
+                product: "product-code-123",
+                lotNumber: null,
+                binLocation: binLocation
+        ]
+        ImportPackingListItem importedFile = new ImportPackingListItem()
+        Location location = new Location(id: "fake-location")
+        importedFile.origin = location
+
+        ProductAvailabilityService productAvailabilityServiceSpy = Spy(service.productAvailabilityService)
+
+        productAvailabilityServiceSpy.getAvailableBinLocations(_, _) >> [
+                new AvailableItem(
+                        inventoryItem: new InventoryItem(lotNumber: "fake-lot-number-1"),
+                        binLocation:  new Location(name: binLocation),
+                ),
+                new AvailableItem(
+                        inventoryItem: new InventoryItem(lotNumber: "fake-lot-number-2"),
+                        binLocation:  new Location(name: "another-bin"),
+                ),
+        ]
+
+        service.productAvailabilityService = productAvailabilityServiceSpy
+
+        when:
+        String inferredLotNumber = service.bindOrInferLotNumber(importedFile, data)
+
+        then:
+        inferredLotNumber == "fake-lot-number-1"
+    }
+
+    void 'bindOrInferLotNumber should return null when binLocation is provided and is available in multiple bins'() {
+        given:
+        String binLocation = "fake-bin-location"
+        Map data = [
+                product: "product-code-123",
+                lotNumber: null,
+                binLocation: binLocation
+        ]
+        ImportPackingListItem importedFile = new ImportPackingListItem()
+        Location location = new Location(id: "fake-location")
+        importedFile.origin = location
+
+        ProductAvailabilityService productAvailabilityServiceSpy = Spy(service.productAvailabilityService)
+
+        productAvailabilityServiceSpy.getAvailableBinLocations(_, _) >> [
+                new AvailableItem(
+                        inventoryItem: new InventoryItem(lotNumber: "fake-lot-number-1"),
+                        binLocation:  new Location(name: binLocation),
+                ),
+                new AvailableItem(
+                        inventoryItem: new InventoryItem(lotNumber: "fake-lot-number-2"),
+                        binLocation:  new Location(name: binLocation),
+                ),
+                new AvailableItem(
+                        inventoryItem: new InventoryItem(lotNumber: "fake-lot-number-3"),
+                        binLocation:  new Location(name: "another-bin"),
+                ),
+        ]
+
+        service.productAvailabilityService = productAvailabilityServiceSpy
+
+        when:
+        String inferredLotNumber = service.bindOrInferLotNumber(importedFile, data)
+
+        then:
+        inferredLotNumber == null
+    }
+
+    void 'bindOrInferLotNumber should return proper lotNumber when binLocation is not provided but stock in default bin is available'() {
+        given:
+        Map data = [
+                product: "product-code-123",
+                lotNumber: null,
+                binLocation: null
+        ]
+        ImportPackingListItem importedFile = new ImportPackingListItem()
+        Location location = new Location(id: "fake-location")
+        importedFile.origin = location
+
+        ProductAvailabilityService productAvailabilityServiceSpy = Spy(service.productAvailabilityService)
+
+        productAvailabilityServiceSpy.getAvailableBinLocations(_, _) >> [
+                new AvailableItem(
+                        inventoryItem: new InventoryItem(lotNumber: "fake-lot-number-1"),
+                        binLocation:  new Location(name: "bin-one"),
+                ),
+                new AvailableItem(
+                        inventoryItem: new InventoryItem(lotNumber: "fake-lot-number-2"),
+                        binLocation:  new Location(name: "bin-two"),
+                ),
+                new AvailableItem(
+                        inventoryItem: new InventoryItem(lotNumber: "fake-lot-number-3"),
+                        binLocation:  null
+                ),
+        ]
+
+        service.productAvailabilityService = productAvailabilityServiceSpy
+
+        when:
+        String inferredLotNumber = service.bindOrInferLotNumber(importedFile, data)
+
+        then:
+        inferredLotNumber == "fake-lot-number-3"
+    }
+
+    void 'bindOrInferLotNumber should return null when binLocation is not provided and stock is available in multiple default bins'() {
+        given:
+        Map data = [
+                product: "product-code-123",
+                lotNumber: null,
+                binLocation: null
+        ]
+        ImportPackingListItem importedFile = new ImportPackingListItem()
+        Location location = new Location(id: "fake-location")
+        importedFile.origin = location
+
+        ProductAvailabilityService productAvailabilityServiceSpy = Spy(service.productAvailabilityService)
+
+        productAvailabilityServiceSpy.getAvailableBinLocations(_, _) >> [
+                new AvailableItem(
+                        inventoryItem: new InventoryItem(lotNumber: "fake-lot-number-1"),
+                        binLocation:  new Location(name: "bin-one"),
+                ),
+                new AvailableItem(
+                        inventoryItem: new InventoryItem(lotNumber: "fake-lot-number-2"),
+                        binLocation:  null,
+                ),
+                new AvailableItem(
+                        inventoryItem: new InventoryItem(lotNumber: "fake-lot-number-3"),
+                        binLocation:  null
+                ),
+        ]
+
+        service.productAvailabilityService = productAvailabilityServiceSpy
+
+        when:
+        String inferredLotNumber = service.bindOrInferLotNumber(importedFile, data)
+
+        then:
+        inferredLotNumber == null
+    }
+}

--- a/src/test/groovy/unit/org/pih/warehouse/fulfillment/InferringOutboundImportValuesSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/fulfillment/InferringOutboundImportValuesSpec.groovy
@@ -13,7 +13,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 @Unroll
-class FulfillmentServiceSpec extends Specification implements ServiceUnitTest<FulfillmentService>, DataTest {
+class InferringOutboundImportValuesSpec extends Specification implements ServiceUnitTest<FulfillmentService>, DataTest {
 
     void setup() {
         service.productAvailabilityService = new ProductAvailabilityService()


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** [OBPIH-6747](https://pihemr.atlassian.net/browse/OBPIH-6747)

**Description:**
The inferring bin Location and lot number required a bit of a refactor, I decided to move many parts into standalone service methods for better maintainability and readability because this feature has grown a bit.

Additionally since  there are many different inferring/binding scenarios I am working on implementing tests for these methods

---
### :camera: Screenshots & Recordings (optional)

> *If this PR contains a UI change, consider adding one or more screenshots here or link to a screen recording to help reviewers visualize the change. Otherwise, you can remove this section.*


[OBPIH-6747]: https://pihemr.atlassian.net/browse/OBPIH-6747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ