### PR TITLE
Fix mkdocs build integration with readthedocs (fixes #4345)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,15 +5,19 @@
 # Required
 version: 2
 
+# Allows you to specify the base Read the Docs image used to build the documentation
+# and control versions of tools. https://docs.readthedocs.io/en/stable/config-file/v2.html#build
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+# Configuration for MkDocs documentation
+# https://docs.readthedocs.io/en/stable/config-file/v2.html#mkdocs
 mkdocs:
   configuration: mkdocs.yml
 
-# Optionally build your docs in additional formats such as PDF
-formats:
-   - pdf
-
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.7
    install:
    - requirements: docs/requirements.txt


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:**
#4345 

**Description:**

Readthedocs integration has been failing on all branches derived from develop for a long time. That leads to a failing build check for every PR that gets created. 

![image](https://github.com/user-attachments/assets/79d4e015-26c6-43d8-b15b-95f7abc72cb0)

Here's what the build on readthedocs looks like. 
![image](https://github.com/user-attachments/assets/27c5047e-dd91-45ea-ab70-71991dba8ccf)

We fixed the issue months ago, but it's on a long-lived feature branch (OBPIH-6197) aimed at updating our docs for the 0.9.x release. And unfortunately, those change have not been pushed to develop yet. 

So here we are. 

And here's a recent build of the current branch on readthedocs, showing that the changes allows builds to pass successfully.

![image](https://github.com/user-attachments/assets/52e5bbb7-1614-447a-8e31-12a9d54ae206)
