### PR TITLE
OBPIH-6825 Prioritize active persons when fetching by name or email

### DIFF
--- a/grails-app/services/org/pih/warehouse/data/PersonService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/PersonService.groovy
@@ -25,7 +25,7 @@ class PersonService {
      */
     private Person getPersonByEmail(String email) {
         List<Person> people = Person.findAllByEmail(email)
-        if (people?.empty) {
+        if (people.empty) {
             return null
         }
 
@@ -87,8 +87,7 @@ class PersonService {
         }
 
         InternetAddress internetAddress
-        try
-        {
+        try {
             internetAddress = new InternetAddress(recipient, false)
         }
         catch (AddressException ignored) {

--- a/grails-app/services/org/pih/warehouse/data/PersonService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/PersonService.groovy
@@ -11,33 +11,136 @@ package org.pih.warehouse.data
 
 import grails.gorm.transactions.Transactional
 import grails.validation.ValidationException
+import javax.mail.internet.AddressException
+import javax.mail.internet.InternetAddress
+import org.apache.commons.lang.StringUtils
+
 import org.pih.warehouse.core.Person
 
 @Transactional
 class PersonService {
 
-    Person getPersonByNames(String[] names) {
-        return Person.findByFirstNameAndLastName(names[0], names[1])
+    /**
+     * @return The first person we can find who has the given email, giving preference to active people.
+     */
+    private Person getPersonByEmail(String email) {
+        List<Person> people = Person.findAllByEmail(email)
+        if (people?.empty) {
+            return null
+        }
+
+        // We give preference to active people, so if there is one found, return it, otherwise return anyone.
+        return people.find{ it.active } ?: people.first()
     }
 
-    Person getPersonByNames(String combinedNames) {
-        String[] names = extractNames(combinedNames)
-        return getPersonByNames(names)
+    /**
+     * @return The first person we can find who is active and has the given email
+     */
+    Person getActivePersonByEmail(String email) {
+        return Person.findByActiveAndEmail(true, email)
     }
 
-    Person getOrCreatePersonFromNames(String combinedNames) {
+    /**
+     * Fetch a user via their full name. We require the combined name to be provided (instead of first name
+     * and last name individually) because while internally we split the name so that it conforms to the firstName and
+     * lastName fields in the Person table, we want to eventually move away from forcing that name structure upon users.
+     *
+     * @return Returns the first person we can find who has the given email, giving preference to active people.
+     */
+    private Person getPersonByName(String combinedNames) {
         String[] names = extractNames(combinedNames)
-        Person person = getPersonByNames(names)
-        if (!person) {
-            person = new Person(firstName: names[0], lastName: names[1])
-            if (!person.save(flush: true)) {
-                throw new ValidationException("Cannot save recipient ${combinedNames} due to errors", person.errors)
-            }
+        List<Person> people = Person.findAllByFirstNameAndLastName(names[0], names[1])
+        if (people?.empty) {
+            return null
+        }
+
+        // We give preference to active people, so if there is one found, return it, otherwise return anyone.
+        return people.find{ it.active } ?: people.first()
+    }
+
+    /**
+     * Fetch an active user via their full name. We require the combined name to be provided (instead of first name
+     * and last name individually) because while internally we split the name so that it conforms to the firstName and
+     * lastName fields in the Person table, we want to eventually move away from forcing that name structure upon users.
+     *
+     * @param combinedNames The person's full name (first name + last name) combined into a single String.
+     * @return A Person who is active and has a firstName and lastName matching the combinedNames
+     */
+    Person getActivePersonByName(String combinedNames) {
+        if (StringUtils.isBlank(combinedNames)) {
+            return null
+        }
+
+        String[] names = extractNames(combinedNames)
+        return Person.findByActiveAndFirstNameAndLastName(true, names[0], names[1])
+    }
+
+    /**
+     * @param recipient Either a RFC822O internet/email address (ex: "Justin Miranda <justin@openboxes.com>")
+     *        or simply the recipient's name (ex: "Justin Miranda"). We accept both formats since either
+     *        format can be provided during data imports.
+     * @return A Person who has the provided name and email. Will be a new Person if they didn't previously exist.
+     */
+    Person getOrCreatePersonByRecipient(String recipient) {
+        if (StringUtils.isBlank(recipient)) {
+            return null
+        }
+
+        InternetAddress internetAddress
+        try
+        {
+            internetAddress = new InternetAddress(recipient, false)
+        }
+        catch (AddressException ignored) {
+            // If recipient isn't a valid internet address, it must be a regular name.
+            return getOrCreatePersonFromNames(recipient)
+        }
+
+        // If a person exists with the given email, return them. Note that this can return inactive people so
+        // the caller must properly handle that case. We do this to avoid creating duplicate users.
+        Person person = getPersonByEmail(internetAddress.address)
+        if (person) {
+            return person
+        }
+
+        // Otherwise create a new person.
+        if (!internetAddress.personal) {
+            throw new RuntimeException("Cannot save new recipient without a name: ${recipient}")
+        }
+        String[] names = extractNames(internetAddress.personal)
+        person = new Person(firstName: names[0], lastName: names[1], email: internetAddress.address)
+        if (!person.save(flush: true)) {
+            throw new ValidationException("Cannot save recipient ${recipient} due to errors", person.errors)
         }
         return person
     }
 
-    String[] extractNames(String combinedNames) {
+    /**
+     * @param combinedNames The person's full name (first name + last name) combined into a single String.
+     * @return A Person who has the provided combinedName. Will be a new Person if they didn't previously exist.
+     */
+    private Person getOrCreatePersonFromNames(String combinedNames) {
+        // If a person exists with the given name, return them. Note that this can return inactive people so
+        // the caller must properly handle that case. We do this to avoid creating duplicate users.
+        Person person = getPersonByName(combinedNames)
+        if (person) {
+            return person
+        }
+
+        String[] names = extractNames(combinedNames)
+        person = new Person(firstName: names[0], lastName: names[1])
+        if (!person.save(flush: true)) {
+            throw new ValidationException("Cannot save recipient ${combinedNames} due to errors", person.errors)
+        }
+        return person
+    }
+
+    private String[] extractNames(String combinedNames) {
+        // TODO: We should be smarter about how we process names here. If someone has the name "John Thomas Blanchard",
+        //       how do we split it into first name and last name? If someone doesn't have a last name, what do we do?
+        //       This highlights the fact that we're trying to make a judgement call about a name (a single first name
+        //       and last name pair) that doesn't apply universally across cultures. Better would be to have a single
+        //       "name" field that stores the name plainly. Then this whole method can go away.
         String[] names = combinedNames.split(" ", 2)
         if (names.length <= 1) {
             throw new RuntimeException("Recipient ${combinedNames} must have at least two names (i.e. first name and last name)")

--- a/grails-app/services/org/pih/warehouse/order/OrderService.groovy
+++ b/grails-app/services/org/pih/warehouse/order/OrderService.groovy
@@ -801,8 +801,8 @@ class OrderService {
                     orderItem.unitPrice = parsedUnitPrice
 
                     if (recipient) {
-                        Person person = personService.getPersonByNames(recipient)
-                        if (!person?.active) {
+                        Person person = personService.getActivePersonByName(recipient)
+                        if (!person) {
                             throw new IllegalArgumentException("Cannot set a recipient who is non-existant or inactive: ${recipient}")
                         }
                         orderItem.recipient = person

--- a/grails-app/services/org/pih/warehouse/shipping/CombinedShipmentService.groovy
+++ b/grails-app/services/org/pih/warehouse/shipping/CombinedShipmentService.groovy
@@ -16,6 +16,7 @@ import grails.util.Holders
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.Person
 import org.pih.warehouse.core.UnitOfMeasure
+import org.pih.warehouse.data.PersonService
 import org.pih.warehouse.importer.ImportDataCommand
 import org.pih.warehouse.inventory.InventoryItem
 import org.pih.warehouse.order.Order
@@ -33,6 +34,7 @@ class CombinedShipmentService {
     def inventoryService
     def messageService
     def localizationService
+    PersonService personService
 
     /**
      * Parse the given text into a list of maps.
@@ -224,12 +226,10 @@ class CombinedShipmentService {
 
                 Person recipient = line.recipient ? Person.get(line.recipient) : null
                 if (!recipient && line.recipient) {
-                    String[] names = line.recipient.split(" ")
-                    if (names.length == 2) {
-                        String firstName = names[0], lastName = names[1]
-                        recipient = Person.findByFirstNameAndLastName(firstName, lastName)
-                    } else if (names.length == 1) {
-                        recipient = Person.findByEmail(names[0])
+                    if (line.recipient.contains(" ")) {
+                        recipient = personService.getActivePersonByName(line.recipient)
+                    } else {
+                        recipient = personService.getActivePersonByEmail(line.recipient)
                     }
                     if (!recipient) {
                         throw new IllegalArgumentException("Unable to locate person")

--- a/grails-app/services/org/pih/warehouse/shipping/CombinedShipmentService.groovy
+++ b/grails-app/services/org/pih/warehouse/shipping/CombinedShipmentService.groovy
@@ -226,11 +226,9 @@ class CombinedShipmentService {
 
                 Person recipient = line.recipient ? Person.get(line.recipient) : null
                 if (!recipient && line.recipient) {
-                    if (line.recipient.contains(" ")) {
-                        recipient = personService.getActivePersonByName(line.recipient)
-                    } else {
-                        recipient = personService.getActivePersonByEmail(line.recipient)
-                    }
+                    recipient = line.recipient.contains(" ") ?
+                            personService.getActivePersonByName(line.recipient) :
+                            personService.getActivePersonByEmail(line.recipient)
                     if (!recipient) {
                         throw new IllegalArgumentException("Unable to locate person")
                     }

--- a/grails-app/services/org/pih/warehouse/shipping/ShipmentService.groovy
+++ b/grails-app/services/org/pih/warehouse/shipping/ShipmentService.groovy
@@ -12,7 +12,6 @@ package org.pih.warehouse.shipping
 import grails.gorm.transactions.Transactional
 import grails.util.Holders
 import grails.validation.ValidationException
-import org.apache.commons.validator.EmailValidator
 import org.apache.poi.hssf.usermodel.HSSFSheet
 import org.apache.poi.hssf.usermodel.HSSFWorkbook
 import org.apache.poi.ss.usermodel.Cell
@@ -50,7 +49,6 @@ import org.pih.warehouse.receiving.ReceiptStatusCode
 import org.springframework.validation.BeanPropertyBindingResult
 import org.springframework.validation.Errors
 
-import javax.mail.internet.InternetAddress
 import java.math.RoundingMode
 
 @Transactional
@@ -2045,45 +2043,6 @@ class ShipmentService {
         return true
     }
 
-    /**
-     * Finds (or creates) a person record given the provided address (e.g. Justin Miranda <justin@openboxes.com>)
-     *
-     * @param address address string in RFC822 format
-     * @return
-     */
-    Person findOrCreatePerson(String recipient) {
-        log.info "Find or create person: ${recipient}"
-
-        Person person
-        if (recipient) {
-            // Recipient string includes email and name,
-            if (EmailValidator.getInstance().isValid(recipient)) {
-                InternetAddress emailAddress = new InternetAddress(recipient, false)
-                person = Person.findByEmail(emailAddress.address)
-
-                // Person record not found, creating a new person as long as the name is provided
-                if (!person) {
-                    // If there's no personal attribute we cannot determine the first and last name of the recipient.
-                    // This will return null and should throw an error
-                    if (!emailAddress.personal) {
-                        throw new RuntimeException("Cannot find a recipient with email address ${recipient}")
-                    }
-                    String[] names = emailAddress.personal.split(" ", 2)
-                    person = new Person(firstName: names[0], lastName: names[1], email: emailAddress.address)
-                    if (!person.save(flush: true)) {
-                        throw new ValidationException("Cannot save recipient ${recipient} due to errors", person.errors)
-                    }
-                }
-            }
-            // Recipient string only includes name
-            else {
-                person = personService.getOrCreatePersonFromNames(recipient)
-            }
-        }
-        return person
-
-    }
-
     boolean importPackingList(String shipmentId, InputStream inputStream) {
         int lineNumber = 0
 
@@ -2108,10 +2067,12 @@ class ShipmentService {
                 // The container assigned to the shipment item should be the one that contains the item (e.g. box contains item, pallet contains boxes)
                 Container container = box ?: pallet ?: null
 
-                Person recipient
-                if (item.recipient) {
-                    recipient = findOrCreatePerson(item.recipient)
+                // Set the recipient of the item. Don't allow for an inactive recipients to be used.
+                Person recipient = personService.getOrCreatePersonByRecipient(item.recipient)
+                if (recipient && !recipient.active) {
+                    throw new IllegalArgumentException("Cannot set an inactive person as recipient: ${item.recipient}")
                 }
+
                 // Check to see if a shipment item already exists within the given container
                 ShipmentItem shipmentItem = shipment.shipmentItems.find {
                     it.inventoryItem == inventoryItem &&

--- a/src/test/groovy/unit/org/pih/warehouse/person/PersonServiceSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/person/PersonServiceSpec.groovy
@@ -1,0 +1,104 @@
+package unit.org.pih.warehouse.person
+
+import grails.testing.gorm.DataTest
+import grails.testing.services.ServiceUnitTest
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import org.pih.warehouse.core.Person
+import org.pih.warehouse.data.PersonService
+
+@Unroll
+class PersonServiceSpec extends Specification implements ServiceUnitTest<PersonService>, DataTest {
+    void setupSpec() {
+        mockDomain Person
+    }
+
+    void 'getActivePersonByEmail expect person #expectedPerson to be returned when given email #email'() {
+        given:
+        new Person(id: '1', email: '1@1.com', active: false).save(validate: false)
+        new Person(id: '2', email: '1@1.com', active: true).save(validate: false)
+
+        expect:
+        service.getActivePersonByEmail(email)?.id == expectedPerson
+
+        where:
+        email     || expectedPerson
+        null      || null
+        '1@1.com' || '2'
+        '2@2.com' || null
+    }
+
+    void 'getActivePersonByName expect person #expectedPerson to be returned when given name #name'() {
+        given:
+        new Person(id: '1', firstName: 'a', lastName: 'b', active: false).save(validate: false)
+        new Person(id: '2', firstName: 'a', lastName: 'b', active: true).save(validate: false)
+
+        expect:
+        service.getActivePersonByName(name)?.id == expectedPerson
+
+        where:
+        name    || expectedPerson
+        null    || null
+        ''      || null
+        'a b'   || '2'
+        'a b c' || null
+    }
+
+    void 'getActivePersonByName fails when given only a single word'() {
+        when:
+        service.getActivePersonByName('oneword')
+
+        then:
+        thrown(RuntimeException)
+    }
+
+    void 'getOrCreatePersonByRecipient expect person #expectedPerson to be returned when given recipient #recipient'() {
+        given:
+        new Person(id: '1', firstName: 'a', lastName: 'b', email: '1@1.com', active: false).save(validate: false)
+        new Person(id: '2', firstName: 'a', lastName: 'b', email: '1@1.com', active: true).save(validate: false)
+        new Person(id: '3', firstName: 'c', lastName: 'd', email: '2@2.com', active: false).save(validate: false)
+
+        expect:
+        service.getOrCreatePersonByRecipient(recipient)?.id == expectedPerson
+
+        where:
+        recipient       || expectedPerson
+        null            || null
+        ''              || null
+        'a b'           || '2'
+        '<1@1.com>'     || '2'
+        'e f <2@2.com>' || '3'  // email takes priority, even if name doesn't match and user is inactive.
+    }
+
+    void 'getOrCreatePersonByRecipient creates a new person when given non-existing recipient #recipient'() {
+        when:
+        Person person = service.getOrCreatePersonByRecipient(recipient)
+
+        then:
+        person?.firstName == expectedFirstName
+        person?.lastName == expectedLastName
+        person?.email == expectedEmail
+
+        where:
+        recipient       || expectedFirstName | expectedLastName | expectedEmail
+        'a b'           || 'a'               | 'b'              | null
+        'a b <1@1.com>' || 'a'               | 'b'              | '1@1.com'
+    }
+
+    void 'getOrCreatePersonByRecipient fails when given only a single word'() {
+        when:
+        service.getOrCreatePersonByRecipient('oneword')
+
+        then:
+        thrown(RuntimeException)
+    }
+
+    void 'getOrCreatePersonByRecipient fails a name is not provided'() {
+        when:
+        service.getOrCreatePersonByRecipient('<no@name.com>')
+
+        then:
+        thrown(RuntimeException)
+    }
+}


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6825

**Description:** Because we don't enforce any uniqueness on name or email in our system for entries in the Person table, when fetching people by name and email, there's a chance we'll find more than one. When this happens, we simply pick the first one we get. This can cause inconsistent behaviour when we have two identical users, one active and one inactive.

This was uncovered in PO import but is relevant to all flows that fetch a single Person.

This change is to prioritize returning active Person entries in the case where we have duplicates. 

![image-20241204-151550](https://github.com/user-attachments/assets/e862dd04-ad5e-4350-a5e0-2dec70d32a24)
