### PR TITLE
OBPIH-6936 filter out empty ABC classes from cycle count filter dropdown

### DIFF
--- a/grails-app/services/org/pih/warehouse/product/ProductClassificationService.groovy
+++ b/grails-app/services/org/pih/warehouse/product/ProductClassificationService.groovy
@@ -44,6 +44,7 @@ class ProductClassificationService {
                 groupProperty("abcClass")
             }
             isNotNull("abcClass")
+            ne("abcClass", "")  // Once classifications have their own entity, this should be removed.
         } as List<String>
 
         productClassifications += InventoryLevel.createCriteria().listDistinct() {
@@ -53,6 +54,7 @@ class ProductClassificationService {
             // Only fetch abcClasses that are configured for the requesting facility.
             eq("inventory", facility.inventory)
             isNotNull("abcClass")
+            ne("abcClass", "")  // Once classifications have their own entity, this should be removed.
         } as List<String>
 
         // Sort the results by ABC class name. Once ABC class becomes its own domain, this can be moved to the query.

--- a/src/integration-test/groovy/org/pih/warehouse/api/spec/product/ProductClassificationApiListFiltersOutEmptySpec.groovy
+++ b/src/integration-test/groovy/org/pih/warehouse/api/spec/product/ProductClassificationApiListFiltersOutEmptySpec.groovy
@@ -1,0 +1,51 @@
+package org.pih.warehouse.api.spec.product
+
+import grails.gorm.transactions.Transactional
+import org.springframework.beans.factory.annotation.Autowired
+import spock.lang.Shared
+
+import org.pih.warehouse.api.client.product.ProductClassificationApiWrapper
+import org.pih.warehouse.api.spec.base.ApiSpec
+import org.pih.warehouse.inventory.InventoryLevel
+import org.pih.warehouse.product.Product
+import org.pih.warehouse.product.ProductClassificationDto
+
+class ProductClassificationApiListFiltersOutEmptySpec extends ApiSpec {
+
+    @Autowired
+    ProductClassificationApiWrapper productClassificationApiWrapper
+
+    @Shared
+    Product product
+
+    @Shared
+    InventoryLevel inventoryLevel
+
+    @Transactional
+    void setupData() {
+        product = Product.build(abcClass: "")
+        inventoryLevel= InventoryLevel.build(abcClass: "", inventory: location.inventory)
+    }
+
+    @Transactional
+    void cleanupData() {
+        if (product) {
+            product.delete()
+        }
+        if (inventoryLevel) {
+            inventoryLevel.delete()
+        }
+    }
+
+    void 'given a valid facility, list excludes the empty string'() {
+        when:
+        List<ProductClassificationDto> classifications = productClassificationApiWrapper.listOK(location.id)
+
+        then:
+        assert !asNames(classifications).contains("")
+    }
+
+    private List<String> asNames(List<ProductClassificationDto> classifications) {
+        return classifications.collect { it.name }
+    }
+}


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6936

**Description:** Filter out null and empty string ABC classifications when fetching them for the cycle count filter dropdown so that we don't get a confusing empty option.


---
### :camera: Screenshots & Recordings (optional)

![image](https://github.com/user-attachments/assets/ba394643-8818-4431-92a2-fc605e7d7971)

