### PR TITLE
DO NOT MERGE! example implementation of binding java.time types

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -200,8 +200,19 @@ grails:
         javascript:
             library: jquery
     databinding:
+        # The formats that Grails will attempt to use when binding input Strings to java.util.Date fields.
+        # We now use the java.time classes instead (ex: Instant, LocalDate). Those fields define their own
+        # ValueConverter classes and so don't use the formats defined here.
         dateFormats:
+            # Old date formats, don't use going forward! Kept first in the list to maintain backwards compatability.
+            - 'MM/dd/yyyy HH:mm:ss XXX'
+            - 'MM/dd/yyyy HH:mm XXX'
             - 'MM/dd/yyyy'
+            # ISO-8601 formats. These are better than the old formats, but new APIs should always use Instant instead
+            # of Date. Note that a format without time and timezone is NOT allowed here because that would be ambiguous
+            # and would lead to Date conversion weirdness. If you need a date only, use LocalDate.
+            - "yyyy-MM-dd'T'HH:mm:ssXXX"
+            - "yyyy-MM-dd'T'HH:mmXXX"
         convertEmptyStringsToNull: false
 endpoints:
     jmx:

--- a/grails-app/controllers/org/pih/warehouse/TestingDatesApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/TestingDatesApiController.groovy
@@ -1,0 +1,11 @@
+package org.pih.warehouse
+
+import grails.converters.JSON
+
+class TestingDatesApiController {
+
+    def save(TestingDates dates) {
+        TestingDates savedDates = dates.save(failOnError: true)
+        render([data: savedDates] as JSON)
+    }
+}

--- a/grails-app/controllers/org/pih/warehouse/UrlMappings.groovy
+++ b/grails-app/controllers/org/pih/warehouse/UrlMappings.groovy
@@ -947,6 +947,11 @@ class UrlMappings {
             action = [POST: "createRequests"]
         }
 
+        "/api/testing-dates" {
+            controller = "testingDatesApi"
+            action = [POST: "save"]
+        }
+
         // Error handling
 
         "401"(controller: "errors", action: "handleUnauthorized")

--- a/grails-app/controllers/org/pih/warehouse/api/StockMovementApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/StockMovementApiController.groovy
@@ -11,6 +11,8 @@ package org.pih.warehouse.api
 
 import grails.converters.JSON
 import org.grails.web.json.JSONObject
+
+import org.pih.warehouse.DateUtil
 import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.DocumentService
@@ -359,19 +361,12 @@ class StockMovementApiController {
         render([data: pendingRequisitionDetails] as JSON)
     }
 
-    /**
-     * Bind the date field value to the date object.
-     *
-     * @param dateObject
-     * @param jsonObject
-     * @param dateField
-     */
     private Date parseDateRequested(String date) {
-        return date ? Constants.EXPIRATION_DATE_FORMATTER.parse(date) : null
+        return DateUtil.asDate(date, Constants.EXPIRATION_DATE_FORMATTER)
     }
 
     private Date parseDateShipped(String date) {
-        return date ? Constants.DELIVERY_DATE_FORMATTER.parse(date) : null
+        return DateUtil.asDate(date, Constants.DELIVERY_DATE_FORMATTER)
     }
 
     private void bindStockMovement(StockMovement stockMovement, JSONObject jsonObject) {

--- a/grails-app/domain/org/pih/warehouse/TestingDates.groovy
+++ b/grails-app/domain/org/pih/warehouse/TestingDates.groovy
@@ -1,0 +1,32 @@
+package org.pih.warehouse
+
+import java.time.Instant
+import java.time.LocalDate
+
+class TestingDates implements Serializable {
+
+    String id
+    Instant myInstant
+    LocalDate myLocalDate
+    Date myDate
+
+    static mapping = {
+        id generator: 'uuid'
+    }
+
+    static constraints = {
+        myInstant(nullable: true)
+        myLocalDate(nullable: true)
+        myDate(nullable: true)
+    }
+
+    Map toJson() {
+        return [
+                id: id,
+                myInstant: myInstant.toString(),
+                myLocalDate: myLocalDate.toString(),
+                myDate: myDate,
+                myDateToString: myDate.toString(),
+        ]
+    }
+}

--- a/grails-app/init/org/pih/warehouse/BootStrap.groovy
+++ b/grails-app/init/org/pih/warehouse/BootStrap.groovy
@@ -12,6 +12,7 @@ package org.pih.warehouse
 import grails.converters.JSON
 import grails.util.Holders
 import java.math.RoundingMode
+import java.time.ZoneOffset
 import javax.sql.DataSource
 import liquibase.Contexts
 import liquibase.LabelExpression
@@ -94,6 +95,12 @@ class BootStrap {
     DataSource dataSource
 
     def init = { servletContext ->
+
+        // WE SHOULD BE DOING THIS! I commented it out though because it has big implications for everywhere else that
+        // we parse in dates. We should definitely review this though. Without it, the default timezone that we parse
+        // dates to will change depending on where the app is hosted.
+        // TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC))
+
         log.info("Registering JSON marshallers ...")
         registerJsonMarshallers()
 
@@ -619,6 +626,10 @@ class BootStrap {
 
         JSON.registerObjectMarshaller(CycleCountRequest) { CycleCountRequest cycleCountRequest ->
             return cycleCountRequest.toJson()
+        }
+
+        JSON.registerObjectMarshaller(TestingDates) { TestingDates testingDates ->
+            return testingDates.toJson()
         }
     }
 

--- a/grails-app/migrations/0.9.x/changelog-2025-01-01-0000-TEMP_MIGRATION.xml
+++ b/grails-app/migrations/0.9.x/changelog-2025-01-01-0000-TEMP_MIGRATION.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+
+    <changeSet author="ewaterman" id="010120250000-0">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="testing_dates"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="testing_dates">
+            <column name="id" type="CHAR(38)">
+                <constraints nullable="false" primaryKey="true" />
+            </column>
+            <column name="version" type="BIGINT">
+                <constraints nullable="true" />
+            </column>
+            <column name="my_instant" type="DATETIME">
+                <constraints nullable="true" />
+            </column>
+            <column name="my_local_date" type="DATETIME">
+                <constraints nullable="true" />
+            </column>
+            <column name="my_date" type="DATETIME">
+                <constraints nullable="true" />
+            </column>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/grails-app/migrations/0.9.x/changelog.xml
+++ b/grails-app/migrations/0.9.x/changelog.xml
@@ -20,4 +20,5 @@
     <include file="0.9.x/changelog-2024-10-28-1330-add-column-date-delivery-requested-to-requisition.xml" />
     <include file="0.9.x/changelog-2024-12-02-0000-alter-table-location-type-set-location-type-code-non-null.xml" />
     <include file="0.9.x/changelog-2024-12-18-1300-create-table-cycle-count-request.xml" />
+    <include file="0.9.x/changelog-2025-01-01-0000-TEMP_MIGRATION.xml" />
 </databaseChangeLog>

--- a/grails-app/utils/org/pih/warehouse/DateUtil.groovy
+++ b/grails-app/utils/org/pih/warehouse/DateUtil.groovy
@@ -10,11 +10,155 @@
 package org.pih.warehouse
 
 import grails.validation.ValidationException
-
 import java.text.SimpleDateFormat
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.ChronoField
+import org.apache.commons.lang.StringUtils
 
-
+/**
+ * Utility methods on date and datetime objects.
+ *
+ * In our system, we try to work with a small subset of the datetime-related classes:
+ *
+ * - java.time.Instant: An absolute moment in time (measured in seconds since UTC epoch). We should work with Instant
+ *                      whenever possible since it is specific enough to be convertible to other formats, while
+ *                      still being timezone agnostic (and so avoids any locale conversion and weirdness).
+ *
+ * - java.time.LocalDate: A date (day + month + year) with no time or timezone component. Useful for setting fixed
+ *                        dates, where switching to a different timezone should never change the date (ex: expiry date).
+ *
+ * - java.time.ZonedDateTime: A datetime (via LocalDateTime) in a timezone (via ZoneOffset).
+ *                            Useful for working with a human readable datetime in a specific locale, where switching
+ *                            to a different timezone should change the resulting value. Only to be used if we have
+ *                            user-locale-specific logic (ex: We need to check if some datetime would be the next
+ *                            day for the requesting user).
+ *
+ * We also have java.util.Date, which is deprecated and should not be used going forward.
+ */
 class DateUtil {
+
+    /*
+     * Patterns that follow the ISO-8601 + RPC 3339 date formats while allowing for some slight variation in
+     * the pattern.
+     *
+     * Ex: "2000-01-01", "2000/01/01", "20000101" are all valid strings according to FLEXIBLE_DATE_PATTERN.
+     * Ex: both "2000-01-01" and "2000-01-01T00:00:00Z" are valid strings according to FLEXIBLE_DATE_TIME_ZONE_PATTERN.
+     *
+     * We do this mainly to support a wider range of user INPUT, making our parsing logic more flexible.
+     * Internally, we should strive to use a consistent structure and to always OUTPUT the same format (see below
+     * "Fixed Date Formats").
+     *
+     * Note that more specific optionals must be defined in front of less specific ones (ex: [HH:mm:ss][HH:mm],
+     * not [HH:mm][HH:mm:ss]).
+     *
+     * Also note that depending on what date type you're parsing into, this can trigger an error. For example, Instant
+     * requires time and timezone information, and so FLEXIBLE_DATE_TIME_ZONE_PATTERN will fail to parse "2000-01-01"
+     * unless the associated DateTimeFormatter provides a default (via a "withZone(ZoneId)" call).
+     */
+    private static final String FLEXIBLE_DATE_PATTERN = "[yyyy-MM-dd][yyyy/MM/dd][yyyy MM dd][yyyyMMdd]"
+    private static final String FLEXIBLE_TIME_PATTERN =
+            "[HH:mm:ss.SSS][HH:mm:ss:SSS][HHmmssSSS]" +
+            "[HH:mm:ss.SS][HH:mm:ss:SS][HHmmssSS]" +
+            "[HH:mm:ss.S][HH:mm:ss:S][HHmmssS]" +
+            "[HH:mm:ss][HHmmss]" +
+            "[HH:mm][HHmm]"
+    private static final String FLEXIBLE_DATE_TIME_ZONE_PATTERN =
+            "${FLEXIBLE_DATE_PATTERN}[['T'][ ]${FLEXIBLE_TIME_PATTERN}][[XXX][XX][X]]"
+
+    /*
+     * Flexible Date Formats
+     *
+     * "Flexible" in that they allow for multiple formats, and provide appropriate defaults if fields are not provided.
+     *
+     * We should use these flexible formats only when binding user-input Strings to certain data types.
+     * To convert date types back to Strings, just call toString() on them. The reasoning is that we want to accept as
+     * wide a range of user inputs as possible, but internally we want to work with and return a single, known format.
+     */
+    static final DateTimeFormatter FLEXIBLE_DATE_TIME_ZONE_FORMAT = new DateTimeFormatterBuilder()
+            .appendPattern(FLEXIBLE_DATE_TIME_ZONE_PATTERN)
+            // Defaults to 00:00:00.000 if time is not provided in the String
+            .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+            .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+            .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+            .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0)
+            // Defaults to UTC if timezone is not provided in the String
+            .parseDefaulting(ChronoField.OFFSET_SECONDS, ZoneOffset.UTC.getTotalSeconds())
+            .toFormatter()
+    static final DateTimeFormatter FLEXIBLE_DATE_FORMAT = DateTimeFormatter.ofPattern(FLEXIBLE_DATE_PATTERN)
+    static final DateTimeFormatter FLEXIBLE_TIME_FORMAT = DateTimeFormatter.ofPattern(FLEXIBLE_TIME_PATTERN)
+
+    /**
+     * To be used when parsing a String to a java.util.Date.
+     *
+     * @Deprecated SimpleDateFormat is functionally deprecated as of Java 8 and is replaced by DateTimeFormatter.
+     *             Don't use SimpleDateFormat anywhere else from now on.
+     */
+    private static final SimpleDateFormat FLEXIBLE_SIMPLE_FORMAT = new SimpleDateFormat(FLEXIBLE_DATE_TIME_ZONE_PATTERN)
+
+    /**
+     * Null-safe conversion of a (deprecated) java.util.Date to an Instant.
+     * Useful when working with old code that uses the old format.
+     */
+    static Instant asInstant(Date date) {
+        return date ? date.toInstant() : null
+    }
+
+    /**
+     * Null-safe conversion of a ZonedDateTime to an Instant.
+     */
+    static Instant asInstant(ZonedDateTime zonedDateTime) {
+        return zonedDateTime ? zonedDateTime.toInstant() : null
+    }
+
+    /**
+     * Null-safe conversion of an Instant to a ZonedDateTime. If no timezone is provided, we assume UTC.
+     *
+     * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example.
+     */
+    static ZonedDateTime asZonedDateTime(Instant instant, ZoneId zone=ZoneOffset.UTC) {
+        return instant ? instant.atZone(zone) : null
+    }
+
+    /**
+     * Null-safe conversion of a (deprecated) java.util.Date to an ZonedDateTime. If no timezone is provided,
+     * we assume UTC. Useful when working with old code that uses the old format.
+     *
+     * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example.
+     */
+    static ZonedDateTime asZonedDateTime(Date date, ZoneId zone=ZoneOffset.UTC) {
+        return date ? asInstant(date).atZone(zone) : null
+    }
+
+    /**
+     * Binds a String to a (deprecated) java.util.Date.
+     *
+     * @Deprecated Only exists to support old endpoints that manually bind their data. New APIs should not use this
+     *             approach, and should use Command Objects in controller method args to auto-bind the request body.
+     */
+    static Date asDate(String date, SimpleDateFormat format=FLEXIBLE_SIMPLE_FORMAT) {
+        return StringUtils.isBlank(date) ? null : format.parse(date.trim())
+    }
+
+    /**
+     * Null-safe conversion of an Instant to a (deprecated) java.util.Date.
+     * Useful when working with old code that uses the old format.
+     */
+    static Date asDate(Instant instant) {
+        return instant ? Date.from(instant) : null
+    }
+
+    /**
+     * Null-safe conversion of a ZonedDateTime to a (deprecated) java.util.Date.
+     * Useful when working with old code that uses the old format.
+     */
+    static Date asDate(ZonedDateTime zonedDateTime) {
+        return zonedDateTime ? asDate(zonedDateTime.toInstant()) : null
+    }
 
     static Date clearTime(Date date) {
         Calendar calendar = Calendar.getInstance()

--- a/grails-app/utils/org/pih/warehouse/TestingDatesDto.groovy
+++ b/grails-app/utils/org/pih/warehouse/TestingDatesDto.groovy
@@ -1,0 +1,25 @@
+package org.pih.warehouse
+
+import grails.validation.Validateable
+import java.time.Instant
+import java.time.LocalDate
+
+class TestingDatesDto implements Validateable {
+    Instant myInstant
+    LocalDate myLocalDate
+    Date myDate
+
+    static constraints = {
+        myInstant(nullable: true)
+        myLocalDate(nullable: true)
+        myDate(nullable: true)
+    }
+
+    Map toJson() {
+        return [
+                myInstant: myInstant.toString(),
+                myLocalDate: myLocalDate.toString(),
+                myDate: myDate,
+        ]
+    }
+}

--- a/grails-app/utils/org/pih/warehouse/databinding/InstantValueConverter.groovy
+++ b/grails-app/utils/org/pih/warehouse/databinding/InstantValueConverter.groovy
@@ -1,0 +1,37 @@
+package org.pih.warehouse.databinding
+
+import java.time.Instant
+import org.apache.commons.lang.StringUtils
+import org.springframework.stereotype.Component
+
+import org.pih.warehouse.DateUtil
+
+/**
+ * As of Java 8, Java.util.Date is functionally replaced with the java.time classes, but Grails 4 and older does not
+ * support databinding a datetime String to an Instant (only timestamps) so we need to add support ourselves.
+ * https://github.com/grails/grails-core/issues/11811
+ */
+@Component
+class InstantValueConverter extends StringValueConverter<Instant> {
+
+    /**
+     * Binds a given user-input String to an Instant.
+     *
+     * An Instant is an absolute moment in time, so to construct it we need a full datetime with timezone included.
+     * As such, if the given string doesn't provide a time, we default to "00:00.000" (aka the start of the day),
+     * and if it doesn't provide a timezone, we default to "Z" (aka UTC).
+     *
+     * We could have tried to determine the client's timezone by looking in the session and defaulting to that timezone
+     * instead, but that would be making assumptions about what format the client is providing, which may not be
+     * correct. The universally accepted "default" timezone is UTC, so for the sake of simplicity, we use that as a
+     * fallback if the client doesn't provide timezone information themselves (though they really should).
+     *
+     * @param value "2000-01-01", "2000-01-01T00:00", "2000-01-01T00:00Z", "2000-01-01T00:00+05:00" for example
+     */
+    @Override
+    Instant convertString(String value) {
+        return StringUtils.isBlank(value) ?
+                null :
+                Instant.from(DateUtil.FLEXIBLE_DATE_TIME_ZONE_FORMAT.parse(value.trim()))
+    }
+}

--- a/grails-app/utils/org/pih/warehouse/databinding/LocalDateValueConverter.groovy
+++ b/grails-app/utils/org/pih/warehouse/databinding/LocalDateValueConverter.groovy
@@ -1,0 +1,31 @@
+package org.pih.warehouse.databinding
+
+import java.time.LocalDate
+import org.apache.commons.lang.StringUtils
+import org.springframework.stereotype.Component
+
+import org.pih.warehouse.DateUtil
+
+/**
+ * As of Java 8, Java.util.Date is functionally replaced with the java.time classes, but Grails 4 and older does not
+ * support databinding a datetime String to a LocalDate so we need to add support ourselves.
+ * https://github.com/grails/grails-core/issues/11811
+ */
+@Component
+class LocalDateValueConverter extends StringValueConverter<LocalDate> {
+
+    /**
+     * Parse a given String into a LocalDate of the given format.
+     *
+     * Because LocalDate is time and timezone agnostic, the String only expects day, month, and year elements. To avoid
+     * any timezone related confusion, Any additional data provided (such as time and timezone) will trigger an error.
+     *
+     * @param value "2000/01/01" for example
+     */
+    @Override
+    LocalDate convertString(String value) {
+        return StringUtils.isBlank(value) ?
+                null :
+                LocalDate.parse(value.trim(), DateUtil.FLEXIBLE_DATE_FORMAT)
+    }
+}

--- a/grails-app/utils/org/pih/warehouse/databinding/StringValueConverter.groovy
+++ b/grails-app/utils/org/pih/warehouse/databinding/StringValueConverter.groovy
@@ -1,0 +1,34 @@
+package org.pih.warehouse.databinding
+
+import grails.databinding.converters.ValueConverter
+import org.springframework.core.GenericTypeResolver
+
+/**
+ * A convenience base class that our ValueConverters can extend from. Useful since a vast majority of the time, our
+ * user inputs (request body, uri + query params) are Strings.
+ *
+ * @param <T> The type that we're converting to.
+ */
+abstract class StringValueConverter<T> implements ValueConverter {
+
+    /**
+     * Defines how to convert a user-input String to the necessary data type.
+     */
+    abstract T convertString(String value)
+
+    @Override
+    boolean canConvert(Object value) {
+        return value instanceof String
+    }
+
+    @Override
+    Class<?> getTargetType() {
+        // The Spring *magic* way of extracting the type from a class.
+        return (Class<T>) GenericTypeResolver.resolveTypeArgument(getClass(), StringValueConverter.class)
+    }
+
+    @Override
+    Object convert(Object value) {
+        return convertString((String) value)
+    }
+}

--- a/src/integration-test/groovy/org/pih/warehouse/api/client/TestingDatesApi.groovy
+++ b/src/integration-test/groovy/org/pih/warehouse/api/client/TestingDatesApi.groovy
@@ -1,0 +1,24 @@
+package org.pih.warehouse.api.client
+
+import groovy.transform.InheritConstructors
+import io.restassured.builder.RequestSpecBuilder
+import io.restassured.http.Method
+import io.restassured.response.Response
+import io.restassured.specification.RequestSpecification
+import io.restassured.specification.ResponseSpecification
+import org.springframework.boot.test.context.TestComponent
+
+import org.pih.warehouse.api.client.base.AuthenticatedApi
+
+@TestComponent
+@InheritConstructors
+class TestingDatesApi extends AuthenticatedApi {
+
+    Response testDates(String body, ResponseSpecification responseSpec) {
+        RequestSpecification requestSpec = new RequestSpecBuilder()
+                .setBody(body)
+                .build()
+
+        return request(requestSpec, responseSpec, Method.POST, "/testing-dates")
+    }
+}

--- a/src/integration-test/groovy/org/pih/warehouse/api/client/TestingDatesApiWrapper.groovy
+++ b/src/integration-test/groovy/org/pih/warehouse/api/client/TestingDatesApiWrapper.groovy
@@ -1,0 +1,18 @@
+package org.pih.warehouse.api.client
+
+import groovy.transform.InheritConstructors
+import io.restassured.path.json.JsonPath
+import org.grails.web.json.JSONObject
+import org.springframework.boot.test.context.TestComponent
+
+import org.pih.warehouse.api.client.base.ApiWrapper
+
+@TestComponent
+@InheritConstructors
+class TestingDatesApiWrapper extends ApiWrapper<TestingDatesApi> {
+
+    JsonPath testDatesOK(JSONObject body) {
+        return api.testDates(body.toString(), responseSpecUtil.OK_RESPONSE_SPEC)
+                .jsonPath()
+    }
+}

--- a/src/integration-test/groovy/org/pih/warehouse/api/spec/TestingDatesApiSpec.groovy
+++ b/src/integration-test/groovy/org/pih/warehouse/api/spec/TestingDatesApiSpec.groovy
@@ -1,0 +1,113 @@
+package org.pih.warehouse.api.spec
+
+import grails.gorm.transactions.Transactional
+import io.restassured.path.json.JsonPath
+import org.grails.web.json.JSONObject
+import org.springframework.beans.factory.annotation.Autowired
+import spock.lang.Unroll
+
+import org.pih.warehouse.TestingDates
+import org.pih.warehouse.api.client.TestingDatesApiWrapper
+import org.pih.warehouse.api.spec.base.ApiSpec
+
+@Unroll
+class TestingDatesApiSpec extends ApiSpec {
+
+    @Autowired
+    TestingDatesApiWrapper api
+
+    @Transactional
+    void setupData() {
+        // Truncate the table before running each test
+        TestingDates.executeUpdate('delete from TestingDates')
+    }
+
+    void 'test Instant: #scenario'() {
+        given:
+        JSONObject request = new JSONObject().put('myInstant', givenDate)
+
+        when:
+        JsonPath response = api.testDatesOK(request)
+
+        then:
+        assert response.get("data.myInstant") == expectedConvertedDate
+
+        where:
+        givenDate                   || expectedConvertedDate  | scenario
+        "2000-01-01T00:00:00.000Z"  || "2000-01-01T00:00:00Z" | "Full string in proper ISO format"
+        "2000-01-01T00:00:00.000"   || "2000-01-01T00:00:00Z" | "Full string, no timezone"
+        "2000-01-01T00:00:00.00"    || "2000-01-01T00:00:00Z" | "Shorter millis"
+        "2000-01-01T00:00:00.0"     || "2000-01-01T00:00:00Z" | "Shorter millis"
+        "2000-01-01T00:00:00"       || "2000-01-01T00:00:00Z" | "No millis"
+        "2000-01-01T00:00"          || "2000-01-01T00:00:00Z" | "No seconds"
+        "2000-01-01"                || "2000-01-01T00:00:00Z" | "No time"
+        "2000 01 01"                || "2000-01-01T00:00:00Z" | "Date with spaces"
+        "2000/01/01"                || "2000-01-01T00:00:00Z" | "Date with slashes"
+        "20000101"                  || "2000-01-01T00:00:00Z" | "Date with no separator"
+        "2000-01-01 00:00:00.000Z"  || "2000-01-01T00:00:00Z" | "Replace 'T' with space"
+        "2000-01-01T000000000Z"     || "2000-01-01T00:00:00Z" | "Time with no separator"
+        "2000-01-01T00000000Z"      || "2000-01-01T00:00:00Z" | "Time with no separator, shorter millis"
+        "2000-01-01T0000000Z"       || "2000-01-01T00:00:00Z" | "Time with no separator, shorter millis"
+        "2000-01-01T000000Z"        || "2000-01-01T00:00:00Z" | "Time with no separator, no millis"
+        "2000-01-01T0000Z"          || "2000-01-01T00:00:00Z" | "Time with no separator, no seconds"
+        "2000-01-01T00:00:00:000Z"  || "2000-01-01T00:00:00Z" | "Time with millis replace '.' with ':'"
+        "2000-01-01T00:00:00:00Z"   || "2000-01-01T00:00:00Z" | "Time with millis replace '.' with ':', shorter millis"
+        "2000-01-01T00:00:00:0Z"    || "2000-01-01T00:00:00Z" | "Time with millis replace '.' with ':', shorter millis"
+        // It can handle various timezone inputs. Yay!
+        "2000-01-01T00:00:00-05"    || "2000-01-01T05:00:00Z" | "Timezone conforming to X format"
+        "2000-01-01T00:00:00-0500"  || "2000-01-01T05:00:00Z" | "Timezone conforming to XX format"
+        "2000-01-01T00:00:00-05:00" || "2000-01-01T05:00:00Z" | "Timezone conforming to XXX format"
+    }
+
+    void 'test LocalDate: #givenDate'() {
+        given:
+        JSONObject request = new JSONObject().put('myLocalDate', givenDate)
+
+        when:
+        JsonPath response = api.testDatesOK(request)
+
+        then:
+        assert response.get("data.myLocalDate") == expectedResult
+
+        where:
+        givenDate    || expectedResult | scenario
+        "2000-01-01" || "2000-01-01"   | "Date with dashes"
+        "2000 01 01" || "2000-01-01"   | "Date with spaces"
+        "2000/01/01" || "2000-01-01"   | "Date with slashes"
+        "20000101"   || "2000-01-01"   | "Date with no separator"
+    }
+
+    void 'test Date: #scenario'() {
+        given:
+        JSONObject request = new JSONObject().put('myDate', givenDate)
+
+        when:
+        JsonPath response = api.testDatesOK(request)
+
+        then:
+        assert response.get("data.myDate") == expectedResult
+        assert response.get("data.myDateToString") == expectedToStringResult
+
+        // See how the resulting format changes depending on whether you call Date.toString() or not in the domain's
+        // toJson() method. This inconsistency is confusing and error-prone! Not a huge issue though because we'd
+        // notice immediately if we accidentally did Date.toString() because it'd break the frontend.
+        where:
+        givenDate                    || expectedResult         | expectedToStringResult         | scenario
+        // See how we input no tz information, but the server decides to treat it as local time (which for me currently
+        // is CST). If someone runs this test against a server in a different tz, it'll fail. Bad!
+        // To fix this, we need to add "TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC))" to BootStrap.groovy
+        "01/01/2000"                 || "2000-01-01T06:00:00Z" | "Sat Jan 01 00:00:00 CST 2000" | "Date only"
+
+        // It handles Z (aka UTC) fine if it's provided (though toString() still displays local time).
+        "01/01/2000 00:00:00 Z"      || "2000-01-01T00:00:00Z" | "Fri Dec 31 18:00:00 CST 1999" | "Datetime UTC"
+        "2000-01-01T00:00:00Z"       || "2000-01-01T00:00:00Z" | "Fri Dec 31 18:00:00 CST 1999" | "Datetime ISO UTC"
+        "01/01/2000 00:00 Z"         || "2000-01-01T00:00:00Z" | "Fri Dec 31 18:00:00 CST 1999" | "Datetime no seconds UTC"
+        "2000-01-01T00:00Z"          || "2000-01-01T00:00:00Z" | "Fri Dec 31 18:00:00 CST 1999" | "Datetime no seconds ISO UTC"
+
+        // It handles other timezone info fine if it's provided (though toString() still displays local time).
+        "01/01/2000 00:00:00 -01:00" || "2000-01-01T01:00:00Z" | "Fri Dec 31 19:00:00 CST 1999" | "Datetime -01:00"
+        "2000-01-01T00:00:00-01:00"  || "2000-01-01T01:00:00Z" | "Fri Dec 31 19:00:00 CST 1999" | "Datetime ISO -01:00"
+        "01/01/2000 00:00 -01:00"    || "2000-01-01T01:00:00Z" | "Fri Dec 31 19:00:00 CST 1999" | "Datetime no seconds -01:00"
+        "2000-01-01T00:00-01:00"     || "2000-01-01T01:00:00Z" | "Fri Dec 31 19:00:00 CST 1999" | "Datetime no seconds ISO -01:00"
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/Constants.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/Constants.groovy
@@ -25,6 +25,10 @@ class Constants {
     static final adminControllers = ['createProduct', 'admin']
     static final adminActions = ['product': ['create'], 'person': ['list'], 'user': ['list'], 'location': ['edit'], 'shipper': ['create'], 'locationGroup': ['create'], 'locationType': ['create'], '*': ['delete']]
 
+    // TODO: Don't add more dates here! We should refactor all usages of these constants to instead use the
+    //       DateTimeFormatter constants in DateUtil. The backend should always return dates in the same format so that
+    //       the frontend can easily parse response objects. Let the frontend decide what the display format of each
+    //       individual field should be.
     static final String DEFAULT_YEAR_FORMAT = "yyyy"
     static final String DEFAULT_DATE_FORMAT = "dd/MMM/yyyy"
     static final String DEFAULT_DATE_TIME_FORMAT = "dd/MMM/yyyy HH:mm:ss"

--- a/src/main/groovy/util/StringUtil.groovy
+++ b/src/main/groovy/util/StringUtil.groovy
@@ -11,11 +11,11 @@ package util
 
 import groovy.text.SimpleTemplateEngine
 
-import java.text.DateFormat
 import java.text.MessageFormat
-import java.text.SimpleDateFormat
 
-
+/**
+ * Utility methods for parsing/formatting strings and general string manipulation.
+ */
 class StringUtil {
 
     static String mask(String value) {
@@ -34,22 +34,6 @@ class StringUtil {
 
     static String format(text, args) {
         return MessageFormat.format(text, args)
-    }
-
-    static Date parseDate(String format, String source) {
-        if (source) {
-            DateFormat dateFormat = new SimpleDateFormat(format)
-            return dateFormat.parse(source)
-        }
-        return null
-    }
-
-    static String formatString(String format, Date date) {
-        if (date) {
-            DateFormat dateFormat = new SimpleDateFormat(format)
-            return dateFormat.format(date)
-        }
-        return null
     }
 
     static String format(String text) {

--- a/src/test/groovy/unit/org/pih/warehouse/utils/databinding/InstantValueConverterSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/utils/databinding/InstantValueConverterSpec.groovy
@@ -1,0 +1,54 @@
+package unit.org.pih.warehouse.utils.databinding
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import org.pih.warehouse.databinding.InstantValueConverter
+
+@Unroll
+class InstantValueConverterSpec extends Specification {
+
+    @Shared
+    InstantValueConverter converter
+
+    void setupSpec() {
+        converter = new InstantValueConverter()
+    }
+
+    void 'convertString should successfully parse in valid strings for case: #scenario'() {
+        expect:
+        assert converter.convertString(givenDate).toString() == expectedConvertedDate
+
+        where:
+        givenDate                   || expectedConvertedDate  | scenario
+        "2000-01-01T00:00:00.000Z"  || "2000-01-01T00:00:00Z" | "Full string in proper ISO format"
+        "2000-01-01T00:00:00.000"   || "2000-01-01T00:00:00Z" | "Full string, no timezone"
+        "2000-01-01T00:00:00.00"    || "2000-01-01T00:00:00Z" | "Shorter millis"
+        "2000-01-01T00:00:00.0"     || "2000-01-01T00:00:00Z" | "Shorter millis"
+        "2000-01-01T00:00:00"       || "2000-01-01T00:00:00Z" | "No millis"
+        "2000-01-01T00:00"          || "2000-01-01T00:00:00Z" | "No seconds"
+        "2000-01-01"                || "2000-01-01T00:00:00Z" | "No time"
+        "2000 01 01"                || "2000-01-01T00:00:00Z" | "Date with spaces"
+        "2000/01/01"                || "2000-01-01T00:00:00Z" | "Date with slashes"
+        "20000101"                  || "2000-01-01T00:00:00Z" | "Date with no separator"
+        "2000-01-01 00:00:00.000Z"  || "2000-01-01T00:00:00Z" | "Replace 'T' with space"
+        "2000-01-01T000000000Z"     || "2000-01-01T00:00:00Z" | "Time with no separator"
+        "2000-01-01T00000000Z"      || "2000-01-01T00:00:00Z" | "Time with no separator, shorter millis"
+        "2000-01-01T0000000Z"       || "2000-01-01T00:00:00Z" | "Time with no separator, shorter millis"
+        "2000-01-01T000000Z"        || "2000-01-01T00:00:00Z" | "Time with no separator, no millis"
+        "2000-01-01T0000Z"          || "2000-01-01T00:00:00Z" | "Time with no separator, no seconds"
+        "2000-01-01T00:00:00:000Z"  || "2000-01-01T00:00:00Z" | "Time with millis replace '.' with ':'"
+        "2000-01-01T00:00:00:00Z"   || "2000-01-01T00:00:00Z" | "Time with millis replace '.' with ':', shorter millis"
+        "2000-01-01T00:00:00:0Z"    || "2000-01-01T00:00:00Z" | "Time with millis replace '.' with ':', shorter millis"
+        "2000-01-01T00:00:00-05"    || "2000-01-01T05:00:00Z" | "Timezone conforming to X format w/ negative"
+        "2000-01-01T00:00:00-0500"  || "2000-01-01T05:00:00Z" | "Timezone conforming to XX format w/ negative"
+        "2000-01-01T00:00:00-05:00" || "2000-01-01T05:00:00Z" | "Timezone conforming to XXX format w/ negative"
+        "2000-01-01T00:00:00+00"    || "2000-01-01T00:00:00Z" | "Timezone conforming to X format w/ zero"
+        "2000-01-01T00:00:00+0000"  || "2000-01-01T00:00:00Z" | "Timezone conforming to XX format w/ zero"
+        "2000-01-01T00:00:00+00:00" || "2000-01-01T00:00:00Z" | "Timezone conforming to XXX format w/ zero"
+        "2000-01-01T00:00:00+05"    || "1999-12-31T19:00:00Z" | "Timezone conforming to X format w/ positive"
+        "2000-01-01T00:00:00+0500"  || "1999-12-31T19:00:00Z" | "Timezone conforming to XX format w/ positive"
+        "2000-01-01T00:00:00+05:00" || "1999-12-31T19:00:00Z" | "Timezone conforming to XXX format w/ positive"
+    }
+}

--- a/src/test/groovy/unit/org/pih/warehouse/utils/databinding/LocalDateValueConverterSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/utils/databinding/LocalDateValueConverterSpec.groovy
@@ -1,0 +1,46 @@
+package unit.org.pih.warehouse.utils.databinding
+
+import java.time.format.DateTimeParseException
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import org.pih.warehouse.databinding.LocalDateValueConverter
+
+@Unroll
+class LocalDateValueConverterSpec extends Specification {
+
+    @Shared
+    LocalDateValueConverter converter
+
+    void setupSpec() {
+        converter = new LocalDateValueConverter()
+    }
+
+    void 'convertString should successfully parse in valid strings: #scenario'() {
+        expect:
+        assert converter.convertString(givenDate).toString() == expectedResult
+
+        where:
+        givenDate    || expectedResult | scenario
+        "2000-01-01" || "2000-01-01"   | "Date with dashes"
+        "2000 01 01" || "2000-01-01"   | "Date with spaces"
+        "2000/01/01" || "2000-01-01"   | "Date with slashes"
+        "20000101"   || "2000-01-01"   | "Date with no separator"
+    }
+
+    void 'convertString should fail to parse invalid strings because: #failureReason'() {
+        when:
+        converter.convertString(givenDate)
+
+        then:
+        thrown(DateTimeParseException)
+
+        where:
+        givenDate          || failureReason
+        "2000-01-01T00:00" || "LocalDate should have no time component"
+        "2000-01-32"       || "day out of range"
+        "2000-13-01"       || "month out of range"
+        "10000-13-01"      || "year out of range"
+    }
+}


### PR DESCRIPTION
DO NOT MERGE!

This PR is an example implementation of how we could use the new java.time classes in our domain objects.

PR that adds data binding support of Instant and LocalDate: https://github.com/openboxes/openboxes/pull/5023

The main piece of information here is TestingDatesApiSpec, which I've commented on explaining the drawbacks of java.util.Date, mainly around the timezone that it defaults to. I also demonstrate how Instant and LocalDate fix the issue.

Feel free to leave comments here as well.

Once my other PR gets merged, I'll close this one. I only created it so we'd have something to reference when reviewing the other PR.