### PR TITLE
OBPIH-6959 use ABC Class from inventory level in cycle count products list

### DIFF
--- a/grails-app/migrations/views/cycle-count-session.sql
+++ b/grails-app/migrations/views/cycle-count-session.sql
@@ -6,7 +6,7 @@ CREATE OR REPLACE VIEW cycle_count_session AS (
 		product.id as product_id,
 		location.id as facility_id,
         cycle_count_request.id as cycle_count_request_id,
-		product.abc_class as abc_class,
+        COALESCE(inventory_level.abc_class, product.abc_class) as abc_class,
 
 		# Inventory Item Count
 		count(*) as inventory_item_count,
@@ -27,6 +27,7 @@ CREATE OR REPLACE VIEW cycle_count_session AS (
 	JOIN location on product_availability.location_id = location.id
 	JOIN product on product_availability.product_id = product.id
 	JOIN inventory on location.inventory_id = inventory.id
+    LEFT OUTER JOIN inventory_level on product.id = inventory_level.product_id AND inventory.id = inventory_level.inventory_id
     LEFT OUTER JOIN cycle_count_request ON product.id = cycle_count_request.product_id AND location.id = cycle_count_request.facility_id
     WHERE product_availability.quantity_on_hand > 0
        AND (cycle_count_request.id IS NULL OR (cycle_count_request.status <> 'COMPLETED' AND cycle_count_request.status <> 'CANCELED'))

--- a/grails-app/services/org/pih/warehouse/inventory/CycleCountService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/CycleCountService.groovy
@@ -62,8 +62,7 @@ class CycleCountService {
                 "in"("tags.id", command.tags.collect { it.id })
             }
             if (command.abcClasses) {
-                createProductAlias(delegate, usedAliases)
-                "in"("product.abcClass", command.abcClasses)
+                "in"("abcClass", command.abcClasses)
             }
             if (command.sort) {
                 getCandidatesSortOrder(command.sort, command.order, delegate, usedAliases)


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6959

**Description:** When generating abcClass in cycle_count_session, first check if there's an inventory level defined for the product, and use abcClass from there. Otherwise fallback to the abcClass as defined in the product