### PR TITLE
allow tests to run independently from code coverage

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -33,11 +33,12 @@ jobs:
       # Run all tests against each of the databases defined in the above matrix. We could split the integration
       # tests into a separate job and run the matrix only on that job (because unit tests don't care about the
       # underlying database and so running them against multiple databases is pointless), but matrix jobs are run
-      # in parallel so it wouldn't save us any running time to do that. Plus it would overcomplicate the flow.
-      - name: Run All Tests
-        run: TEST_DATABASE=${{ matrix.testdatabase }} ./grailsw test-app --non-interactive --no-daemon
+      # in parallel, so it wouldn't save us any running time to do that. Plus it would overcomplicate the flow.
+      # The jacocoTestReport task dependsOn all tests, and so will run them before generating the report.
+      - name: Run All Tests (with coverage)
+        run: TEST_DATABASE=${{ matrix.testdatabase }} ./gradlew jacocoTestReport --no-daemon
 
-      # Tests are run for each database in the above matrix but we only want to generate a code coverage report once.
+      # Tests are run for each database in the above matrix, but we only want to publish a code coverage report once.
       # "strategy.job-index" gives us the index of the current job in the matrix. Any index is fine. We use the first.
       - name: Upload results to Codecov
         if: ${{ strategy.job-index == 0 }}

--- a/build.gradle
+++ b/build.gradle
@@ -903,10 +903,6 @@ tasks.withType(Test) {
         showStandardStreams = true
     }
 
-    // Generate a code coverage report whenever tests run. This is useful for simplifying uploading coverage reports
-    // during our CI flows. The actual report generation is quick (<20 seconds), so it's fine to do this every time.
-    finalizedBy jacocoTestReport
-
     jacoco {
         // When running tests, exclude the given folders from Jacoco coverage % generation.
         excludes = jacocoExcludes


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** N/A

**Description:** Removes the `finalizedBy jacocoTestReport` block in all test tasks that was generating jacoco reports.

This was convenient for GitHub Actions since it allowed them to just run `./grailsw test-app` to generate reports but it also prevented us from being able to do things like `grails test-app AuthApiSpec -integration` to refine what tests we want to run. jacocoTestReport has `dependsOn test, integrationTest` so it'd end up running ALL the tests and ignoring the filters.

This solution is actually better IMO in that it requires us to be more specific about when we want to run tests for the purpose of generating a report (`./gradlew jacocoTestReport`)

