### PR TITLE
OBPIH-6698 Include label and defaultMessage in base field componnt when props are passed as dynamic attributes

### DIFF
--- a/src/js/components/form-elements/BaseField.jsx
+++ b/src/js/components/form-elements/BaseField.jsx
@@ -121,8 +121,8 @@ class BaseField extends Component {
         component={renderField}
         renderInput={this.renderInput}
         attributes={attr}
-        label={label}
-        defaultMessage={defaultMessage}
+        label={dynamicAttr?.label || label}
+        defaultMessage={dynamicAttr?.defaultMessage || defaultMessage}
         touched={this.state.touched}
         arrayField={arrayField}
       />


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** [OBPIH-6698](https://pihemr.atlassian.net/browse/OBPIH-6698)

**Description:**
After some recent changes to the receiving workflow it appears that props `label` and `defaultMessage` were not properly passed to the BaseField component when passing them through dyanmicAttributes which broke the test because screen reader was not able to find the appropriate textfield when looking for Receving now field by label

---
### :camera: Screenshots & Recordings (optional)

> *If this PR contains a UI change, consider adding one or more screenshots here or link to a screen recording to help reviewers visualize the change. Otherwise, you can remove this section.*


[OBPIH-6698]: https://pihemr.atlassian.net/browse/OBPIH-6698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ