### PR TITLE
OBPIH-6649 Add support for Jacoco code coverage reporting

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -31,18 +31,16 @@ jobs:
       # tests into a separate job and run the matrix only on that job (because unit tests don't care about the
       # underlying database and so running them against multiple databases is pointless), but matrix jobs are run
       # in parallel so it wouldn't save us any running time to do that. Plus it would overcomplicate the flow.
-      - name: Run All Tests    
-        if: ${{ strategy.job-index != 0 }}
+      - name: Run All Tests
         run: TEST_DATABASE=${{ matrix.testdatabase }} ./grailsw test-app --non-interactive --no-daemon
 
       # Tests are run for each database in the above matrix but we only want to generate a code coverage report once.
       # "strategy.job-index" gives us the index of the current job in the matrix. Any index is fine. We use the first.
-      - name: Run All Tests With Coverage
-        if: ${{ strategy.job-index == 0 }}
-        run: TEST_DATABASE=${{ matrix.testdatabase }} ./grailsw test-app -coverage -xml --non-interactive --no-daemon
-
       - name: Upload results to Codecov
         if: ${{ strategy.job-index == 0 }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./build/reports/jacoco/test/jacocoTestReport.xml
+          fail_ci_if_error: false
+          verbose: true

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -3,6 +3,9 @@ name: Backend Tests
 # Is only runnable via other workflows
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: true
 
 env:
   JAVA_VERSION: 8
@@ -41,6 +44,3 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./build/reports/jacoco/test/jacocoTestReport.xml
-          fail_ci_if_error: false
-          verbose: true

--- a/.github/workflows/on-change.yml
+++ b/.github/workflows/on-change.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   run-frontend-tests:
     uses: ./.github/workflows/frontend-tests.yml
+    secrets: inherit
 
   run-backend-tests:
     uses: ./.github/workflows/backend-tests.yml
+    secrets: inherit

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   run-frontend-tests:
     uses: ./.github/workflows/frontend-tests.yml
+    secrets: inherit
 
   run-backend-tests:
     uses: ./.github/workflows/backend-tests.yml
+    secrets: inherit

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,10 @@ plugins {
 
     // enable `grails gradle autoLintGradle`
     id 'nebula.lint' version '17.8.0'
+
+    // Adds the "jacocoTestReport" command for generating code coverage reports as well as the
+    // "jacocoTestCoverageVerification" command for validating coverage percentage minimums.
+    id 'jacoco'
 }
 
 // prevent warfile issues by applying this before `asset-pipeline`. OBGM-353
@@ -838,30 +842,66 @@ task writePom {
     }
 }
 
+// Jacoco code coverage reporting. https://docs.gradle.org/4.10.3/userguide/jacoco_plugin.html
+// Running "./gradlew jacocoTestReport" will execute all unit and integration tests, then generate a code
+// coverage report under the "/build/reports/jacoco" folder.
+jacoco {
+    // Jacoco 0.7.7 requires ASM Version 5.1+ https://www.eclemma.org/jacoco/trunk/doc/changes.html
+    toolVersion = '0.7.6.201602180812'
+}
+// Note that the paths here are by package name (as they are in "build/classes/groovy/main"). As such, we cannot
+// filter by Grails folders such as "**/controller/**" (but we could filter by "**/*Controller.class").
+List jacocoExcludes = [
+        // Filter out the Groovy-generated closure classes from Jacoco for the sake of visual clarity in the report.
+        // https://stackoverflow.com/questions/39453696/how-do-you-exclude-implicit-groovy-closure-classes-from-jacoco-test-resport-with
+        '**/*$*_closure*',
+]
+jacocoTestReport {
+    // Makes sure that tests are always run before a report is generated (because otherwise the report will be blank or
+    // out of date). This allows us to run both tests and coverage with "./gradlew jacocoTestReport"
+    dependsOn test, integrationTest
+
+    // Generates a combined report based on the coverage results generated from both unit tests and integration tests.
+    executionData test, integrationTest
+
+    reports {
+        xml.enabled true  // Needed so that we can upload to Codecov.
+        html.enabled true  // Useful for verifying locally during development.
+    }
+
+    doFirst {
+        // Our source code builds to both "build/classes/groovy" and "build/classes/java" so we need to filter one of
+        // the two class paths out to avoid "Can't add different class with same name" errors. It's dirty to do this
+        // in the "doFirst" block, but it's the only way to tell Jacoco to ONLY use this path.
+        classDirectories = files(files("build/classes/groovy/main").collect {
+            // Then also exclude any packages from the report that we didn't actually generate any coverage % for.
+            fileTree(dir: it, exclude: jacocoExcludes)
+        })
+    }
+}
+
+// Configuration for both "test" and "integrationTest" tasks.
 tasks.withType(Test) {
     systemProperty 'geb.build.reportsDir', reporting.file('geb/integrationTest')
     systemProperty 'geb.env', System.getProperty('geb.env')
     systemProperty 'webdriver.chrome.driver', System.getProperty('webdriver.chrome.driver')
     systemProperty 'webdriver.firefox.driver', System.getProperty('webdriver.firefox.driver')
+    systemProperty "username", System.getProperty("username")
+    systemProperty "password", System.getProperty("password")
+
     testLogging {
         events 'failed', 'passed', 'skipped'
         exceptionFormat 'full'
-    }
-}
-
-/**
- * Used when running integration tests. Can be defined at the commandline by our build and
- * test pipelines (which use secrets, not plaintext passwords).
- */
-test {
-    systemProperty "username", System.getProperty("username")
-    systemProperty "password", System.getProperty("password")
-}
-
-integrationTest {
-    testLogging {
-        events "passed", "skipped", "failed"
         showStackTraces = true
         showStandardStreams = true
+    }
+
+    // Generate a code coverage report whenever tests run. This is useful for simplifying uploading coverage reports
+    // during our CI flows. The actual report generation is quick (<20 seconds), so it's fine to do this every time.
+    finalizedBy jacocoTestReport
+
+    jacoco {
+        // When running tests, exclude the given folders from Jacoco coverage % generation.
+        excludes = jacocoExcludes
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -852,9 +852,9 @@ jacoco {
 // Note that the paths here are by package name (as they are in "build/classes/groovy/main"). As such, we cannot
 // filter by Grails folders such as "**/controller/**" (but we could filter by "**/*Controller.class").
 List jacocoExcludes = [
-        // Filter out the Groovy-generated closure classes from Jacoco for the sake of visual clarity in the report.
-        // https://stackoverflow.com/questions/39453696/how-do-you-exclude-implicit-groovy-closure-classes-from-jacoco-test-resport-with
-        '**/*$*_closure*',
+        // This filters out all the Groovy-generated closure elements from Jacoco, which helps de-clutter the report but
+        // also prevents any closures from being counted in the report. Leave them in to get a more accurate percentage.
+        //'**/*$*_closure*',
 ]
 jacocoTestReport {
     // Makes sure that tests are always run before a report is generated (because otherwise the report will be blank or


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6649

**Description:** Generates a code coverage report using Jacoco whenever tests are run and then uploads them to Codecov when commits are pushed to PRs or when PRs are merged to develop.

Codecov dashboard: https://app.codecov.io/gh/openboxes/openboxes/

![image](https://github.com/user-attachments/assets/71656dd2-a7e2-4970-a077-22dafd257aae)

![image](https://github.com/user-attachments/assets/77e8d3c3-8527-4331-ac92-be3ec1e28d0e)


And this is what the raw HTML Jacoco reports that codecov is built from look like (we probably won't use these much except for local testing):
![Screenshot from 2024-11-07 17-34-05](https://github.com/user-attachments/assets/ac4c64f9-c667-426b-b28d-e15ba776d292)