### PR TITLE
OBPIH-6225 Include UoM when splitting the line

### DIFF
--- a/src/js/components/stock-movement-wizard/combined-shipments/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/combined-shipments/AddItemsPage.jsx
@@ -252,6 +252,7 @@ const FIELDS = {
               referenceId: fieldValue.orderItemId,
               orderNumber: fieldValue.orderNumber,
               packSize: fieldValue.packSize,
+              unitOfMeasure: fieldValue.unitOfMeasure,
               quantityAvailable: fieldValue.quantityAvailable,
             }, rowIndex);
           },


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** [OBPIH-6225](https://pihemr.atlassian.net/browse/OBPIH-6225)

**Description:**
QA releaved a bug where the UoM label was not visible when splitting the line

---
### :camera: Screenshots & Recordings (optional)

> *If this PR contains a UI change, consider adding one or more screenshots here or link to a screen recording to help reviewers visualize the change. Otherwise, you can remove this section.*


[OBPIH-6225]: https://pihemr.atlassian.net/browse/OBPIH-6225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ