### PR TITLE
OBPIH-6275 Export boolean values as true/false booleans, instead of a…

### DIFF
--- a/grails-app/services/org/pih/warehouse/core/DocumentService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/DocumentService.groovy
@@ -404,9 +404,11 @@ class DocumentService {
     void createExcelRow(HSSFSheet sheet, int rowNumber, Map dataRow) {
         Row excelRow = sheet.createRow(rowNumber)
         dataRow.keySet().eachWithIndex { columnName, index ->
-            def cellValue = dataRow.get(columnName) ?: ""
-            // POI can't handle objects so we need to convert all objects to strings unless they are numeric
-            if (!(cellValue instanceof Number)) {
+            def actualValue = dataRow.get(columnName)
+            // We can't just check the truthiness of the actualValue, because the false boolean would be evaluated to an empty string
+            def cellValue = actualValue == null ? "" : actualValue
+            // POI can't handle objects so we need to convert all objects to strings unless they are numeric or boolean
+            if (!(cellValue instanceof Number) && !(cellValue instanceof Boolean)) {
                 cellValue = cellValue.toString()
             }
             excelRow.createCell(index).setCellValue(cellValue)

--- a/grails-app/services/org/pih/warehouse/data/DataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/DataService.groovy
@@ -702,13 +702,13 @@ class DataService {
                 } else if (element.defaultValue && !value) {
                     value = element.defaultValue
                 }
-                // We can't just check the truthiness of the actualValue, because the false boolean would be evaluated to an empty string
+                // We can't just check the truthiness of the value, because the false boolean would be evaluated to an empty string
                 properties[fieldName] = value == null ? "" : value
             } else {
                 // to access object value by key we must use the object.get(key) instead of object[key]
                 // because using the object[key] will throw an error when trying to export data using the batch controller
                 value = object.get(element) ?: element.tokenize('.').inject(object) { v, k -> v?."$k" }
-                // We can't just check the truthiness of the actualValue, because the false boolean would be evaluated to an empty string
+                // We can't just check the truthiness of the value, because the false boolean would be evaluated to an empty string
                 properties[fieldName] = value == null ? "" : value
             }
         }

--- a/grails-app/services/org/pih/warehouse/data/DataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/DataService.groovy
@@ -702,12 +702,14 @@ class DataService {
                 } else if (element.defaultValue && !value) {
                     value = element.defaultValue
                 }
-                properties[fieldName] = value ?: ""
+                // We can't just check the truthiness of the actualValue, because the false boolean would be evaluated to an empty string
+                properties[fieldName] = value == null ? "" : value
             } else {
                 // to access object value by key we must use the object.get(key) instead of object[key]
                 // because using the object[key] will throw an error when trying to export data using the batch controller
                 value = object.get(element) ?: element.tokenize('.').inject(object) { v, k -> v?."$k" }
-                properties[fieldName] = value ?: ""
+                // We can't just check the truthiness of the actualValue, because the false boolean would be evaluated to an empty string
+                properties[fieldName] = value == null ? "" : value
             }
         }
         return properties


### PR DESCRIPTION
…n empty string for false boolean

### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:**

**Description:**
Initially I wanted to just parse booleans to string for the product sources export, not to impact the generic export builder, but it turned out, that the validation while importing the template back, would prevent the active field from being imported, as it would be passed as string, not as a boolean.
The change would potentially impact e.g. the Locations export, but I'd say there is nothing wrong with that, as it also fixes the same problem in the locations export, that would be probably addressed in a ticket anyway.

---
### :camera: Screenshots & Recordings (optional)

> *If this PR contains a UI change, consider adding one or more screenshots here or link to a screen recording to help reviewers visualize the change. Otherwise, you can remove this section.*
