### PR TITLE
OBPIH-6784 Set a more lenient session timeout

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -77,7 +77,11 @@ management:
 server:
     contextPath: "/openboxes"
     session:
-        timeout: 3600
+        # The time (in seconds) of inactivity before we invalidate the user's session. (7200 is two hours.)
+        # In SpringBoot 2+, this setting is "server.servlet.session.timeout"
+        # This setting is only applied when running via embedded server. Settings for when the app is deployed to
+        # a Tomcat Servlet can be found in /src/main/webapp/WEB-INF/web.xml
+        timeout: 7200
 ---
 grails:
     #

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+
+    <!--
+    Server configuration for non-embedded server deployments (ie when deploying to an external Tomcat Servlet).
+    Note that running the application with an embedded server will not pick up these settings. Any settings that we
+    want to also apply for embedded servers should also be configured in a property file such as application.yml.
+    -->
+
+    <session-config>
+        <!--
+        The time (in minutes) of inactivity before we invalidate the user's session. (120 is two hours.)
+        "server.session.timeout" (or "server.servlet.session.timeout" in SpringBoot 2+) is the matching
+        setting in application.yml.
+         -->
+        <session-timeout>120</session-timeout>
+    </session-config>
+
+</web-app>


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6784

**Description:**

1) We're changing our session timeout from 1 to 2 hours.
2) Configura a custom timeout for non-embedded server deploys (ie when deploying to an external Tomcat Servlet). The config in applicaiton.yml only applies to embedded servers. the web.xml file works for external Tomcat deploys.
