### PR TITLE
OBPIH-6691 Add partially invoiced order summary status for order adjustments

### DIFF
--- a/grails-app/migrations/views/order-summary-helper-views.sql
+++ b/grails-app/migrations/views/order-summary-helper-views.sql
@@ -278,26 +278,30 @@ CREATE OR REPLACE VIEW order_summary AS (
                            LEFT OUTER JOIN order_item_summary ON order_item_summary.id = order_item.id
                   WHERE `order`.order_type_id = 'PURCHASE_ORDER'
                   GROUP BY `order`.id
-                  UNION SELECT `order`.id                                                                AS id,
-                               `order`.status                                                            AS order_status,
-                               0                                                                         AS quantity_ordered,
-                               0                                                                         AS items_ordered,
+                  UNION SELECT `order`.id                                                                  AS id,
+                               `order`.status                                                              AS order_status,
+                               0                                                                           AS quantity_ordered,
+                               0                                                                           AS items_ordered,
                                -- count all distinct adjustment items, this is for the case when adjustment might be canceled,
                                -- then invoiced (invoiced quantity is 0), then uncanceled and invoiced again with quantity 1
-                               IFNULL(COUNT(DISTINCT order_adjustment.id), 0)                            AS adjustments_count,
-                               0                                                                         AS quantity_shipped,
-                               0                                                                         AS items_shipped,
-                               0                                                                         AS quantity_received,
-                               0                                                                         AS items_received,
-                               0                                                                         AS quantity_canceled,
-                               0                                                                         AS quantity_invoiced,
-                               0                                                                         AS items_invoiced,
-                               IFNULL(COUNT(DISTINCT order_adjustment_payment_status.adjustment_id), 0)  AS adjustments_invoiced,
-                               SUM(DISTINCT total_adjustments.total_adjustments)                         AS total_adjustments,
-                               IFNULL(SUM(ABS(order_adjustment_payment_status.invoiced_amount)), 0)      AS invoiced_adjustments_amount
+                               IFNULL(COUNT(DISTINCT order_adjustment.id), 0)                              AS adjustments_count,
+                               0                                                                           AS quantity_shipped,
+                               0                                                                           AS items_shipped,
+                               0                                                                           AS quantity_received,
+                               0                                                                           AS items_received,
+                               0                                                                           AS quantity_canceled,
+                               0                                                                           AS quantity_invoiced,
+                               0                                                                           AS items_invoiced,
+                               IFNULL(COUNT(DISTINCT order_adjustment_payment_statuses.adjustment_id), 0)  AS adjustments_invoiced,
+                               SUM(DISTINCT total_adjustments.total_adjustments)                           AS total_adjustments,
+                               IFNULL(SUM(ABS(order_adjustment_payment_statuses.invoiced_amount)), 0)      AS invoiced_adjustments_amount
                   FROM `order`
                            LEFT OUTER JOIN order_adjustment ON order_adjustment.order_id = `order`.id
-                           LEFT OUTER JOIN order_adjustment_payment_status ON order_adjustment_payment_status.adjustment_id = order_adjustment.id
+                           LEFT OUTER JOIN (
+                                SELECT adjustment_id, SUM(invoiced_amount) as invoiced_amount
+                                FROM order_adjustment_payment_status
+                                GROUP BY adjustment_id
+                           ) as order_adjustment_payment_statuses ON order_adjustment_payment_statuses.adjustment_id = order_adjustment.id
                            LEFT OUTER JOIN (
                       SELECT order_id,
                              SUM(total_adjustment) AS total_adjustments


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6691

**Description:**
This reopen was due to the following behavior:
    - Create PO, add an item, and adjustment with a percentage value for that item
    - Generate prepayment invoice 
    - Generate final invoice for adjustment
    - Edit unit price/qty of the item to lower value
    - Generate final invoice pending value difference for adjustment
    - Ship item
    - Generate invoice for item
    See that status remains Partially Invoiced. 

This issue was caused by the fact, that if we are editing an order item that is bound with order adjustment we have to invoice the value difference, which is a negative value, but the value of the adjustment is positive. After summing the absolute amount values for the order we had, for example:
- total_adjustments: 0.2
- invoiced_adjustments_amount: 1
invoicing the "difference" in values is the only case when we are able to invoice the same order adjustment with negative and positive values because we have validation for that in every editting.
---
