### PR TITLE
OBPIH-6839 Improve performance of order's derived status fetch and update

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/api/PurchaseOrderApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/PurchaseOrderApiController.groovy
@@ -14,15 +14,18 @@ import org.pih.warehouse.importer.CSVUtils
 import org.pih.warehouse.order.Order
 import org.pih.warehouse.order.OrderItem
 import org.pih.warehouse.order.OrderItemStatusCode
+import org.pih.warehouse.order.OrderService
 import org.pih.warehouse.order.OrderStatus
 import org.pih.warehouse.order.OrderSummary
+import org.pih.warehouse.order.OrderSummaryService
 import org.pih.warehouse.order.OrderSummaryStatus
 
 import java.math.RoundingMode
 
 class PurchaseOrderApiController {
 
-    def orderService
+    OrderService orderService
+    OrderSummaryService orderSummaryService
 
     def list() {
         List<OrderSummary> purchaseOrders = orderService.getPurchaseOrders(params)
@@ -234,7 +237,6 @@ class PurchaseOrderApiController {
     }
 
     def orderItemsDerivedStatus = {
-        Order order = Order.get(params.id)
-        render order?.getOrderItemsDerivedStatus() as JSON
+        render orderSummaryService.getOrderItemsDerivedStatus(params.id) as JSON
     }
 }

--- a/grails-app/jobs/org/pih/warehouse/jobs/RefreshOrderSummaryJob.groovy
+++ b/grails-app/jobs/org/pih/warehouse/jobs/RefreshOrderSummaryJob.groovy
@@ -1,12 +1,12 @@
 package org.pih.warehouse.jobs
 
 import grails.util.Holders
-import org.pih.warehouse.order.OrderService
+import org.pih.warehouse.order.OrderSummaryService
 import org.quartz.JobExecutionContext
 
 class RefreshOrderSummaryJob {
 
-    OrderService orderService
+    OrderSummaryService orderSummaryService
 
     static concurrent = false
 
@@ -21,7 +21,7 @@ class RefreshOrderSummaryJob {
         if (JobUtils.shouldExecute(RefreshOrderSummaryJob)) {
             def startTime = System.currentTimeMillis()
             log.info("Refreshing order summary: " + context.mergedJobDataMap)
-            orderService.refreshOrderSummary()
+            orderSummaryService.refreshOrderSummary()
             log.info "Finished refreshing order summary in " + (System.currentTimeMillis() - startTime) + " ms"
         }
     }

--- a/grails-app/services/org/pih/warehouse/data/DataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/DataService.groovy
@@ -59,12 +59,12 @@ class DataService {
         return new Sql(dataSource).rows(query, params)
     }
 
-    void executeStatement(String statement) {
+    void executeStatement(String statement, Boolean logStatement = true) {
         Sql sql = new Sql(dataSource)
         sql.withTransaction {
             try {
                 def startTime = System.currentTimeMillis()
-                log.info "Executing statement ${statement}"
+                log.info "Executing statement ${logStatement ? statement : ''}"
                 sql.execute(statement)
                 log.info "Updated ${sql.updateCount} rows in " +  (System.currentTimeMillis() - startTime) + " ms"
                 sql.commit()
@@ -75,9 +75,9 @@ class DataService {
         }
     }
 
-    void executeStatements(List statementList) {
+    void executeStatements(List statementList, Boolean logStatements = true) {
         statementList.each { String statement ->
-            executeStatement(statement)
+            executeStatement(statement, logStatements)
         }
     }
 

--- a/grails-app/services/org/pih/warehouse/order/OrderService.groovy
+++ b/grails-app/services/org/pih/warehouse/order/OrderService.groovy
@@ -1248,61 +1248,6 @@ class OrderService {
         return results
     }
 
-    /**
-     * Refreshing entire Order Summary materialized view, should be only triggered from time to time
-     * (same statements as in the order-summary-materialized-view.sql)
-     * */
-    def refreshOrderSummary() {
-        List statements = [
-            // Drop mv temp table if somehow it still exists
-            "DROP TABLE IF EXISTS order_summary_mv_temp;",
-            // Create temp mv table from sql view (to shorten the time when MV is unavailable)
-            "CREATE TABLE order_summary_mv_temp AS SELECT DISTINCT * FROM order_summary;",
-            "DROP TABLE IF EXISTS order_summary_mv;",
-            // Copy data from temp mv table into mv table
-            "CREATE TABLE IF NOT EXISTS order_summary_mv LIKE order_summary_mv_temp;",
-            "TRUNCATE order_summary_mv;",
-            "INSERT INTO order_summary_mv SELECT * FROM order_summary_mv_temp;",
-            "ALTER TABLE order_summary_mv ADD UNIQUE INDEX (id);",
-            // Cleanup
-            "DROP TABLE IF EXISTS order_summary_mv_temp;",
-        ]
-        dataService.executeStatements(statements)
-    }
-
-    /**
-     * Refreshing the Order Summary materialized view for a specific list of Order Ids (PASS ONLY A PO IDs)
-     * */
-    def refreshOrderSummary(List<String> orderIds, Boolean isDelete) {
-        List statements = []
-        orderIds?.each { String orderId ->
-            if (isDelete) {
-                statements << "DELETE FROM order_summary_mv WHERE id = '${orderId}';"
-            } else {
-                statements << "REPLACE INTO order_summary_mv (SELECT * FROM order_summary WHERE id = '${orderId}');"
-            }
-        }
-
-        if (statements && checkIfOrderSummaryExists()) {
-            dataService.executeStatements(statements)
-        }
-    }
-
-    Boolean checkIfOrderSummaryExists() {
-        try {
-            // Check if table exists.
-            dataService.executeQuery("SELECT * FROM order_summary_mv LIMIT 1")
-            return true
-        } catch (Exception e) {
-            // UndeclaredThrowableException caused by MySQLSyntaxErrorException is thrown when
-            // the table 'order_summary_mv' doesn't exist. Then just simply refresh entire table
-            log.info "Refreshing order summary failed due to: ${e?.cause?.message}. Refreshing entire table now."
-
-            RefreshOrderSummaryJob.triggerNow()
-            return false
-        }
-    }
-
     Map getOrderSummary(String orderId) {
         Order order = Order.get(orderId)
         def orderItems = order?.orderItems

--- a/grails-app/services/org/pih/warehouse/order/OrderSummaryService.groovy
+++ b/grails-app/services/org/pih/warehouse/order/OrderSummaryService.groovy
@@ -1,0 +1,441 @@
+/**
+ * Copyright (c) 2012 Partners In Health.  All rights reserved.
+ * The use and distribution terms for this software are covered by the
+ * Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+ * which can be found in the file epl-v10.html at the root of this distribution.
+ * By using this software in any fashion, you are agreeing to be bound by
+ * the terms of this license.
+ * You must not remove this notice, or any other, from this software.
+ **/
+package org.pih.warehouse.order
+
+import org.pih.warehouse.data.DataService
+import org.pih.warehouse.jobs.RefreshOrderSummaryJob
+
+
+/**
+ * TODO: This OrderSummaryService is temporary (or to be expanded) solution for performance issues with
+ *  order summary helper views during fetching and reloading data. In next iteration we should migrate
+ *  from using views to use queries and/or create stored procedures (imho we should get rid of views and leave
+ *  only the materialized views)
+ * */
+class OrderSummaryService {
+
+    DataService dataService
+
+    String getOrderItemStatusSelect(String orderId) {
+        return """
+            SELECT
+                order_id,
+                order_number,
+                IFNULL(MAX(quantity_ordered), 0)    AS quantity_ordered,
+                IFNULL(SUM(quantity_shipped), 0)    AS quantity_shipped,
+                order_item_id
+            FROM (
+                SELECT
+                    `order`.id                  AS order_id,
+                    `order`.order_number        AS order_number,
+                    order_item.id               AS order_item_id,
+                    CASE
+                        WHEN order_item.order_item_status_code = 'CANCELED' THEN 0
+                        ELSE IFNULL(MAX(order_item.quantity), 0)
+                    END AS quantity_ordered,
+                    CASE
+                        WHEN shipment.current_status IN ('SHIPPED', 'PARTIALLY_RECEIVED', 'RECEIVED') THEN SUM(shipment_item.quantity / order_item.quantity_per_uom)
+                        ELSE 0
+                    END AS quantity_shipped
+                FROM `order`
+                    LEFT OUTER JOIN order_item ON order.id = order_item.order_id
+                    LEFT OUTER JOIN order_shipment ON order_item.id = order_shipment.order_item_id
+                    LEFT OUTER JOIN shipment_item ON shipment_item.id = order_shipment.shipment_item_id
+                    LEFT OUTER JOIN shipment ON shipment.id = shipment_item.shipment_id
+                WHERE `order`.order_type_id = 'PURCHASE_ORDER'
+                    AND `order`.id = '${orderId}'
+                GROUP BY `order`.id, order_item.id, shipment.id
+            ) AS order_item_status GROUP BY order_id, order_item_id
+        """
+    }
+
+    String getOrderItemReceiptStatusSelect(String orderId) {
+        return """
+            SELECT
+                order_id,
+                order_item_id,
+                order_number,
+                IFNULL(SUM(quantity_received), 0) AS quantity_received,
+                IFNULL(SUM(quantity_canceled), 0) AS quantity_canceled
+            FROM (
+                SELECT
+                    `order`.id               AS order_id,
+                    `order`.order_number     AS order_number,
+                    order_item.id            AS order_item_id,
+                    SUM(receipt_item.quantity_received / order_item.quantity_per_uom)   AS quantity_received,
+                    SUM(receipt_item.quantity_canceled / order_item.quantity_per_uom)   AS quantity_canceled
+                FROM `order`
+                    LEFT OUTER JOIN order_item ON `order`.id = order_item.order_id
+                    LEFT OUTER JOIN order_shipment ON order_item.id = order_shipment.order_item_id
+                    LEFT OUTER JOIN shipment_item ON shipment_item.id = order_shipment.shipment_item_id
+                    LEFT OUTER JOIN shipment ON shipment.id = shipment_item.shipment_id
+                    LEFT OUTER JOIN receipt_item ON receipt_item.shipment_item_id = shipment_item.id
+                WHERE `order`.order_type_id = 'PURCHASE_ORDER'
+                    AND `order`.id = '${orderId}'
+                    AND order_item.order_item_status_code != 'CANCELLED'
+                    AND shipment.current_status = 'RECEIVED' OR shipment.current_status = 'PARTIALLY_RECEIVED'
+                GROUP BY `order`.id, `order`.order_number, order_item.id, shipment.id
+            ) AS order_receipt_status GROUP BY order_item_id
+        """
+    }
+
+    String getOrderItemPaymentStatusSelect(String orderId) {
+        return """
+            SELECT
+                order_id,
+                order_number,
+                order_item_id,
+                IFNULL(SUM(quantity_ordered), 0)  AS quantity_ordered,
+                IFNULL(SUM(quantity_invoiced), 0) AS quantity_invoiced
+            FROM (
+                SELECT
+                    order_item.id                                               AS order_item_id,
+                    `order`.id                                                  AS order_id,
+                    `order`.order_number                                        AS order_number,
+                    order_item.quantity                                         AS quantity_ordered,
+                    SUM(invoice_item.quantity)                                  AS quantity_invoiced
+                FROM `order`
+                    LEFT OUTER JOIN order_item ON order.id = order_item.order_id
+                    LEFT OUTER JOIN order_shipment ON order_item.id = order_shipment.order_item_id
+                    LEFT OUTER JOIN shipment_item ON shipment_item.id = order_shipment.shipment_item_id
+                    LEFT OUTER JOIN shipment_invoice ON shipment_invoice.shipment_item_id = shipment_item.id
+                    LEFT OUTER JOIN invoice_item ON invoice_item.id = shipment_invoice.invoice_item_id
+                    LEFT OUTER JOIN invoice ON invoice.id = invoice_item.invoice_id
+                WHERE `order`.order_type_id = 'PURCHASE_ORDER'
+                    AND `order`.id = '${orderId}'
+                    AND order_item.order_item_status_code != 'CANCELLED'
+                    AND (invoice.invoice_type_id != '5' OR invoice.invoice_type_id IS NULL)
+                    AND invoice.date_posted IS NOT NULL
+                    AND (invoice_item.inverse IS NULL OR invoice_item.inverse = FALSE)
+                GROUP BY `order`.id, order_item.id, invoice_item.id, shipment_item.id
+            ) AS order_item_payment_status GROUP BY order_item_id
+        """
+    }
+
+    String getOrderItemSummarySelect(String orderId) {
+        return """
+            SELECT
+                order_item_id AS id,
+                order_id,
+                order_number,
+                product_id,
+                quantity,
+                order_item_status,
+                quantity_uom_id,
+                quantity_per_uom,
+                unit_price,
+                quantity_ordered     AS quantity_ordered,
+                quantity_shipped     AS quantity_shipped,
+                quantity_received    AS quantity_received,
+                quantity_canceled    AS quantity_canceled,
+                quantity_invoiced    AS quantity_invoiced,
+                IF(quantity_ordered > 0, 1, 0) AS is_item_fully_ordered,
+                IF(quantity_shipped > 0 AND quantity_shipped = quantity_ordered, 1, 0) AS is_item_fully_shipped,
+                IF(quantity_received + quantity_canceled > 0 AND quantity_received + quantity_canceled = quantity_ordered, 1, 0)  AS is_item_fully_received,
+                IF(quantity_invoiced > 0 AND quantity_invoiced = quantity_ordered, 1, 0) AS is_item_fully_invoiced,
+                COALESCE(payment_status, receipt_status, shipment_status, order_item_status, order_status) AS derived_status
+            FROM (
+                SELECT
+                    order_item.id                                       AS order_item_id,
+                    `order`.id                                          AS order_id,
+                    `order`.order_number                                AS order_number,
+                    `order`.status                                      AS order_status,
+                    order_item.product_id                               AS product_id,
+                    quantity,
+                    order_item.order_item_status_code                   AS order_item_status,
+                    quantity_uom_id,
+                    quantity_per_uom,
+                    unit_price,
+                    IFNULL(SUM(order_item_status.quantity_ordered), 0)             AS quantity_ordered,
+                    IFNULL(SUM(order_item_status.quantity_shipped), 0)             AS quantity_shipped,
+                    IFNULL(SUM(order_receipt_status.quantity_received), 0)         AS quantity_received,
+                    IFNULL(SUM(order_receipt_status.quantity_canceled), 0)         AS quantity_canceled,
+                    IFNULL(SUM(order_item_payment_status.quantity_invoiced), 0)    AS quantity_invoiced,
+                    CASE
+                        WHEN SUM(order_item_status.quantity_ordered) + SUM(order_item_status.quantity_shipped) = 0 THEN NULL
+                        WHEN SUM(order_item_status.quantity_ordered) = SUM(order_item_status.quantity_shipped) THEN 'SHIPPED'
+                        WHEN SUM(order_item_status.quantity_ordered) > 0 AND SUM(order_item_status.quantity_shipped) > 0 THEN 'PARTIALLY_SHIPPED'
+                        ELSE NULL
+                    END AS shipment_status,
+                    CASE
+                        WHEN SUM(order_receipt_status.quantity_received) = 0 THEN NULL
+                        WHEN (SUM(order_item_status.quantity_ordered) - SUM(order_receipt_status.quantity_canceled)) <= SUM(order_receipt_status.quantity_received) THEN 'RECEIVED'
+                        WHEN (SUM(order_item_status.quantity_ordered) - SUM(order_receipt_status.quantity_canceled)) > SUM(order_receipt_status.quantity_received) AND SUM(order_receipt_status.quantity_received) > 0 THEN 'PARTIALLY_RECEIVED'
+                        ELSE NULL
+                    END AS receipt_status,
+                    CASE
+                        WHEN SUM(order_item_status.quantity_ordered) + SUM(order_item_payment_status.quantity_invoiced) = 0 THEN NULL
+                        WHEN SUM(order_item_status.quantity_ordered) = SUM(order_item_payment_status.quantity_invoiced) THEN 'INVOICED'
+                        WHEN SUM(order_item_status.quantity_ordered) > SUM(order_item_payment_status.quantity_invoiced) AND SUM(order_item_payment_status.quantity_invoiced) > 0 THEN 'PARTIALLY_INVOICED'
+                        ELSE NULL
+                    END AS payment_status
+                FROM order_item
+                    JOIN `order` ON order_item.order_id = `order`.id
+                    LEFT OUTER JOIN (${getOrderItemStatusSelect(orderId)}) order_item_status ON order_item_status.order_item_id = order_item.id
+                    LEFT OUTER JOIN (${getOrderItemReceiptStatusSelect(orderId)}) order_receipt_status ON order_receipt_status.order_item_id = order_item.id
+                    LEFT OUTER JOIN (${getOrderItemPaymentStatusSelect(orderId)}) order_item_payment_status ON order_item_payment_status.order_item_id = order_item.id
+                WHERE `order`.order_type_id = 'PURCHASE_ORDER'
+                    AND `order`.id = '${orderId}'
+                GROUP BY order_item.id
+            ) AS order_item_summary
+        """
+    }
+
+    String getOrderAdjustmentPaymentStatusSelect(String orderId) {
+        return """
+            SELECT
+                order_id,
+                order_number,
+                adjustment_id,
+                invoice_item_id,
+                order_status,
+                quantity_invoiced,
+                invoice_item_amount as invoiced_amount
+            FROM (
+                SELECT
+                    `order`.id                                                 AS order_id,
+                    order_adjustment.id                                        AS adjustment_id,
+                    IF(invoice.date_posted IS NULL, 0, invoice_item.amount)    AS invoice_item_amount,
+                    `order`.order_number                                       AS order_number,
+                    order.status                                               AS order_status,
+                    invoice_item.id                                            AS invoice_item_id,
+                    CASE
+                        WHEN invoice.date_posted IS NOT NULL THEN IFNULL(invoice_item.quantity, 0)
+                        ELSE 0
+                    END                                                        AS quantity_invoiced
+                FROM `order`
+                    LEFT OUTER JOIN order_adjustment ON order_adjustment.order_id = `order`.id
+                    INNER JOIN order_adjustment_invoice ON order_adjustment_invoice.order_adjustment_id = order_adjustment.id
+                    LEFT OUTER JOIN invoice_item ON invoice_item.id = order_adjustment_invoice.invoice_item_id
+                    LEFT OUTER JOIN invoice ON invoice.id = invoice_item.invoice_id
+                WHERE `order`.order_type_id = 'PURCHASE_ORDER'
+                    AND `order`.id = '${orderId}'
+                    AND (invoice.invoice_type_id != '5' OR invoice.invoice_type_id IS NULL)
+                    AND (invoice_item.inverse IS NULL OR invoice_item.inverse = FALSE)
+                    AND order_adjustment.canceled != 1
+                GROUP BY `order`.id, `order`.order_number, invoice_item.id, order_adjustment.id
+            ) AS order_adjustment_payment_status
+        """
+    }
+
+    String getOrderSummarySelect(String orderId) {
+        return """
+            SELECT
+                id,
+                id AS order_id,
+                quantity_ordered,
+                adjustments_count,
+                quantity_shipped,
+                quantity_received,
+                quantity_canceled,
+                quantity_invoiced,
+                adjustments_invoiced,
+                items_ordered,
+                items_shipped,
+                items_received,
+                items_invoiced,
+                order_status,
+                shipment_status,
+                receipt_status,
+                payment_status,
+                CASE
+                    WHEN shipment_status = 'SHIPPED'
+                    AND receipt_status = 'RECEIVED'
+                    AND payment_status = 'INVOICED' THEN 'COMPLETED'
+                    ELSE COALESCE(payment_status, receipt_status, shipment_status, order_status)
+                END AS derived_status
+            FROM (
+                SELECT 
+                    id,
+                    order_status,
+                    SUM(items_and_adjustments_union.quantity_ordered)     AS quantity_ordered,
+                    SUM(items_and_adjustments_union.adjustments_count)    AS adjustments_count,
+                    SUM(items_and_adjustments_union.quantity_shipped)     AS quantity_shipped,
+                    SUM(items_and_adjustments_union.quantity_received)    AS  quantity_received,
+                    SUM(items_and_adjustments_union.quantity_canceled)    AS quantity_canceled,
+                    SUM(items_and_adjustments_union.quantity_invoiced)    AS quantity_invoiced,
+                    SUM(items_and_adjustments_union.items_ordered)        AS items_ordered,
+                    SUM(items_and_adjustments_union.items_shipped)        AS items_shipped,
+                    SUM(items_and_adjustments_union.items_received)       AS items_received,
+                    SUM(items_and_adjustments_union.items_invoiced)       AS items_invoiced,
+                    SUM(items_and_adjustments_union.adjustments_invoiced) AS adjustments_invoiced,
+                    CASE
+                        WHEN (SUM(items_and_adjustments_union.quantity_ordered) + SUM(items_and_adjustments_union.quantity_shipped)) = 0 THEN NULL
+                        WHEN SUM(items_and_adjustments_union.quantity_ordered) = SUM(items_and_adjustments_union.quantity_shipped) THEN 'SHIPPED'
+                        WHEN SUM(items_and_adjustments_union.quantity_ordered) > 0
+                        AND SUM(items_and_adjustments_union.quantity_shipped) > 0 THEN 'PARTIALLY_SHIPPED'
+                        ELSE NULL
+                    END AS shipment_status,
+                    CASE
+                        WHEN SUM(items_and_adjustments_union.quantity_received) = 0 THEN NULL
+                        WHEN (SUM(items_and_adjustments_union.quantity_ordered) - SUM(items_and_adjustments_union.quantity_canceled)) > SUM(items_and_adjustments_union.quantity_received)
+                        AND SUM(items_and_adjustments_union.quantity_received) > 0 THEN 'PARTIALLY_RECEIVED'
+                        WHEN (SUM(items_and_adjustments_union.quantity_ordered) - SUM(items_and_adjustments_union.quantity_canceled)) <= SUM(items_and_adjustments_union.quantity_received) THEN 'RECEIVED'
+                        ELSE NULL
+                    END AS receipt_status,
+                    CASE
+                        WHEN (SUM(items_and_adjustments_union.quantity_ordered) = 0
+                        AND SUM(items_and_adjustments_union.adjustments_count) = 0)
+                        OR (SUM(items_and_adjustments_union.quantity_invoiced) = 0
+                        AND SUM(items_and_adjustments_union.adjustments_invoiced) = 0) THEN NULL
+                        WHEN (SUM(items_and_adjustments_union.quantity_ordered) = SUM(items_and_adjustments_union.quantity_invoiced))
+                        AND (SUM(items_and_adjustments_union.adjustments_count) = SUM(items_and_adjustments_union.adjustments_invoiced)
+                        AND SUM(items_and_adjustments_union.total_adjustments) = SUM(items_and_adjustments_union.invoiced_adjustments_amount)) THEN 'INVOICED'
+                        ELSE 'PARTIALLY_INVOICED'
+                    END AS payment_status
+                FROM (
+                    SELECT `order`.id                                              AS id,
+                        `order`.status                                          AS order_status,
+                        IFNULL(SUM(order_item_summary.quantity_ordered), 0)     AS quantity_ordered,
+                        SUM(order_item_summary.is_item_fully_ordered)           AS items_ordered,
+                        0                                                       AS adjustments_count,
+                        IFNULL(SUM(order_item_summary.quantity_shipped), 0)     AS quantity_shipped,
+                        SUM(order_item_summary.is_item_fully_shipped)           AS items_shipped,
+                        IFNULL(SUM(order_item_summary.quantity_received), 0)    AS quantity_received,
+                        SUM(order_item_summary.is_item_fully_received)          AS items_received,
+                        IFNULL(SUM(order_item_summary.quantity_canceled), 0)    AS quantity_canceled,
+                        IFNULL(SUM(order_item_summary.quantity_invoiced), 0)    AS quantity_invoiced,
+                        SUM(order_item_summary.is_item_fully_invoiced)          AS items_invoiced,
+                        0                                                       AS adjustments_invoiced,
+                        0                                                       AS total_adjustments,
+                        0                                                       AS invoiced_adjustments_amount
+                    FROM `order`
+                        LEFT OUTER JOIN order_item ON order_item.order_id = `order`.id
+                        LEFT OUTER JOIN (${getOrderItemSummarySelect(orderId)}) order_item_summary ON order_item_summary.id = order_item.id
+                    WHERE `order`.order_type_id = 'PURCHASE_ORDER'
+                    GROUP BY `order`.id
+                    UNION SELECT
+                        `order`.id                                                                    AS id,
+                        `order`.status                                                                AS order_status,
+                        0                                                                             AS quantity_ordered,
+                        0                                                                             AS items_ordered,
+                        IFNULL(COUNT(DISTINCT order_adjustment.id), 0)                                AS adjustments_count,
+                        0                                                                             AS quantity_shipped,
+                        0                                                                             AS items_shipped,
+                        0                                                                             AS quantity_received,
+                        0                                                                             AS items_received,
+                        0                                                                             AS quantity_canceled,
+                        0                                                                             AS quantity_invoiced,
+                        0                                                                             AS items_invoiced,
+                        IFNULL(SUM(order_adjustment_payment_statuses.quantity_invoiced), 0)           AS adjustments_invoiced,
+                        SUM(DISTINCT total_adjustments.total_adjustments)                             AS total_adjustments,
+                        IFNULL(SUM(ABS(order_adjustment_payment_statuses.invoiced_amount)), 0)        AS invoiced_adjustments_amount
+                    FROM `order`
+                        LEFT OUTER JOIN order_adjustment ON order_adjustment.order_id = `order`.id
+                        LEFT OUTER JOIN (
+                            SELECT adjustment_id, SUM(invoiced_amount) as invoiced_amount, IF(SUM(quantity_invoiced) > 0, 1, 0) as quantity_invoiced
+                            FROM (${getOrderAdjustmentPaymentStatusSelect(orderId)}) AS order_adjustment_payment_status
+                            GROUP BY adjustment_id
+                            ) as order_adjustment_payment_statuses ON order_adjustment_payment_statuses.adjustment_id = order_adjustment.id
+                        LEFT OUTER JOIN (
+                            SELECT order_id,
+                                SUM(total_adjustment) AS total_adjustments
+                            FROM (
+                                SELECT
+                                    `order`.id AS order_id,
+                                    order_adjustment.id AS order_adjustment_id,
+                                    SUM(
+                                        DISTINCT ABS(
+                                            IFNULL(
+                                                order_adjustment.amount, IF(
+                                                order_adjustment.percentage IS NOT NULL,
+                                                IF(
+                                                    order_item_id IS NOT NULL,
+                                                    order_item.quantity * order_item.unit_price * (order_adjustment.percentage / 100),
+                                                    order_total.order_total * (order_adjustment.percentage / 100)), 0)
+                                            )
+                                        )
+                                    ) AS total_adjustment
+                                FROM `order`
+                                    LEFT OUTER JOIN order_adjustment ON order_adjustment.order_id = `order`.id
+                                    LEFT OUTER JOIN (${getOrderAdjustmentPaymentStatusSelect(orderId)}) order_adjustment_payment_status ON order_adjustment_payment_status.adjustment_id = order_adjustment.id
+                                    LEFT OUTER JOIN order_item ON order_adjustment.order_item_id = order_item.id
+                                    LEFT OUTER JOIN (
+                                        SELECT oi.order_id AS order_id,
+                                            SUM(oi.quantity * oi.unit_price) AS order_total
+                                        FROM order_item oi
+                                            LEFT OUTER JOIN `order` o ON o.id = oi.order_id
+                                        GROUP BY oi.order_id
+                                    ) AS order_total ON `order`.id = order_total.order_id
+                                WHERE order_adjustment.canceled IS NOT TRUE
+                                GROUP BY order_adjustment_id, order_id
+                            ) AS amount_per_order_by_adjustment
+                        GROUP BY amount_per_order_by_adjustment.order_id) AS total_adjustments ON total_adjustments.order_id = `order`.id
+                    WHERE `order`.order_type_id = 'PURCHASE_ORDER'
+                        AND `order`.id = '${orderId}'
+                        AND order_adjustment.canceled IS NOT TRUE
+                    GROUP BY `order`.id) AS items_and_adjustments_union
+                GROUP BY id, order_status) AS order_summary
+            WHERE id = '${orderId}'
+        """
+    }
+
+    /**
+     * Refreshing entire Order Summary materialized view, should be only triggered from time to time
+     * (same statements as in the order-summary-materialized-view.sql)
+     * */
+    def refreshOrderSummary() {
+        List statements = [
+            // Drop mv temp table if somehow it still exists
+            "DROP TABLE IF EXISTS order_summary_mv_temp;",
+            // Create temp mv table from sql view (to shorten the time when MV is unavailable)
+            "CREATE TABLE order_summary_mv_temp AS SELECT DISTINCT * FROM order_summary;",
+            "DROP TABLE IF EXISTS order_summary_mv;",
+            // Copy data from temp mv table into mv table
+            "CREATE TABLE IF NOT EXISTS order_summary_mv LIKE order_summary_mv_temp;",
+            "TRUNCATE order_summary_mv;",
+            "INSERT INTO order_summary_mv SELECT * FROM order_summary_mv_temp;",
+            "ALTER TABLE order_summary_mv ADD UNIQUE INDEX (id);",
+            // Cleanup
+            "DROP TABLE IF EXISTS order_summary_mv_temp;",
+        ]
+        dataService.executeStatements(statements)
+    }
+
+    /**
+     * Refreshing the Order Summary materialized view for a specific list of Order Ids (PASS ONLY A PO IDs)
+     * */
+    def refreshOrderSummary(List<String> orderIds, Boolean isDelete) {
+        List statements = []
+        orderIds?.each { String orderId ->
+            if (isDelete) {
+                statements << "DELETE FROM order_summary_mv WHERE id = '${orderId}';"
+            } else {
+                String orderSummarySelect = getOrderSummarySelect(orderId)
+                statements << "REPLACE INTO order_summary_mv (${orderSummarySelect});"
+            }
+        }
+
+        if (statements && checkIfOrderSummaryExists()) {
+            dataService.executeStatements(statements, false)
+        }
+    }
+
+    Boolean checkIfOrderSummaryExists() {
+        try {
+            // Check if table exists.
+            dataService.executeQuery("SELECT * FROM order_summary_mv LIMIT 1")
+            return true
+        } catch (Exception e) {
+            // UndeclaredThrowableException caused by MySQLSyntaxErrorException is thrown when
+            // the table 'order_summary_mv' doesn't exist. Then just simply refresh entire table
+            log.info "Refreshing order summary failed due to: ${e?.cause?.message}. Refreshing entire table now."
+
+            RefreshOrderSummaryJob.triggerNow()
+            return false
+        }
+    }
+
+    def getOrderItemsDerivedStatus(String orderId) {
+        String orderItemSummarySelect = getOrderItemSummarySelect(orderId)
+        List orderItemSummaryList = dataService.executeQuery(orderItemSummarySelect)
+        orderItemSummaryList.inject([:]) { map, Map item -> map << [(item?.id): item?.derived_status] }
+    }
+}

--- a/grails-app/services/org/pih/warehouse/order/RefreshOrderSummaryEventService.groovy
+++ b/grails-app/services/org/pih/warehouse/order/RefreshOrderSummaryEventService.groovy
@@ -9,23 +9,20 @@
  **/
 package org.pih.warehouse.order
 
-import grails.core.GrailsApplication
 import grails.gorm.transactions.Transactional
-import org.pih.warehouse.order.RefreshOrderSummaryEvent
 import org.springframework.context.ApplicationListener
 
 @Transactional
 class RefreshOrderSummaryEventService implements ApplicationListener<RefreshOrderSummaryEvent> {
 
-    GrailsApplication grailsApplication
-    def orderService
+    OrderSummaryService orderSummaryService
 
     void onApplicationEvent(RefreshOrderSummaryEvent event) {
         log.info "Application event ${event} has been published! " + event.properties
 
         if (event?.orderIds && !event.disableRefresh) {
             log.info "Refreshing order summary ${event.isDelete ? 'before delete action' : ''} for orders with ids : ${event.orderIds}"
-            orderService.refreshOrderSummary(event.orderIds, event.isDelete)
+            orderSummaryService.refreshOrderSummary(event.orderIds, event.isDelete)
         } else {
             log.info "Event not processed because ${!event?.orderIds ? 'lack of purchase order ids.' : 'it was disabled by event publisher.'}"
         }

--- a/grails-app/views/order/_summary.gsp
+++ b/grails-app/views/order/_summary.gsp
@@ -372,13 +372,23 @@
 
       function fetchOrderDerivedStatus() {
         const orderId = $('#orderId').val();
-        $.ajax({
-          url: "${request.contextPath}/json/getOrdersDerivedStatus",
-          data: "order.id=" + orderId,
-          success: function(data, textStatus, jqXHR){
-            $("." + orderId).text(data[orderId]);
-          }
-        });
+        if (orderId) {
+          $.ajax({
+            url: "${request.contextPath}/json/getOrdersDerivedStatus",
+            data: "order.id=" + orderId,
+            success: function(data, textStatus, jqXHR) {
+              $("." + orderId).text(data[orderId]);
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+              console.error(jqXHR, textStatus, errorThrown);
+              if (jqXHR.responseText) {
+                $.notify(jqXHR.responseText, "error");
+              } else {
+                $.notify("An error occurred", "error");
+              }
+            }
+          });
+        }
       }
     </script>
 </div>

--- a/grails-app/views/order/list.gsp
+++ b/grails-app/views/order/list.gsp
@@ -229,6 +229,14 @@
 						for (const [orderId, derivedStatus] of Object.entries(data)) {
 							$("." + orderId).text(derivedStatus);
 						}
+					},
+					error: function (jqXHR, textStatus, errorThrown) {
+						console.error(jqXHR, textStatus, errorThrown);
+						if (jqXHR.responseText) {
+							$.notify(jqXHR.responseText, "error");
+						} else {
+							$.notify("An error occurred", "error");
+						}
 					}
 				});
 			}

--- a/grails-app/views/order/show.gsp
+++ b/grails-app/views/order/show.gsp
@@ -331,6 +331,14 @@
                       orderItemId => $("." + orderItemId).text(data[orderItemId])
                     );
                   }
+                },
+                error: function (jqXHR, textStatus, errorThrown) {
+                  console.error(jqXHR, textStatus, errorThrown);
+                  if (jqXHR.responseText) {
+                    $.notify(jqXHR.responseText, "error");
+                  } else {
+                    $.notify("An error occurred", "error");
+                  }
                 }
               });
             }


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:**
https://pihemr.atlassian.net/browse/OBPIH-6839

**Description:**
I added OrderSummaryService which basically copies the queries from the order summary helper views (with only one difference, each of these now pulls data for a specific order ID). This OrderSummaryService is a temporary (or to be expanded) solution for performance issues with order summary helper views during fetching and reloading data. In the next iteration, we should migrate from using views to using queries and/or we should move these to stored procedures (imho we should get rid of the views and leave only the materialized views plus queries / stored procedures)

