### PR TITLE
Default to a blank dsn if sentry env vars are not set

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -616,14 +616,14 @@ grails:
             usebridge: true
 
 sentry:
-    # TODO: For some reason adding the "sentry-spring-boot-starter" dependency and defining the dsn here causes:
+    # TODO: For some reason adding the "sentry-spring-boot-starter" dependency causes:
     #       - java.lang.IllegalStateException: Error processing condition on io.sentry.spring.boot.SentryAutoConfiguration$HubConfiguration$SentryWebMvcConfiguration.transactionNameProvider
     #       - Caused by: java.lang.reflect.MalformedParameterizedTypeException: null
     #       https://github.com/getsentry/sentry-java/blob/6.34.0/sentry-spring-boot/src/main/java/io/sentry/spring/boot/SentryAutoConfiguration.java#L268-L272
     #       Find a way to bypass this auto-configuration or provide a default implementation of transactionNameProvider.
     #       Possibly related to: https://github.com/getsentry/sentry-java/issues/1863
     #       Until this is resolved, all sentry related properties must be defined in sentry.properties.
-    #dsn: ${SENTRY_DSN_BACKEND}
+    dsn: ${SENTRY_DSN_BACKEND:${SENTRY_DSN:""}}
 
     # A custom setting that defines the format of Sentry HTTP transaction names
     httpTransactionNameFormat: CONTROLLER_METHOD

--- a/grails-app/conf/logback-spring.xml
+++ b/grails-app/conf/logback-spring.xml
@@ -4,17 +4,25 @@
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
     <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
-    <!-- Allows Logback logs to appear in Sentry. See sentry.properties for configuration. -->
+    <springProperty scope="context" name="sentryDsn" source="sentry.dsn" />
+
+    <!--
+    Allows Logback logs to appear in Sentry. See sentry.properties and application.yml for configuration.
+    Once we switch to using the "sentry-spring-boot-starter" dependency, we can move all this Sentry configuration to
+    application.yml https://docs.sentry.io/platforms/java/guides/spring-boot/logging-frameworks/#logback
+    -->
     <appender name="sentry" class="io.sentry.logback.SentryAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <!-- Use the INFO log level or higher for Sentry so that we don't hit our usage limit. -->
             <level>info</level>
         </filter>
-        <encoder>
-            <pattern>
-                <!-- https://logback.qos.ch/manual/layouts.html -->
-                %date{ISO8601} %-5level [%thread] %logger{40}: %message%n%xException
-            </pattern>
-        </encoder>
+        <options>
+            <!--
+            DSN is required here because Sentry for logback is configured separately from Sentry for Servlet
+            (see SentryServletContextListener for that). https://docs.sentry.io/platforms/java/guides/logback/
+            -->
+            <dsn>${sentryDsn}</dsn>
+        </options>
     </appender>
 
     <!-- log levels for software we maintain -->

--- a/grails-app/controllers/org/pih/warehouse/SentryInterceptor.groovy
+++ b/grails-app/controllers/org/pih/warehouse/SentryInterceptor.groovy
@@ -18,7 +18,7 @@ import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.User
 
 /**
- * Intercepts Sentry traces/logs and enhances their context with user information.
+ * Intercepts HTTP requests, adding user information to the Sentry transaction that will be created for the request.
  *
  * If we ever switch to use the Spring Security plugin, this code will need to be moved to a Spring Component
  * that implements SentryUserProvider.
@@ -31,7 +31,7 @@ class SentryInterceptor {
 
     AuthService authService
 
-    public SentryInterceptor() {
+    SentryInterceptor() {
         matchAll().except(uri: '/static/**').except(uri: "/info").except(uri: "/health")
     }
 

--- a/src/main/groovy/org/pih/warehouse/monitoring/SentryServletContextListener.groovy
+++ b/src/main/groovy/org/pih/warehouse/monitoring/SentryServletContextListener.groovy
@@ -34,7 +34,7 @@ class SentryServletContextListener implements ServletContextListener {
 
                 // If "SENTRY_DSN" is defined, or a dsn is provided in sentry.properties, those will take precedence
                 // over "SENTRY_DSN_BACKEND". If none of these are defined, Sentry will be disabled.
-                options.dsn = System.getenv("SENTRY_DSN_BACKEND")
+                options.dsn = System.getenv("SENTRY_DSN_BACKEND") ?: ""
 
                 // We set the git commit of the release as the Sentry release tag to be able to group
                 // Sentry errors by release. Once we switch to use the "io.sentry:sentry-spring-boot-starter"


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** N/A

**Description:** Currently we see the following warning during startup when local testing:

`10:13:50,850 |-WARN in io.sentry.logback.SentryAppender[sentry] - Failed to init Sentry during appender initialization: DSN is required. Use empty string or set enabled to false in SentryOptions to disable SDK.`

This also causes logback to dump a whole bunch of other debug logs.

The fix sets a default value of empty string (which disables Sentry) for the dsn if the SENTRY_DSN_BACKEND or SENTRY_DSN environment variables are not set.