### PR TITLE
OBPIH-6821 Try next sequence number if generating an order number fails

### DIFF
--- a/src/main/groovy/org/pih/warehouse/core/identification/IdentifierGeneratorContext.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/identification/IdentifierGeneratorContext.groovy
@@ -42,5 +42,5 @@ class IdentifierGeneratorContext {
      * These must be defined in the .format property in GStrings prefixed with the "custom" category. Ex: ${custom.x}
      * This is to distinguish the custom keys from entity-specific keys (which are defined in the .properties property).
      */
-    Map customProperties
+    Map<String, String> customProperties = new HashMap<>()
 }


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6821

**Description:** See ticket for details, but this PR fixes an issue where an organization's sequence number falls out of sync with the order numbers that we have generated for POs. Essentially the PR adds a retry mechanism where if the id we generate is not unique, check the next 10 sequence numbers if they're available.

