### PR TITLE
OBPIH-6742 Performance: Virtualize table on receiving workflow

### DIFF
--- a/src/js/components/form-elements/TableBodyVirtualized.jsx
+++ b/src/js/components/form-elements/TableBodyVirtualized.jsx
@@ -111,7 +111,7 @@ class TableBodyVirtualized extends Component {
     const RowComponent = fieldsConfig.rowComponent || TableRow;
     const { totalCount } = properties;
 
-    if (fields.value[index]) {
+    if (fields?.value?.[index]) {
       const dynamicRowAttr = fieldsConfig.getDynamicRowAttr ?
         fieldsConfig.getDynamicRowAttr({
           ...properties,

--- a/src/js/components/receiving/PartialReceivingPage.jsx
+++ b/src/js/components/receiving/PartialReceivingPage.jsx
@@ -103,6 +103,11 @@ const TABLE_FIELDS = {
   containers: {
     type: ArrayField,
     arrowsNavigation: true,
+    virtualized: true,
+    totalCount: ({ totalCount }) => totalCount,
+    isRowLoaded: ({ isRowLoaded }) => isRowLoaded,
+    loadMoreRows: ({ loadMoreRows }) => loadMoreRows(),
+    isFirstPageLoaded: ({ isFirstPageLoaded }) => isFirstPageLoaded,
     rowComponent: TableRowWithSubfields,
     headerFontSize: '0.775rem',
     subfieldKey: 'shipmentItems',
@@ -452,6 +457,7 @@ class PartialReceivingPage extends Component {
 
     this.state = {
       values: {},
+      isFirstPageLoaded: false,
     };
     this.autofillLines = this.autofillLines.bind(this);
     this.setLocation = this.setLocation.bind(this);
@@ -462,6 +468,7 @@ class PartialReceivingPage extends Component {
     this.exportTemplate = this.exportTemplate.bind(this);
     this.importTemplate = this.importTemplate.bind(this);
     this.rewriteQuantitiesAfterSave = this.rewriteQuantitiesAfterSave.bind(this);
+    this.isRowLoaded = this.isRowLoaded.bind(this);
   }
 
   componentDidMount() {
@@ -582,6 +589,7 @@ class PartialReceivingPage extends Component {
           this.setState({
             values: parseResponse(response.data.data),
             initialReceiptCandidates: parseResponse(response.data.data),
+            isFirstPageLoaded: true,
           });
         });
       })
@@ -966,6 +974,10 @@ class PartialReceivingPage extends Component {
       .catch(() => this.props.hideSpinner());
   }
 
+  isRowLoaded({ index }) {
+    return !!this.state.values.containers[index];
+  }
+
   render() {
     return (
       <div>
@@ -1044,6 +1056,10 @@ class PartialReceivingPage extends Component {
                   <div className="my-2 table-form" data-testid="items-table">
                     {_.map(TABLE_FIELDS, (fieldConfig, fieldName) =>
                       renderFormField(fieldConfig, fieldName, {
+                        totalCount: this.state.values?.containers?.length || 0,
+                        loadMoreRows: () => {},
+                        isRowLoaded: this.isRowLoaded,
+                        isFirstPageLoaded: this.state.isFirstPageLoaded,
                         autofillLines: this.autofillLines,
                         saveEditLine: this.saveEditLine,
                         setLocation: this.setLocation,


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6742

**Description:**
<span><span data-testid="comment-base-item-156951"><p data-renderer-start-pos="1">The virtualization in this workflow uses one <strong data-renderer-mark="true">container </strong>as one “row”. This means that if we have more containers the better the performance of this table will be. So, when we have everything under one container all lines will be loaded at once, so there won’t be any performance changes. That implies that in the worst case, there is no improvement, but in the best case there will be rather big improvement.  As an additional thing - we should remember that the current implementation of our virtualized components is not ideal, so when we are scrolling a little bit faster we will see empty lines, but it will be loaded in a few milliseconds.</p><div class="ak-editor-panel css-cbll9a" data-panel-type="info"></div></span></span><span><span data-testid="comment-base-item-156951"><div class="ak-editor-panel css-cbll9a" data-panel-type="info"><div class="ak-editor-panel__content"><p data-renderer-start-pos="647"><strong data-renderer-mark="true">Reminder</strong>: performance issues in this workflow are caused by rendering too many DOM elements simultaneously (table renders too many rows). Phases of detecting changes in React look the following:</p><ul class="ak-ul" data-indent-level="1"><li><p data-renderer-start-pos="845">triggering phase - at this step React detects changes in states, so he knows that there is a probability for changes in displaying content. In our case, it is marking checkboxes, adding comments, etc.</p></li><li><p data-renderer-start-pos="1049">rendering phase - at this step, React calls all of the nested components and checks whether any of the properties were changed, and then React applies them to the virtual DOM.</p></li><li><p data-renderer-start-pos="1228">commit phase - at this step, React applies all of the required changes to the DOM using a minimal amount of operations.</p></li></ul></div></div><p data-renderer-start-pos="1352"><em data-renderer-mark="true">To make the measures more relevant I measured the calculation times a few times and then I calculated the average time of the operations. All of the operations were triggered on a receiving page with 200 items. Everything is split between containers including from 1 item to 11 at max.</em></p><p data-renderer-start-pos="1639"><strong data-renderer-mark="true">To compare the changes in rendering components I created a table:</strong></p><div class="pm-table-container " data-layout="custom" style="width: inherit;"><div class="pm-table-wrapper">
Action | Before virtualization | After virtualization
-- | -- | --
Initial page loading | 18.21s (includes fetching time) | 6.13s (includes fetching time)
Autofill quantities (Checking checkboxes) | 12.09s | 1.76s
Adding comment | 22.86s | 3.41s
Changing “Receiving now” quantity | 17.55s | 2.64s

</div></div></span></span>
