### PR TITLE
OBPIH-6936 remove duplicates from product classification list endpoint

### DIFF
--- a/src/integration-test/groovy/org/pih/warehouse/api/spec/product/ProductClassificationApiCRUDSpec.groovy
+++ b/src/integration-test/groovy/org/pih/warehouse/api/spec/product/ProductClassificationApiCRUDSpec.groovy
@@ -44,7 +44,10 @@ class ProductClassificationApiCRUDSpec extends ApiSpec {
 
         then:
         assert classifications.size() >= 3  // Don't use '==' because other tests might have left data in the db
-        assert asNames(classifications).containsAll([CLASS_A, CLASS_B, CLASS_C])
+
+        List<String> names = asNames(classifications)
+        assert names.containsAll([CLASS_A, CLASS_B, CLASS_C])
+        assert names.size() == new HashSet<>(names).size()  // Ensure there are no duplicates
     }
 
     void 'given an invalid facility, list correctly errors'() {


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6936

**Description:** Remove duplicates from the product classification list endpoint by fetching the ABC classes as a Set


---
### :camera: Screenshots & Recordings (optional)

![image](https://github.com/user-attachments/assets/c5366494-1b1e-4c0a-8e90-67c39171be7a)

