### PR TITLE
OBPIH-6099 Fix issue with global recipient on outbound autosave

### DIFF
--- a/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
@@ -1065,7 +1065,7 @@ class AddItemsPage extends Component {
 
     // We don't want to save the item during editing or
     // when there is an error in line
-    if (isEdited) {
+    if (isEdited || editAll) {
       this.debouncedSave();
       return;
     }

--- a/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/AddItemsPage.jsx
@@ -189,6 +189,15 @@ const NO_STOCKLIST_FIELDS = {
               onChange={(val) => {
                 if (val) {
                   setRecipientValue(val);
+                  saveProgress({
+                    editAll: true,
+                    values: update(values, {
+                      lineItems: {
+                        $set: values.lineItems
+                          .map((item) => update(item, { recipient: { $set: val } })),
+                      },
+                    }),
+                  });
                 }
               }}
             />
@@ -1021,7 +1030,7 @@ class AddItemsPage extends Component {
 
   // if rowIndex is passed, it means that we are editing row
   // not adding new one
-  saveProgress = ({ values, rowIndex, fieldValue }) => {
+  saveProgress = ({ values, rowIndex, fieldValue, editAll }) => {
     if (!this.props.isAutosaveEnabled) {
       return;
     }
@@ -1034,6 +1043,10 @@ class AddItemsPage extends Component {
     // rowIndex is present
     const isEdited = rowIndex !== undefined;
     const itemsWithStatuses = values.lineItems.map((item) => {
+      if (editAll) {
+        return { ...item, rowSaveStatus: RowSaveStatus.PENDING };
+      }
+
       if (isEdited && rowIndex === values.lineItems.indexOf(item)) {
         return { ...fieldValue, rowSaveStatus: RowSaveStatus.PENDING };
       }


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** /[OBPIH-6099](https://pihemr.atlassian.net/browse/OBPIH-6099)

**Description:** Issue was that on outbound workflow when autosave was enabled this globalr ecipient did not work propetly

Current autosave behacior only includes logic for individual edits on the row, since we are working with a "bulk" update I had to add some modifications like thi `editAll` prop


---
### :camera: Screenshots & Recordings (optional)

> *If this PR contains a UI change, consider adding one or more screenshots here or link to a screen recording to help reviewers visualize the change. Otherwise, you can remove this section.*


[OBPIH-6099]: https://pihemr.atlassian.net/browse/OBPIH-6099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ