### PR TITLE
OBPIH-6757 Fix a bug related to 1:1 association between product suppl…

### DIFF
--- a/grails-app/services/org/pih/warehouse/data/ProductSupplierService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSupplierService.groovy
@@ -226,7 +226,9 @@ class ProductSupplierService {
         productSupplier.manufacturer = manufacturerName ? Organization.findByName(manufacturerName) : null
         productSupplier.supplierCode = supplierCode ? supplierCode : null
         productSupplier.manufacturerCode = manufacturerCode ? manufacturerCode : null
-        productSupplier.save()
+        if (!productSupplier.code && !productSupplier.id) {
+            assignSourceCode(productSupplier, supplier)
+        }
 
         if (unitOfMeasure && quantity) {
             ProductPackage defaultProductPackage =
@@ -239,15 +241,17 @@ class ProductSupplierService {
                 defaultProductPackage.product = productSupplier.product
                 defaultProductPackage.uom = unitOfMeasure
                 defaultProductPackage.quantity = quantity
-                productSupplier.addToProductPackages(defaultProductPackage)
-                productSupplier.defaultProductPackage = defaultProductPackage
+                productSupplier.save()
                 defaultProductPackage.productSupplier = productSupplier
+                defaultProductPackage.save(flush: true)
+                productSupplier.defaultProductPackage = defaultProductPackage
+                productSupplier.addToProductPackages(defaultProductPackage)
+
                 if (price != null) {
                     ProductPrice productPrice = new ProductPrice()
                     productPrice.price = price
                     defaultProductPackage.productPrice = productPrice
                 }
-                productSupplier.addToProductPackages(defaultProductPackage)
             } else if (price != null && !defaultProductPackage.productPrice) {
                 ProductPrice productPrice = new ProductPrice()
                 productPrice.price = price
@@ -283,9 +287,6 @@ class ProductSupplierService {
                 params.globalPreferenceTypeValidityStartDate,
                 params.globalPreferenceTypeValidityEndDate)
 
-        if (!productSupplier.code && !productSupplier.id) {
-            assignSourceCode(productSupplier, supplier)
-        }
         return productSupplier
     }
 

--- a/grails-app/services/org/pih/warehouse/data/ProductSupplierService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/ProductSupplierService.groovy
@@ -241,8 +241,17 @@ class ProductSupplierService {
                 defaultProductPackage.product = productSupplier.product
                 defaultProductPackage.uom = unitOfMeasure
                 defaultProductPackage.quantity = quantity
+                /**
+                    Product supplier needs to be saved here to receive an ID in order to be able to assign it to the product package
+                    otherwise the transient property value exception would be thrown
+                 */
                 productSupplier.save()
                 defaultProductPackage.productSupplier = productSupplier
+                /**
+                    The flush is needed because of the order Hibernate uses to save the entities in this operation -
+                    for productSupplier.defaultProductPackage to be stored properly and not be cleared after transaction commit, the flush is needed
+                    Check OBPIH-6757 for more details (#4904 PR)
+                 */
                 defaultProductPackage.save(flush: true)
                 productSupplier.defaultProductPackage = defaultProductPackage
                 productSupplier.addToProductPackages(defaultProductPackage)


### PR DESCRIPTION
…ier and product package + fix generating a source code

### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:**

**Description:**
The fix for the main problem was adding a flush in product package save. Why it is needed is due to the fact of our complicated relationships in the product supplier domain - we have both 1:1 (`defaultProductPackage`) and 1:N (`productPackages`) relationships between product supplier and product package.
When attempting to save a `productPackage` without saving the `productSupplier` before, we would get an error that we try to use a "transient instance must be saved before current operation".
On the other hand, if we save the `productSupplier` before and then save the `productPackage` and assign it to the `productSupplier` everything looks great in the debugger - we can see that the `productSupplier.defaultProductPackage` is assigned properly as well as `productSupplier.productPackages` list contains the package.
The problem was that after the session was flushed and the transaction was commited, the `productSupplier.defaultPackage` was cleared (became `null`), whereas the list (`productSupplier.productPackages`) stayed untouched.
It's due to the queue that Hibernate generated for those operations as the transaction commit - when we call the `save()` without flush, the sql logs look like this:
```
Hibernate: 
    insert 
    into
        product_supplier
        (version, product_id, manufacturer_id, supplier_code, date_created, code, model_number, last_updated, default_product_package_id, active, standard_lead_time_days, tiered_pricing, supplier_id, manufacturer_code, comments, upc, brand_name, rating_type_code, manufacturer_name, name, product_code, supplier_name, contract_price_id, description, min_order_quantity, ndc, id) 
    values
        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
Hibernate: 
    insert 
    into
        product_package
        (version, product_id, date_created, gtin, last_updated, updated_by_id, uom_id, product_supplier_id, product_price_id, quantity, name, created_by_id, description, id) 
    values
        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
```
so as you can see, we save the product supplier before the product package, so the `default_product_package_id` must be `null` at this point.
As for the 1:N bidirectional association, it is enough to store the foreign key in the product package table, so in the `product_supplier_id` property which is NOT null at this point (hence the list is not cleared, whereas the 1:1 is cleared).

When we call `save(flush: true)` though, the logs look like this:

```
Hibernate: 
    insert 
    into
        product_supplier
        (version, product_id, manufacturer_id, supplier_code, date_created, code, model_number, last_updated, default_product_package_id, active, standard_lead_time_days, tiered_pricing, supplier_id, manufacturer_code, comments, upc, brand_name, rating_type_code, manufacturer_name, name, product_code, supplier_name, contract_price_id, description, min_order_quantity, ndc, id) 
    values
        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
Hibernate: 
    insert 
    into
        product_package
        (version, product_id, date_created, gtin, last_updated, updated_by_id, uom_id, product_supplier_id, product_price_id, quantity, name, created_by_id, description, id) 
    values
        (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
Hibernate: 
    update
        product_supplier 
    set
        version=?,
        product_id=?,
        manufacturer_id=?,
        supplier_code=?,
        date_created=?,
        code=?,
        model_number=?,
        last_updated=?,
        default_product_package_id=?,
        active=?,
        standard_lead_time_days=?,
        tiered_pricing=?,
        supplier_id=?,
        manufacturer_code=?,
        comments=?,
        upc=?,
        brand_name=?,
        rating_type_code=?,
        manufacturer_name=?,
        name=?,
        product_code=?,
        supplier_name=?,
        contract_price_id=?,
        description=?,
        min_order_quantity=?,
        ndc=? 
    where
        id=? 
        and version=?
Hibernate: 
    select
        this_.id as id1_80_0_,
        this_.version as version2_80_0_,
        this_.product_id as product_3_80_0_,
        this_.date_created as date_cre4_80_0_,
        this_.gtin as gtin5_80_0_,
        this_.last_updated as last_upd6_80_0_,
        this_.updated_by_id as updated_7_80_0_,
        this_.uom_id as uom_id8_80_0_,
        this_.product_supplier_id as product_9_80_0_,
        this_.product_price_id as product10_80_0_,
        this_.quantity as quantit11_80_0_,
        this_.name as name12_80_0_,
        this_.created_by_id as created13_80_0_,
        this_.description as descrip14_80_0_ 
    from
        product_package this_ 
    where
        (
            this_.uom_id=? 
            and this_.product_id=? 
            and this_.quantity=? 
            and this_.product_supplier_id=?
        ) limit ?
Hibernate: 
    update
        product_package 
    set
        version=?,
        product_id=?,
        date_created=?,
        gtin=?,
        last_updated=?,
        updated_by_id=?,
        uom_id=?,
        product_supplier_id=?,
        product_price_id=?,
        quantity=?,
        name=?,
        created_by_id=?,
        description=? 
    where
        id=? 
        and version=?
```
so the product supplier is updated with the existing product package, that has just been persisted - this didn't take place in the first version and this is why the `productSupplier.defaultProductPackage` was `null` after the transaction was commited.

---
### :camera: Screenshots & Recordings (optional)

> *If this PR contains a UI change, consider adding one or more screenshots here or link to a screen recording to help reviewers visualize the change. Otherwise, you can remove this section.*
