### PR TITLE
OBPIH-6707 Fix quantity shipped indicator on edit modal when a brand …

### DIFF
--- a/src/js/components/receiving/PartialReceivingPage.jsx
+++ b/src/js/components/receiving/PartialReceivingPage.jsx
@@ -579,7 +579,10 @@ class PartialReceivingPage extends Component {
     return apiClient.get(url)
       .then((response) => {
         this.setState({ values: {} }, () => {
-          this.setState({ values: parseResponse(response.data.data) });
+          this.setState({
+            values: parseResponse(response.data.data),
+            initialReceiptCandidates: parseResponse(response.data.data),
+          });
         });
       })
       .catch(() => this.props.hideSpinner());
@@ -1052,6 +1055,7 @@ class PartialReceivingPage extends Component {
                         hasPartialReceivingSupport: this.props.hasPartialReceivingSupport,
                         translate: this.props.translate,
                         formatLocalizedDate: this.props.formatLocalizedDate,
+                        initialReceiptCandidates: this.state.initialReceiptCandidates,
                       }))}
                   </div>
                   <div className="submit-buttons">


### PR DESCRIPTION
…new row is added to the table

### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:**

**Description:**
The comments before calling the `groupShipmentItems` sort of describe the issue that was caught by Jakub, but in a nutshell - constructor is called only once, so in the constructor I tried to rely on initial values of the form (original qty), and then, while opening a modal, relying on the current values of the form. The problem was that when we add a new row at the end (e.g. we edit the last item), this modal has not yet been built in the background, hence when creating it and having already edited an item (with decreased/increased qty shipped), the new row would look at it as the original qty and the indicator would not be shown in that line.
To fix this, I need to store the initial receipt candidates values separately, not to rely on the values of the form in the constructor.

---
### :camera: Screenshots & Recordings (optional)

> *If this PR contains a UI change, consider adding one or more screenshots here or link to a screen recording to help reviewers visualize the change. Otherwise, you can remove this section.*
