### PR TITLE
OBPIH-6965 add data binding support for java.time classes

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -206,13 +206,24 @@ grails:
         dateFormats:
             # Old date formats, don't use going forward! Kept first in the list to maintain backwards compatability.
             - 'MM/dd/yyyy HH:mm:ss XXX'
+            - 'MM/dd/yyyy HH:mm:ss XX'
+            - 'MM/dd/yyyy HH:mm:ss X'
             - 'MM/dd/yyyy HH:mm XXX'
+            - 'MM/dd/yyyy HH:mm XX'
+            - 'MM/dd/yyyy HH:mm X'
+            # Note that if this format is given, Grails will treat it as midnight in the local server timezone, which
+            # is ahead of UTC, can cause the date to actually be the next day. It can also cause inconsistencies across
+            # hosts/environments if they're configured for different local timezones. Avoid this format going forward!
             - 'MM/dd/yyyy'
-            # ISO-8601 formats. These are better than the old formats, but new APIs should always use Instant instead
-            # of Date. Note that a format without time and timezone is NOT allowed here because that would be ambiguous
-            # and would lead to Date conversion weirdness. If you need a date only, use LocalDate.
+            # ISO-8601 formats. These are better than the old formats, but new APIs should still use Instant instead
+            # of Date whenever possible. Note that a format without time and timezone is NOT allowed here because that
+            # would be ambiguous and would lead to Date conversion weirdness. If you need a date only, use LocalDate.
             - "yyyy-MM-dd'T'HH:mm:ssXXX"
+            - "yyyy-MM-dd'T'HH:mm:ssXX"
+            - "yyyy-MM-dd'T'HH:mm:ssX"
             - "yyyy-MM-dd'T'HH:mmXXX"
+            - "yyyy-MM-dd'T'HH:mmXX"
+            - "yyyy-MM-dd'T'HH:mmX"
         convertEmptyStringsToNull: false
 endpoints:
     jmx:

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -200,8 +200,19 @@ grails:
         javascript:
             library: jquery
     databinding:
+        # The formats that Grails will attempt to use when binding input Strings to java.util.Date fields.
+        # We now use the java.time classes instead (ex: Instant, LocalDate). Those fields define their own
+        # ValueConverter classes and so don't use the formats defined here.
         dateFormats:
+            # Old date formats, don't use going forward! Kept first in the list to maintain backwards compatability.
+            - 'MM/dd/yyyy HH:mm:ss XXX'
+            - 'MM/dd/yyyy HH:mm XXX'
             - 'MM/dd/yyyy'
+            # ISO-8601 formats. These are better than the old formats, but new APIs should always use Instant instead
+            # of Date. Note that a format without time and timezone is NOT allowed here because that would be ambiguous
+            # and would lead to Date conversion weirdness. If you need a date only, use LocalDate.
+            - "yyyy-MM-dd'T'HH:mm:ssXXX"
+            - "yyyy-MM-dd'T'HH:mmXXX"
         convertEmptyStringsToNull: false
 endpoints:
     jmx:

--- a/grails-app/controllers/org/pih/warehouse/api/StockMovementApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/StockMovementApiController.groovy
@@ -11,6 +11,8 @@ package org.pih.warehouse.api
 
 import grails.converters.JSON
 import org.grails.web.json.JSONObject
+
+import org.pih.warehouse.DateUtil
 import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.DocumentService
@@ -359,19 +361,12 @@ class StockMovementApiController {
         render([data: pendingRequisitionDetails] as JSON)
     }
 
-    /**
-     * Bind the date field value to the date object.
-     *
-     * @param dateObject
-     * @param jsonObject
-     * @param dateField
-     */
     private Date parseDateRequested(String date) {
-        return date ? Constants.EXPIRATION_DATE_FORMATTER.parse(date) : null
+        return DateUtil.asDate(date, Constants.EXPIRATION_DATE_FORMATTER)
     }
 
     private Date parseDateShipped(String date) {
-        return date ? Constants.DELIVERY_DATE_FORMATTER.parse(date) : null
+        return DateUtil.asDate(date, Constants.DELIVERY_DATE_FORMATTER)
     }
 
     private void bindStockMovement(StockMovement stockMovement, JSONObject jsonObject) {

--- a/grails-app/init/org/pih/warehouse/BootStrap.groovy
+++ b/grails-app/init/org/pih/warehouse/BootStrap.groovy
@@ -12,6 +12,9 @@ package org.pih.warehouse
 import grails.converters.JSON
 import grails.util.Holders
 import java.math.RoundingMode
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZonedDateTime
 import javax.sql.DataSource
 import liquibase.Contexts
 import liquibase.LabelExpression
@@ -131,6 +134,16 @@ class BootStrap {
     }
 
     void registerJsonMarshallers() {
+
+        // java.time types. With these marshallers we don't need to call toString() on the java.time fields in the
+        // toJson() methods of Domains/DTOs or in the other object marshallers below. When we're on Grails 5+ we can
+        // add the "jackson-datatype-jsr310" dependency and let SpringBoot handle things automatically (it adds the
+        // JavaTimeModule when it registers the ObjectMapper bean), but that doesn't work with our custom ValueConverter
+        // classes for these types, which we need because Grails 4 and older doesn't support these types out of the box.
+        // https://docs.spring.io/spring-boot/how-to/spring-mvc.html#howto.spring-mvc.customize-jackson-objectmapper
+        JSON.registerObjectMarshaller(Instant) { Instant instant -> instant.toString() }
+        JSON.registerObjectMarshaller(LocalDate) { LocalDate localDate -> localDate.toString() }
+        JSON.registerObjectMarshaller(ZonedDateTime) { ZonedDateTime zonedDateTime -> zonedDateTime.toString() }
 
         // Static data
         JSON.registerObjectMarshaller(ContainerType) { ContainerType containerType ->

--- a/grails-app/utils/org/pih/warehouse/DateUtil.groovy
+++ b/grails-app/utils/org/pih/warehouse/DateUtil.groovy
@@ -10,11 +10,155 @@
 package org.pih.warehouse
 
 import grails.validation.ValidationException
-
 import java.text.SimpleDateFormat
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.ChronoField
+import org.apache.commons.lang.StringUtils
 
-
+/**
+ * Utility methods on date and datetime objects.
+ *
+ * In our system, we try to work with a small subset of the datetime-related classes:
+ *
+ * - java.time.Instant: An absolute moment in time (measured in seconds since UTC epoch). We should work with Instant
+ *                      whenever possible since it is specific enough to be convertible to other formats, while
+ *                      still being timezone agnostic (and so avoids any locale conversion and weirdness).
+ *
+ * - java.time.LocalDate: A date (day + month + year) with no time or timezone component. Useful for setting fixed
+ *                        dates, where switching to a different timezone should never change the date (ex: expiry date).
+ *
+ * - java.time.ZonedDateTime: A datetime (via LocalDateTime) in a timezone (via ZoneOffset).
+ *                            Useful for working with a human readable datetime in a specific locale, where switching
+ *                            to a different timezone should change the resulting value. Only to be used if we have
+ *                            user-locale-specific logic (ex: We need to check if some datetime would be the next
+ *                            day for the requesting user).
+ *
+ * We also have java.util.Date, which is deprecated and should not be used going forward.
+ */
 class DateUtil {
+
+    /*
+     * Patterns that follow the ISO-8601 + RPC 3339 date formats while allowing for some slight variation in
+     * the pattern.
+     *
+     * Ex: "2000-01-01", "2000/01/01", "20000101" are all valid strings according to FLEXIBLE_DATE_PATTERN.
+     * Ex: both "2000-01-01" and "2000-01-01T00:00:00Z" are valid strings according to FLEXIBLE_DATE_TIME_ZONE_PATTERN.
+     *
+     * We do this mainly to support a wider range of user INPUT, making our parsing logic more flexible.
+     * Internally, we should strive to use a consistent structure and to always OUTPUT the same format (see below
+     * "Fixed Date Formats").
+     *
+     * Note that more specific optionals must be defined in front of less specific ones (ex: [HH:mm:ss][HH:mm],
+     * not [HH:mm][HH:mm:ss]).
+     *
+     * Also note that depending on what date type you're parsing into, this can trigger an error. For example, Instant
+     * requires time and timezone information, and so FLEXIBLE_DATE_TIME_ZONE_PATTERN will fail to parse "2000-01-01"
+     * unless the associated DateTimeFormatter provides a default (via a "withZone(ZoneId)" call).
+     */
+    private static final String FLEXIBLE_DATE_PATTERN = "[yyyy-MM-dd][yyyy/MM/dd][yyyy MM dd][yyyyMMdd]"
+    private static final String FLEXIBLE_TIME_PATTERN =
+            "[HH:mm:ss.SSS][HH:mm:ss:SSS][HHmmssSSS]" +
+            "[HH:mm:ss.SS][HH:mm:ss:SS][HHmmssSS]" +
+            "[HH:mm:ss.S][HH:mm:ss:S][HHmmssS]" +
+            "[HH:mm:ss][HHmmss]" +
+            "[HH:mm][HHmm]"
+    private static final String FLEXIBLE_DATE_TIME_ZONE_PATTERN =
+            "${FLEXIBLE_DATE_PATTERN}[['T'][ ]${FLEXIBLE_TIME_PATTERN}][[XXX][XX][X]]"
+
+    /*
+     * Flexible Date Formats
+     *
+     * "Flexible" in that they allow for multiple formats, and provide appropriate defaults if fields are not provided.
+     *
+     * We should use these flexible formats only when binding user-input Strings to certain data types.
+     * To convert date types back to Strings, just call toString() on them. The reasoning is that we want to accept as
+     * wide a range of user inputs as possible, but internally we want to work with and return a single, known format.
+     */
+    static final DateTimeFormatter FLEXIBLE_DATE_TIME_ZONE_FORMAT = new DateTimeFormatterBuilder()
+            .appendPattern(FLEXIBLE_DATE_TIME_ZONE_PATTERN)
+            // Defaults to 00:00:00.000 if time is not provided in the String
+            .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+            .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+            .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+            .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0)
+            // Defaults to UTC if timezone is not provided in the String
+            .parseDefaulting(ChronoField.OFFSET_SECONDS, ZoneOffset.UTC.getTotalSeconds())
+            .toFormatter()
+    static final DateTimeFormatter FLEXIBLE_DATE_FORMAT = DateTimeFormatter.ofPattern(FLEXIBLE_DATE_PATTERN)
+    static final DateTimeFormatter FLEXIBLE_TIME_FORMAT = DateTimeFormatter.ofPattern(FLEXIBLE_TIME_PATTERN)
+
+    /**
+     * To be used when parsing a String to a java.util.Date.
+     *
+     * @Deprecated SimpleDateFormat is functionally deprecated as of Java 8 and is replaced by DateTimeFormatter.
+     *             Don't use SimpleDateFormat anywhere else from now on.
+     */
+    private static final SimpleDateFormat FLEXIBLE_SIMPLE_FORMAT = new SimpleDateFormat(FLEXIBLE_DATE_TIME_ZONE_PATTERN)
+
+    /**
+     * Null-safe conversion of a (deprecated) java.util.Date to an Instant.
+     * Useful when working with old code that uses the old format.
+     */
+    static Instant asInstant(Date date) {
+        return date ? date.toInstant() : null
+    }
+
+    /**
+     * Null-safe conversion of a ZonedDateTime to an Instant.
+     */
+    static Instant asInstant(ZonedDateTime zonedDateTime) {
+        return zonedDateTime ? zonedDateTime.toInstant() : null
+    }
+
+    /**
+     * Null-safe conversion of an Instant to a ZonedDateTime. If no timezone is provided, we assume UTC.
+     *
+     * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example.
+     */
+    static ZonedDateTime asZonedDateTime(Instant instant, ZoneId zone=ZoneOffset.UTC) {
+        return instant ? instant.atZone(zone) : null
+    }
+
+    /**
+     * Null-safe conversion of a (deprecated) java.util.Date to an ZonedDateTime. If no timezone is provided,
+     * we assume UTC. Useful when working with old code that uses the old format.
+     *
+     * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example.
+     */
+    static ZonedDateTime asZonedDateTime(Date date, ZoneId zone=ZoneOffset.UTC) {
+        return date ? asInstant(date).atZone(zone) : null
+    }
+
+    /**
+     * Binds a String to a (deprecated) java.util.Date.
+     *
+     * @Deprecated Only exists to support old endpoints that manually bind their data. New APIs should not use this
+     *             approach, and should use Command Objects in controller method args to auto-bind the request body.
+     */
+    static Date asDate(String date, SimpleDateFormat format=FLEXIBLE_SIMPLE_FORMAT) {
+        return StringUtils.isBlank(date) ? null : format.parse(date.trim())
+    }
+
+    /**
+     * Null-safe conversion of an Instant to a (deprecated) java.util.Date.
+     * Useful when working with old code that uses the old format.
+     */
+    static Date asDate(Instant instant) {
+        return instant ? Date.from(instant) : null
+    }
+
+    /**
+     * Null-safe conversion of a ZonedDateTime to a (deprecated) java.util.Date.
+     * Useful when working with old code that uses the old format.
+     */
+    static Date asDate(ZonedDateTime zonedDateTime) {
+        return zonedDateTime ? asDate(zonedDateTime.toInstant()) : null
+    }
 
     static Date clearTime(Date date) {
         Calendar calendar = Calendar.getInstance()

--- a/grails-app/utils/org/pih/warehouse/DateUtil.groovy
+++ b/grails-app/utils/org/pih/warehouse/DateUtil.groovy
@@ -10,14 +10,12 @@
 package org.pih.warehouse
 
 import grails.validation.ValidationException
+import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeFormatterBuilder
-import java.time.temporal.ChronoField
 import org.apache.commons.lang.StringUtils
 
 /**
@@ -42,63 +40,25 @@ import org.apache.commons.lang.StringUtils
  */
 class DateUtil {
 
-    /*
-     * Patterns that follow the ISO-8601 + RPC 3339 date formats while allowing for some slight variation in
-     * the pattern.
-     *
-     * Ex: "2000-01-01", "2000/01/01", "20000101" are all valid strings according to FLEXIBLE_DATE_PATTERN.
-     * Ex: both "2000-01-01" and "2000-01-01T00:00:00Z" are valid strings according to FLEXIBLE_DATE_TIME_ZONE_PATTERN.
-     *
-     * We do this mainly to support a wider range of user INPUT, making our parsing logic more flexible.
-     * Internally, we should strive to use a consistent structure and to always OUTPUT the same format (see below
-     * "Fixed Date Formats").
-     *
-     * Note that more specific optionals must be defined in front of less specific ones (ex: [HH:mm:ss][HH:mm],
-     * not [HH:mm][HH:mm:ss]).
-     *
-     * Also note that depending on what date type you're parsing into, this can trigger an error. For example, Instant
-     * requires time and timezone information, and so FLEXIBLE_DATE_TIME_ZONE_PATTERN will fail to parse "2000-01-01"
-     * unless the associated DateTimeFormatter provides a default (via a "withZone(ZoneId)" call).
-     */
-    private static final String FLEXIBLE_DATE_PATTERN = "[yyyy-MM-dd][yyyy/MM/dd][yyyy MM dd][yyyyMMdd]"
-    private static final String FLEXIBLE_TIME_PATTERN =
-            "[HH:mm:ss.SSS][HH:mm:ss:SSS][HHmmssSSS]" +
-            "[HH:mm:ss.SS][HH:mm:ss:SS][HHmmssSS]" +
-            "[HH:mm:ss.S][HH:mm:ss:S][HHmmssS]" +
-            "[HH:mm:ss][HHmmss]" +
-            "[HH:mm][HHmm]"
-    private static final String FLEXIBLE_DATE_TIME_ZONE_PATTERN =
-            "${FLEXIBLE_DATE_PATTERN}[['T'][ ]${FLEXIBLE_TIME_PATTERN}][[XXX][XX][X]]"
-
-    /*
-     * Flexible Date Formats
-     *
-     * "Flexible" in that they allow for multiple formats, and provide appropriate defaults if fields are not provided.
-     *
-     * We should use these flexible formats only when binding user-input Strings to certain data types.
-     * To convert date types back to Strings, just call toString() on them. The reasoning is that we want to accept as
-     * wide a range of user inputs as possible, but internally we want to work with and return a single, known format.
-     */
-    static final DateTimeFormatter FLEXIBLE_DATE_TIME_ZONE_FORMAT = new DateTimeFormatterBuilder()
-            .appendPattern(FLEXIBLE_DATE_TIME_ZONE_PATTERN)
-            // Defaults to 00:00:00.000 if time is not provided in the String
-            .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
-            .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
-            .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
-            .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0)
-            // Defaults to UTC if timezone is not provided in the String
-            .parseDefaulting(ChronoField.OFFSET_SECONDS, ZoneOffset.UTC.getTotalSeconds())
-            .toFormatter()
-    static final DateTimeFormatter FLEXIBLE_DATE_FORMAT = DateTimeFormatter.ofPattern(FLEXIBLE_DATE_PATTERN)
-    static final DateTimeFormatter FLEXIBLE_TIME_FORMAT = DateTimeFormatter.ofPattern(FLEXIBLE_TIME_PATTERN)
-
     /**
-     * To be used when parsing a String to a java.util.Date.
-     *
-     * @Deprecated SimpleDateFormat is functionally deprecated as of Java 8 and is replaced by DateTimeFormatter.
-     *             Don't use SimpleDateFormat anywhere else from now on.
+     * Formats for parsing a String to a java.util.Date. Mirror the formats defined in application.yml under the
+     * grails.databinding.dateFormats setting. List order is important as formats will be attempted in order.
      */
-    private static final SimpleDateFormat FLEXIBLE_SIMPLE_FORMAT = new SimpleDateFormat(FLEXIBLE_DATE_TIME_ZONE_PATTERN)
+    private static final List<SimpleDateFormat> DEFAULT_SIMPLE_DATE_FORMATS = [
+            new SimpleDateFormat("MM/dd/yyyy HH:mm:ss XXX"),
+            new SimpleDateFormat("MM/dd/yyyy HH:mm:ss XX"),
+            new SimpleDateFormat("MM/dd/yyyy HH:mm:ss X"),
+            new SimpleDateFormat("MM/dd/yyyy HH:mm XXX"),
+            new SimpleDateFormat("MM/dd/yyyy HH:mm XX"),
+            new SimpleDateFormat("MM/dd/yyyy HH:mm X"),
+            new SimpleDateFormat("MM/dd/yyyy"),
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX"),
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX"),
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX"),
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mmXXX"),
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mmXX"),
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mmX"),
+    ]
 
     /**
      * Null-safe conversion of a (deprecated) java.util.Date to an Instant.
@@ -135,13 +95,29 @@ class DateUtil {
     }
 
     /**
-     * Binds a String to a (deprecated) java.util.Date.
+     * Binds a String to a (deprecated) java.util.Date. If no format is given, will use the default configured formats.
      *
      * @Deprecated Only exists to support old endpoints that manually bind their data. New APIs should not use this
      *             approach, and should use Command Objects in controller method args to auto-bind the request body.
      */
-    static Date asDate(String date, SimpleDateFormat format=FLEXIBLE_SIMPLE_FORMAT) {
-        return StringUtils.isBlank(date) ? null : format.parse(date.trim())
+    static Date asDate(String date, SimpleDateFormat format=null) {
+        if (StringUtils.isBlank(date)) {
+            return null
+        }
+
+        String dateSanitized = date.trim()
+        if (format != null) {
+            return format.parse(dateSanitized)
+        }
+
+        for (SimpleDateFormat defaultFormat : DEFAULT_SIMPLE_DATE_FORMATS) {
+            try {
+                return defaultFormat.parse(dateSanitized)
+            } catch (ParseException ignored) {
+                // Do nothing. Try the next format.
+            }
+        }
+        throw new ParseException("Unparseable date: ${date}", 0)
     }
 
     /**

--- a/grails-app/utils/org/pih/warehouse/databinding/DataBindingConstants.groovy
+++ b/grails-app/utils/org/pih/warehouse/databinding/DataBindingConstants.groovy
@@ -1,0 +1,34 @@
+package org.pih.warehouse.databinding
+
+/**
+ * Constants relating to binding request input strings to objects.
+ */
+class DataBindingConstants {
+
+    /*
+     * Patterns that follow the ISO-8601 + RPC 3339 date formats while allowing for some slight variation in
+     * the pattern.
+     *
+     * Ex: "2000-01-01", "2000/01/01", "20000101" are all valid strings according to FLEXIBLE_DATE_PATTERN.
+     * Ex: both "2000-01-01" and "2000-01-01T00:00:00Z" are valid strings according to FLEXIBLE_DATE_TIME_ZONE_PATTERN.
+     *
+     * We do this mainly to support a wider range of user input, making our parsing logic more flexible.
+     * Internally, we should strive to use a consistent structure and to always output the same format.
+     *
+     * Note that more specific optionals must be defined in front of less specific ones (ex: [HH:mm:ss][HH:mm],
+     * not [HH:mm][HH:mm:ss]).
+     *
+     * Also note that depending on what date type you're parsing into, this can trigger an error. For example, Instant
+     * requires time and timezone information, and so FLEXIBLE_DATE_TIME_ZONE_PATTERN will fail to parse "2000-01-01"
+     * unless the associated DateTimeFormatter provides a default for time and zone (via "parseDefaulting").
+     */
+    static final String FLEXIBLE_DATE_PATTERN = "[yyyy-MM-dd][yyyy/MM/dd][yyyy MM dd][yyyyMMdd]"
+    static final String FLEXIBLE_TIME_PATTERN =
+            "[HH:mm:ss.SSS][HH:mm:ss:SSS][HHmmssSSS]" +
+            "[HH:mm:ss.SS][HH:mm:ss:SS][HHmmssSS]" +
+            "[HH:mm:ss.S][HH:mm:ss:S][HHmmssS]" +
+            "[HH:mm:ss][HHmmss]" +
+            "[HH:mm][HHmm]"
+    static final String FLEXIBLE_DATE_TIME_ZONE_PATTERN =
+            "${FLEXIBLE_DATE_PATTERN}[['T'][ ]${FLEXIBLE_TIME_PATTERN}][[XXX][XX][X]]"
+}

--- a/grails-app/utils/org/pih/warehouse/databinding/InstantValueConverter.groovy
+++ b/grails-app/utils/org/pih/warehouse/databinding/InstantValueConverter.groovy
@@ -34,10 +34,13 @@ class InstantValueConverter extends StringValueConverter<Instant> {
      * As such, if the given string doesn't provide a time, we default to "00:00.000" (aka the start of the day),
      * and if it doesn't provide a timezone, we default to "Z" (aka UTC).
      *
-     * We could have tried to determine the client's timezone by looking in the session and defaulting to that timezone
-     * instead, but that would be making assumptions about what format the client is providing, which may not be
-     * correct. The universally accepted "default" timezone is UTC, so for the sake of simplicity, we use that as a
-     * fallback if the client doesn't provide timezone information themselves (though they really should).
+     * This defaulting to UTC is important. We don't want to rely on the system local time, which can vary from host
+     * to host, and can change over time within a single host. Our app should behave the same way no matter where it is
+     * hosted. We also don't want to make assumptions about the timezone that the end user is sending data in/from.
+     *
+     * The universally accepted "default" timezone is UTC, so for the sake of simplicity, we use that as a fallback if
+     * the client doesn't provide timezone information. However, as much as possible we should insist that the client
+     * DOES provide timezone information so that there is no ambiguity as to the precise datetime being provided.
      *
      * @param value "2000-01-01", "2000-01-01T00:00", "2000-01-01T00:00Z", "2000-01-01T00:00+05:00" for example
      */

--- a/grails-app/utils/org/pih/warehouse/databinding/InstantValueConverter.groovy
+++ b/grails-app/utils/org/pih/warehouse/databinding/InstantValueConverter.groovy
@@ -1,10 +1,12 @@
 package org.pih.warehouse.databinding
 
 import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.ChronoField
 import org.apache.commons.lang.StringUtils
 import org.springframework.stereotype.Component
-
-import org.pih.warehouse.DateUtil
 
 /**
  * As of Java 8, Java.util.Date is functionally replaced with the java.time classes, but Grails 4 and older does not
@@ -13,6 +15,17 @@ import org.pih.warehouse.DateUtil
  */
 @Component
 class InstantValueConverter extends StringValueConverter<Instant> {
+
+    private static final DateTimeFormatter FLEXIBLE_DATE_TIME_ZONE_FORMAT = new DateTimeFormatterBuilder()
+            .appendPattern(DataBindingConstants.FLEXIBLE_DATE_TIME_ZONE_PATTERN)
+            // Defaults to 00:00:00.000 if time is not provided in the String
+            .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+            .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+            .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+            .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0)
+            // Defaults to UTC if timezone is not provided in the String
+            .parseDefaulting(ChronoField.OFFSET_SECONDS, ZoneOffset.UTC.getTotalSeconds())
+            .toFormatter()
 
     /**
      * Binds a given user-input String to an Instant.
@@ -32,6 +45,6 @@ class InstantValueConverter extends StringValueConverter<Instant> {
     Instant convertString(String value) {
         return StringUtils.isBlank(value) ?
                 null :
-                Instant.from(DateUtil.FLEXIBLE_DATE_TIME_ZONE_FORMAT.parse(value.trim()))
+                Instant.from(FLEXIBLE_DATE_TIME_ZONE_FORMAT.parse(value.trim()))
     }
 }

--- a/grails-app/utils/org/pih/warehouse/databinding/InstantValueConverter.groovy
+++ b/grails-app/utils/org/pih/warehouse/databinding/InstantValueConverter.groovy
@@ -1,0 +1,37 @@
+package org.pih.warehouse.databinding
+
+import java.time.Instant
+import org.apache.commons.lang.StringUtils
+import org.springframework.stereotype.Component
+
+import org.pih.warehouse.DateUtil
+
+/**
+ * As of Java 8, Java.util.Date is functionally replaced with the java.time classes, but Grails 4 and older does not
+ * support databinding a datetime String to an Instant (only timestamps) so we need to add support ourselves.
+ * https://github.com/grails/grails-core/issues/11811
+ */
+@Component
+class InstantValueConverter extends StringValueConverter<Instant> {
+
+    /**
+     * Binds a given user-input String to an Instant.
+     *
+     * An Instant is an absolute moment in time, so to construct it we need a full datetime with timezone included.
+     * As such, if the given string doesn't provide a time, we default to "00:00.000" (aka the start of the day),
+     * and if it doesn't provide a timezone, we default to "Z" (aka UTC).
+     *
+     * We could have tried to determine the client's timezone by looking in the session and defaulting to that timezone
+     * instead, but that would be making assumptions about what format the client is providing, which may not be
+     * correct. The universally accepted "default" timezone is UTC, so for the sake of simplicity, we use that as a
+     * fallback if the client doesn't provide timezone information themselves (though they really should).
+     *
+     * @param value "2000-01-01", "2000-01-01T00:00", "2000-01-01T00:00Z", "2000-01-01T00:00+05:00" for example
+     */
+    @Override
+    Instant convertString(String value) {
+        return StringUtils.isBlank(value) ?
+                null :
+                Instant.from(DateUtil.FLEXIBLE_DATE_TIME_ZONE_FORMAT.parse(value.trim()))
+    }
+}

--- a/grails-app/utils/org/pih/warehouse/databinding/LocalDateValueConverter.groovy
+++ b/grails-app/utils/org/pih/warehouse/databinding/LocalDateValueConverter.groovy
@@ -1,10 +1,9 @@
 package org.pih.warehouse.databinding
 
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import org.apache.commons.lang.StringUtils
 import org.springframework.stereotype.Component
-
-import org.pih.warehouse.DateUtil
 
 /**
  * As of Java 8, Java.util.Date is functionally replaced with the java.time classes, but Grails 4 and older does not
@@ -13,6 +12,9 @@ import org.pih.warehouse.DateUtil
  */
 @Component
 class LocalDateValueConverter extends StringValueConverter<LocalDate> {
+
+    private static final DateTimeFormatter FLEXIBLE_DATE_FORMAT = DateTimeFormatter.ofPattern(
+            DataBindingConstants.FLEXIBLE_DATE_PATTERN)
 
     /**
      * Parse a given String into a LocalDate of the given format.
@@ -26,6 +28,6 @@ class LocalDateValueConverter extends StringValueConverter<LocalDate> {
     LocalDate convertString(String value) {
         return StringUtils.isBlank(value) ?
                 null :
-                LocalDate.parse(value.trim(), DateUtil.FLEXIBLE_DATE_FORMAT)
+                LocalDate.parse(value.trim(), FLEXIBLE_DATE_FORMAT)
     }
 }

--- a/grails-app/utils/org/pih/warehouse/databinding/LocalDateValueConverter.groovy
+++ b/grails-app/utils/org/pih/warehouse/databinding/LocalDateValueConverter.groovy
@@ -1,0 +1,31 @@
+package org.pih.warehouse.databinding
+
+import java.time.LocalDate
+import org.apache.commons.lang.StringUtils
+import org.springframework.stereotype.Component
+
+import org.pih.warehouse.DateUtil
+
+/**
+ * As of Java 8, Java.util.Date is functionally replaced with the java.time classes, but Grails 4 and older does not
+ * support databinding a datetime String to a LocalDate so we need to add support ourselves.
+ * https://github.com/grails/grails-core/issues/11811
+ */
+@Component
+class LocalDateValueConverter extends StringValueConverter<LocalDate> {
+
+    /**
+     * Parse a given String into a LocalDate of the given format.
+     *
+     * Because LocalDate is time and timezone agnostic, the String only expects day, month, and year elements. To avoid
+     * any timezone related confusion, Any additional data provided (such as time and timezone) will trigger an error.
+     *
+     * @param value "2000/01/01" for example
+     */
+    @Override
+    LocalDate convertString(String value) {
+        return StringUtils.isBlank(value) ?
+                null :
+                LocalDate.parse(value.trim(), DateUtil.FLEXIBLE_DATE_FORMAT)
+    }
+}

--- a/grails-app/utils/org/pih/warehouse/databinding/StringValueConverter.groovy
+++ b/grails-app/utils/org/pih/warehouse/databinding/StringValueConverter.groovy
@@ -1,0 +1,34 @@
+package org.pih.warehouse.databinding
+
+import grails.databinding.converters.ValueConverter
+import org.springframework.core.GenericTypeResolver
+
+/**
+ * A convenience base class that our ValueConverters can extend from. Useful since a vast majority of the time, our
+ * user inputs (request body, uri + query params) are Strings.
+ *
+ * @param <T> The type that we're converting to.
+ */
+abstract class StringValueConverter<T> implements ValueConverter {
+
+    /**
+     * Defines how to convert a user-input String to the necessary data type.
+     */
+    abstract T convertString(String value)
+
+    @Override
+    boolean canConvert(Object value) {
+        return value instanceof String
+    }
+
+    @Override
+    Class<?> getTargetType() {
+        // The Spring *magic* way of extracting the type from a class.
+        return (Class<T>) GenericTypeResolver.resolveTypeArgument(getClass(), StringValueConverter.class)
+    }
+
+    @Override
+    Object convert(Object value) {
+        return convertString((String) value)
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/Constants.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/Constants.groovy
@@ -25,6 +25,10 @@ class Constants {
     static final adminControllers = ['createProduct', 'admin']
     static final adminActions = ['product': ['create'], 'person': ['list'], 'user': ['list'], 'location': ['edit'], 'shipper': ['create'], 'locationGroup': ['create'], 'locationType': ['create'], '*': ['delete']]
 
+    // TODO: Don't add more dates here! We should refactor all usages of these constants to instead use the
+    //       DateTimeFormatter constants in DateUtil. The backend should always return dates in the same format so that
+    //       the frontend can easily parse response objects. Let the frontend decide what the display format of each
+    //       individual field should be.
     static final String DEFAULT_YEAR_FORMAT = "yyyy"
     static final String DEFAULT_DATE_FORMAT = "dd/MMM/yyyy"
     static final String DEFAULT_DATE_TIME_FORMAT = "dd/MMM/yyyy HH:mm:ss"

--- a/src/main/groovy/util/StringUtil.groovy
+++ b/src/main/groovy/util/StringUtil.groovy
@@ -11,11 +11,11 @@ package util
 
 import groovy.text.SimpleTemplateEngine
 
-import java.text.DateFormat
 import java.text.MessageFormat
-import java.text.SimpleDateFormat
 
-
+/**
+ * Utility methods for parsing/formatting strings and general string manipulation.
+ */
 class StringUtil {
 
     static String mask(String value) {
@@ -34,22 +34,6 @@ class StringUtil {
 
     static String format(text, args) {
         return MessageFormat.format(text, args)
-    }
-
-    static Date parseDate(String format, String source) {
-        if (source) {
-            DateFormat dateFormat = new SimpleDateFormat(format)
-            return dateFormat.parse(source)
-        }
-        return null
-    }
-
-    static String formatString(String format, Date date) {
-        if (date) {
-            DateFormat dateFormat = new SimpleDateFormat(format)
-            return dateFormat.format(date)
-        }
-        return null
     }
 
     static String format(String text) {

--- a/src/test/groovy/unit/org/pih/warehouse/utils/DateUtilSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/utils/DateUtilSpec.groovy
@@ -1,0 +1,144 @@
+package unit.org.pih.warehouse.utils
+
+import java.text.ParseException
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import org.pih.warehouse.DateUtil
+
+@Unroll
+class DateUtilSpec extends Specification {
+
+    void 'asDate should successfully parse using the default format for case: #scenario'() {
+        expect:
+        assert new Date(expectedConvertedDate) == DateUtil.asDate(givenDate)
+
+        where:
+        givenDate                   || expectedConvertedDate              | scenario
+        "2000-01-01T00:00:00Z"      || "Sat, 01 Jan 2000 00:00:00 UTC"    | "Full string in proper ISO format"
+        "2000-01-01T00:00Z"         || "Sat, 01 Jan 2000 00:00:00 UTC"    | "No seconds"
+        "2000-01-01T00:00:00-05"    || "Sat, 01 Jan 2000 00:00:00 UTC-05" | "Timezone conforming to X format w/ negative"
+        "2000-01-01T00:00:00-0500"  || "Sat, 01 Jan 2000 00:00:00 UTC-05" | "Timezone conforming to XX format w/ negative"
+        "2000-01-01T00:00:00-05:00" || "Sat, 01 Jan 2000 00:00:00 UTC-05" | "Timezone conforming to XXX format w/ negative"
+        "2000-01-01T00:00:00+00"    || "Sat, 01 Jan 2000 00:00:00 UTC"    | "Timezone conforming to X format w/ zero"
+        "2000-01-01T00:00:00+0000"  || "Sat, 01 Jan 2000 00:00:00 UTC"    | "Timezone conforming to XX format w/ zero"
+        "2000-01-01T00:00:00+00:00" || "Sat, 01 Jan 2000 00:00:00 UTC"    | "Timezone conforming to XXX format w/ zero"
+        "2000-01-01T00:00:00+05"    || "Sat, 01 Jan 2000 00:00:00 UTC+05" | "Timezone conforming to X format w/ positive"
+        "2000-01-01T00:00:00+0500"  || "Sat, 01 Jan 2000 00:00:00 UTC+05" | "Timezone conforming to XX format w/ positive"
+        "2000-01-01T00:00:00+05:00" || "Sat, 01 Jan 2000 00:00:00 UTC+05" | "Timezone conforming to XXX format w/ positive"
+
+        "01/01/2000 00:00:00 Z"     || "Sat, 01 Jan 2000 00:00:00 UTC"    | "Full string in our format"
+        "01/01/2000 00:00 Z"        || "Sat, 01 Jan 2000 00:00:00 UTC"    | "No seconds our format"
+        "01/01/2000 00:00 -05"      || "Sat, 01 Jan 2000 00:00:00 UTC-05" | "Timezone conforming to X format w/ negative our format"
+        "01/01/2000 00:00 -0500"    || "Sat, 01 Jan 2000 00:00:00 UTC-05" | "Timezone conforming to XX format w/ negative our format"
+        "01/01/2000 00:00 -05:00"   || "Sat, 01 Jan 2000 00:00:00 UTC-05" | "Timezone conforming to XXX format w/ negative our format"
+        "01/01/2000 00:00 +00"      || "Sat, 01 Jan 2000 00:00:00 UTC"    | "Timezone conforming to X format w/ zero our format"
+        "01/01/2000 00:00 +0000"    || "Sat, 01 Jan 2000 00:00:00 UTC"    | "Timezone conforming to XX format w/ zero our format"
+        "01/01/2000 00:00 +00:00"   || "Sat, 01 Jan 2000 00:00:00 UTC"    | "Timezone conforming to XXX format w/ zero our format"
+        "01/01/2000 00:00 +05"      || "Sat, 01 Jan 2000 00:00:00 UTC+05" | "Timezone conforming to X format w/ positive our format"
+        "01/01/2000 00:00 +0500"    || "Sat, 01 Jan 2000 00:00:00 UTC+05" | "Timezone conforming to XX format w/ positive our format"
+        "01/01/2000 00:00 +05:00"   || "Sat, 01 Jan 2000 00:00:00 UTC+05" | "Timezone conforming to XXX format w/ positive our format"
+
+        // This case fails because when no timezone is provided to Date, it uses the system local timezone instead of
+        // UTC. This can cause unexpected behaviour! Adding "TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC))"
+        // to Bootstrap.groovy will change the default to always be UTC. This fixes the issue by making the behaviour
+        // consistent (and would allow us to re-enable this test).
+        //"01/01/2000"                || "Sat, 01 Jan 2000 00:00:00 UTC"    | "No time or timezone our format"
+    }
+
+    void 'asDate should fail to parse using the default format when given an invalid date string'() {
+        when:
+        DateUtil.asDate("01 01 2000")
+
+        then:
+        thrown(ParseException)
+    }
+
+    void 'asInstant should successfully convert a Date to an Instant for case: #scenario'() {
+        given:
+        Date date = new Date(givenDate)
+
+        expect:
+        assert DateUtil.asInstant(date).toString() == expectedConvertedDate
+
+        where:
+        givenDate                          || expectedConvertedDate  | scenario
+        "Sat, 01 Jan 2000 00:00:00 UTC"    || "2000-01-01T00:00:00Z" | "UTC timezone"
+        "Sat, 01 Jan 2000 00:00:00 UTC+05" || "1999-12-31T19:00:00Z" | "timezone ahead of UTC"
+        "Sat, 01 Jan 2000 00:00:00 UTC-05" || "2000-01-01T05:00:00Z" | "timezone behind UTC"
+
+        // This case fails because when no timezone is provided to Date, it uses the system local timezone instead of
+        // UTC. This can cause unexpected behaviour! Adding "TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC))"
+        // to Bootstrap.groovy will change the default to always be UTC. This fixes the issue by making the behaviour
+        // consistent (and would allow us to re-enable this test).
+        //"Sat, 01 Jan 2000 00:00:00"        || "2000-01-01T00:00:00Z" | "no timezone given"
+    }
+
+    void 'asInstant should successfully convert a ZonedDateTime to an Instant for case: #scenario'() {
+        given:
+        ZonedDateTime zdt = ZonedDateTime.parse(givenDate)
+
+        expect:
+        assert DateUtil.asInstant(zdt).toString() == expectedConvertedDate
+
+        where:
+        givenDate                   || expectedConvertedDate  | scenario
+        "2000-01-01T00:00:00Z"      || "2000-01-01T00:00:00Z" | "Full string in proper ISO format"
+        "2000-01-01T00:00Z"         || "2000-01-01T00:00:00Z" | "No seconds"
+        "2000-01-01T00:00:00-05:00" || "2000-01-01T05:00:00Z" | "Timezone conforming to XXX format w/ negative"
+        "2000-01-01T00:00:00+00:00" || "2000-01-01T00:00:00Z" | "Timezone conforming to XXX format w/ zero"
+        "2000-01-01T00:00:00+05:00" || "1999-12-31T19:00:00Z" | "Timezone conforming to XXX format w/ positive"
+    }
+
+    void 'asZonedDateTime should successfully convert an Instant to a ZonedDateTime for case: #scenario'() {
+        given:
+        Instant instant = Instant.parse(givenDate)
+
+        expect:
+        assert DateUtil.asZonedDateTime(instant).toString() == expectedConvertedDate
+
+        where:
+        givenDate                   || expectedConvertedDate      | scenario
+        "2000-01-01T00:00:11.111Z"  || "2000-01-01T00:00:11.111Z" | "Full string in proper ISO format"
+        "2000-01-01T00:00:11.000Z"  || "2000-01-01T00:00:11Z"     | "Empty millis are removed"
+        "2000-01-01T00:00:11Z"      || "2000-01-01T00:00:11Z"     | "No millis provided"
+        "2000-01-01T00:00:00Z"      || "2000-01-01T00:00Z"        | "Empty seconds are removed"
+    }
+
+    void 'asZonedDateTime should successfully convert an Instant to a ZonedDateTime with tz for case: #scenario'() {
+        given:
+        Instant instant = Instant.parse(givenDate)
+
+        expect:
+        assert DateUtil.asZonedDateTime(instant, givenTimezone).toString() == expectedConvertedDate
+
+        where:
+        givenDate              | givenTimezone      || expectedConvertedDate    | scenario
+        "2000-01-01T00:00:00Z" | ZoneId.of('Z')     || "2000-01-01T00:00Z"      | "UTC timezone"
+        "2000-01-01T00:00:00Z" | ZoneId.of('+05')   || "2000-01-01T05:00+05:00" | "timezone ahead of UTC"
+        "2000-01-01T00:00:00Z" | ZoneId.of('-05')   || "1999-12-31T19:00-05:00" | "timezone behind UTC"
+    }
+
+    void 'asZonedDateTime should successfully convert a Date to a ZonedDateTime for case: #scenario'() {
+        given:
+        Date date = new Date(givenDate)
+
+        expect:
+        assert DateUtil.asZonedDateTime(date).toString() == expectedConvertedDate
+
+        where:
+        givenDate                          || expectedConvertedDate | scenario
+        "Sat, 01 Jan 2000 00:00:00 UTC"    || "2000-01-01T00:00Z"   | "UTC timezone"
+        "Sat, 01 Jan 2000 00:00:00 UTC+05" || "1999-12-31T19:00Z"   | "timezone ahead of UTC"
+        "Sat, 01 Jan 2000 00:00:00 UTC-05" || "2000-01-01T05:00Z"   | "timezone behind UTC"
+
+        // This case fails because when no timezone is provided to Date, it uses the system local timezone instead of
+        // UTC. This can cause unexpected behaviour! Adding "TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC))"
+        // to Bootstrap.groovy will change the default to always be UTC. This fixes the issue by making the behaviour
+        // consistent (and would allow us to re-enable this test).
+        //"Sat, 01 Jan 2000 00:00:00"        || "2000-01-01T00:00Z"   | "no timezone given"
+    }
+}

--- a/src/test/groovy/unit/org/pih/warehouse/utils/DateUtilSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/utils/DateUtilSpec.groovy
@@ -47,14 +47,20 @@ class DateUtilSpec extends Specification {
         // to Bootstrap.groovy will change the default to always be UTC. This fixes the issue by making the behaviour
         // consistent (and would allow us to re-enable this test).
         //"01/01/2000"                || "Sat, 01 Jan 2000 00:00:00 UTC"    | "No time or timezone our format"
+        // It's noteworthy that the "yyyy" format for java.util.Date supports a two year format
+        //"01/01/00"                  || "Sat, 01 Jan 2000 00:00:00 UTC"    | "No time or timezone our format two digit year"
     }
 
-    void 'asDate should fail to parse using the default format when given an invalid date string'() {
+    void 'asDate should fail to parse using the default format for case: #failureReason'() {
         when:
-        DateUtil.asDate("01 01 2000")
+        DateUtil.asDate(givenDate)
 
         then:
         thrown(ParseException)
+
+        where:
+        givenDate    || failureReason
+        "01 01 2000" || "spaces not supported as separator"
     }
 
     void 'asInstant should successfully convert a Date to an Instant for case: #scenario'() {

--- a/src/test/groovy/unit/org/pih/warehouse/utils/DateUtilSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/utils/DateUtilSpec.groovy
@@ -1,8 +1,10 @@
 package unit.org.pih.warehouse.utils
 
 import java.text.ParseException
+import java.text.SimpleDateFormat
 import java.time.Instant
 import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -13,42 +15,51 @@ import org.pih.warehouse.DateUtil
 class DateUtilSpec extends Specification {
 
     void 'asDate should successfully parse using the default format for case: #scenario'() {
-        expect:
-        assert new Date(expectedConvertedDate) == DateUtil.asDate(givenDate)
+        given: 'a format to Stringify the parsed Date as (for asserting against)'
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+        format.setTimeZone(TimeZone.getTimeZone(ZoneOffset.UTC))
+
+        when:
+        Date date = DateUtil.asDate(givenDate)
+
+        then:
+        assert expectedConvertedDate == format.format(date)
 
         where:
-        givenDate                   || expectedConvertedDate              | scenario
-        "2000-01-01T00:00:00Z"      || "Sat, 01 Jan 2000 00:00:00 UTC"    | "Full string in proper ISO format"
-        "2000-01-01T00:00Z"         || "Sat, 01 Jan 2000 00:00:00 UTC"    | "No seconds"
-        "2000-01-01T00:00:00-05"    || "Sat, 01 Jan 2000 00:00:00 UTC-05" | "Timezone conforming to X format w/ negative"
-        "2000-01-01T00:00:00-0500"  || "Sat, 01 Jan 2000 00:00:00 UTC-05" | "Timezone conforming to XX format w/ negative"
-        "2000-01-01T00:00:00-05:00" || "Sat, 01 Jan 2000 00:00:00 UTC-05" | "Timezone conforming to XXX format w/ negative"
-        "2000-01-01T00:00:00+00"    || "Sat, 01 Jan 2000 00:00:00 UTC"    | "Timezone conforming to X format w/ zero"
-        "2000-01-01T00:00:00+0000"  || "Sat, 01 Jan 2000 00:00:00 UTC"    | "Timezone conforming to XX format w/ zero"
-        "2000-01-01T00:00:00+00:00" || "Sat, 01 Jan 2000 00:00:00 UTC"    | "Timezone conforming to XXX format w/ zero"
-        "2000-01-01T00:00:00+05"    || "Sat, 01 Jan 2000 00:00:00 UTC+05" | "Timezone conforming to X format w/ positive"
-        "2000-01-01T00:00:00+0500"  || "Sat, 01 Jan 2000 00:00:00 UTC+05" | "Timezone conforming to XX format w/ positive"
-        "2000-01-01T00:00:00+05:00" || "Sat, 01 Jan 2000 00:00:00 UTC+05" | "Timezone conforming to XXX format w/ positive"
+        givenDate                   || expectedConvertedDate  | scenario
+        "2000-01-01T00:00:00Z"      || "2000-01-01T00:00:00Z" | "Full string in proper ISO format"
+        "2000-01-01T00:00Z"         || "2000-01-01T00:00:00Z" | "No seconds"
+        "2000-01-01T00:00:00-05"    || "2000-01-01T05:00:00Z" | "Timezone conforming to X format w/ negative"
+        "2000-01-01T00:00:00-0500"  || "2000-01-01T05:00:00Z" | "Timezone conforming to XX format w/ negative"
+        "2000-01-01T00:00:00-05:00" || "2000-01-01T05:00:00Z" | "Timezone conforming to XXX format w/ negative"
+        "2000-01-01T00:00:00+00"    || "2000-01-01T00:00:00Z" | "Timezone conforming to X format w/ zero"
+        "2000-01-01T00:00:00+0000"  || "2000-01-01T00:00:00Z" | "Timezone conforming to XX format w/ zero"
+        "2000-01-01T00:00:00+00:00" || "2000-01-01T00:00:00Z" | "Timezone conforming to XXX format w/ zero"
+        "2000-01-01T00:00:00+05"    || "1999-12-31T19:00:00Z" | "Timezone conforming to X format w/ positive"
+        "2000-01-01T00:00:00+0500"  || "1999-12-31T19:00:00Z" | "Timezone conforming to XX format w/ positive"
+        "2000-01-01T00:00:00+05:00" || "1999-12-31T19:00:00Z" | "Timezone conforming to XXX format w/ positive"
 
-        "01/01/2000 00:00:00 Z"     || "Sat, 01 Jan 2000 00:00:00 UTC"    | "Full string in our format"
-        "01/01/2000 00:00 Z"        || "Sat, 01 Jan 2000 00:00:00 UTC"    | "No seconds our format"
-        "01/01/2000 00:00 -05"      || "Sat, 01 Jan 2000 00:00:00 UTC-05" | "Timezone conforming to X format w/ negative our format"
-        "01/01/2000 00:00 -0500"    || "Sat, 01 Jan 2000 00:00:00 UTC-05" | "Timezone conforming to XX format w/ negative our format"
-        "01/01/2000 00:00 -05:00"   || "Sat, 01 Jan 2000 00:00:00 UTC-05" | "Timezone conforming to XXX format w/ negative our format"
-        "01/01/2000 00:00 +00"      || "Sat, 01 Jan 2000 00:00:00 UTC"    | "Timezone conforming to X format w/ zero our format"
-        "01/01/2000 00:00 +0000"    || "Sat, 01 Jan 2000 00:00:00 UTC"    | "Timezone conforming to XX format w/ zero our format"
-        "01/01/2000 00:00 +00:00"   || "Sat, 01 Jan 2000 00:00:00 UTC"    | "Timezone conforming to XXX format w/ zero our format"
-        "01/01/2000 00:00 +05"      || "Sat, 01 Jan 2000 00:00:00 UTC+05" | "Timezone conforming to X format w/ positive our format"
-        "01/01/2000 00:00 +0500"    || "Sat, 01 Jan 2000 00:00:00 UTC+05" | "Timezone conforming to XX format w/ positive our format"
-        "01/01/2000 00:00 +05:00"   || "Sat, 01 Jan 2000 00:00:00 UTC+05" | "Timezone conforming to XXX format w/ positive our format"
+        "01/01/2000 00:00:00 Z"     || "2000-01-01T00:00:00Z" | "Full string in our format"
+        "01/01/2000 00:00 Z"        || "2000-01-01T00:00:00Z" | "No seconds our format"
+        "01/01/2000 00:00 -05"      || "2000-01-01T05:00:00Z" | "Timezone conforming to X format w/ negative our format"
+        "01/01/2000 00:00 -0500"    || "2000-01-01T05:00:00Z" | "Timezone conforming to XX format w/ negative our format"
+        "01/01/2000 00:00 -05:00"   || "2000-01-01T05:00:00Z" | "Timezone conforming to XXX format w/ negative our format"
+        "01/01/2000 00:00 +00"      || "2000-01-01T00:00:00Z" | "Timezone conforming to X format w/ zero our format"
+        "01/01/2000 00:00 +0000"    || "2000-01-01T00:00:00Z" | "Timezone conforming to XX format w/ zero our format"
+        "01/01/2000 00:00 +00:00"   || "2000-01-01T00:00:00Z" | "Timezone conforming to XXX format w/ zero our format"
+        "01/01/2000 00:00 +05"      || "1999-12-31T19:00:00Z" | "Timezone conforming to X format w/ positive our format"
+        "01/01/2000 00:00 +0500"    || "1999-12-31T19:00:00Z" | "Timezone conforming to XX format w/ positive our format"
+        "01/01/2000 00:00 +05:00"   || "1999-12-31T19:00:00Z" | "Timezone conforming to XXX format w/ positive our format"
 
         // This case fails because when no timezone is provided to Date, it uses the system local timezone instead of
         // UTC. This can cause unexpected behaviour! Adding "TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC))"
         // to Bootstrap.groovy will change the default to always be UTC. This fixes the issue by making the behaviour
         // consistent (and would allow us to re-enable this test).
-        //"01/01/2000"                || "Sat, 01 Jan 2000 00:00:00 UTC"    | "No time or timezone our format"
-        // It's noteworthy that the "yyyy" format for java.util.Date supports a two year format
-        //"01/01/00"                  || "Sat, 01 Jan 2000 00:00:00 UTC"    | "No time or timezone our format two digit year"
+        //"01/01/2000"                || "2000-01-01T00:00:00Z" | "No time or timezone our format"
+
+        // It's noteworthy that the "yyyy" format for java.util.Date supports a two year format but it is year 0 based,
+        // not based on the year of this century (ie "25" is year 25, not 2025)!
+        "01/01/00 00:00 Z"          || "0001-01-01T00:00:00Z" | "No time or timezone our format two digit year"
     }
 
     void 'asDate should fail to parse using the default format for case: #failureReason'() {

--- a/src/test/groovy/unit/org/pih/warehouse/utils/databinding/InstantValueConverterSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/utils/databinding/InstantValueConverterSpec.groovy
@@ -1,6 +1,5 @@
 package unit.org.pih.warehouse.utils.databinding
 
-import java.text.ParseException
 import java.time.format.DateTimeParseException
 import spock.lang.Shared
 import spock.lang.Specification

--- a/src/test/groovy/unit/org/pih/warehouse/utils/databinding/InstantValueConverterSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/utils/databinding/InstantValueConverterSpec.groovy
@@ -1,5 +1,7 @@
 package unit.org.pih.warehouse.utils.databinding
 
+import java.text.ParseException
+import java.time.format.DateTimeParseException
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -16,7 +18,7 @@ class InstantValueConverterSpec extends Specification {
         converter = new InstantValueConverter()
     }
 
-    void 'convertString should successfully parse in valid strings for case: #scenario'() {
+    void 'convertString should successfully parse valid strings for case: #scenario'() {
         expect:
         assert converter.convertString(givenDate).toString() == expectedConvertedDate
 
@@ -50,5 +52,20 @@ class InstantValueConverterSpec extends Specification {
         "2000-01-01T00:00:00+05"    || "1999-12-31T19:00:00Z" | "Timezone conforming to X format w/ positive"
         "2000-01-01T00:00:00+0500"  || "1999-12-31T19:00:00Z" | "Timezone conforming to XX format w/ positive"
         "2000-01-01T00:00:00+05:00" || "1999-12-31T19:00:00Z" | "Timezone conforming to XXX format w/ positive"
+    }
+
+    void 'convertString should fail to parse invalid strings for case: #failureReason'() {
+        when:
+        converter.convertString(givenDate)
+
+        then:
+        thrown(DateTimeParseException)
+
+        where:
+        givenDate     || failureReason
+        "2000-01-32"  || "day out of range"
+        "2000-13-01"  || "month out of range"
+        "10000-13-01" || "year out of range"
+        "00-01-01"    || "two digit year format not supported"
     }
 }

--- a/src/test/groovy/unit/org/pih/warehouse/utils/databinding/InstantValueConverterSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/utils/databinding/InstantValueConverterSpec.groovy
@@ -1,0 +1,54 @@
+package unit.org.pih.warehouse.utils.databinding
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import org.pih.warehouse.databinding.InstantValueConverter
+
+@Unroll
+class InstantValueConverterSpec extends Specification {
+
+    @Shared
+    InstantValueConverter converter
+
+    void setupSpec() {
+        converter = new InstantValueConverter()
+    }
+
+    void 'convertString should successfully parse in valid strings for case: #scenario'() {
+        expect:
+        assert converter.convertString(givenDate).toString() == expectedConvertedDate
+
+        where:
+        givenDate                   || expectedConvertedDate  | scenario
+        "2000-01-01T00:00:00.000Z"  || "2000-01-01T00:00:00Z" | "Full string in proper ISO format"
+        "2000-01-01T00:00:00.000"   || "2000-01-01T00:00:00Z" | "Full string, no timezone"
+        "2000-01-01T00:00:00.00"    || "2000-01-01T00:00:00Z" | "Shorter millis"
+        "2000-01-01T00:00:00.0"     || "2000-01-01T00:00:00Z" | "Shorter millis"
+        "2000-01-01T00:00:00"       || "2000-01-01T00:00:00Z" | "No millis"
+        "2000-01-01T00:00"          || "2000-01-01T00:00:00Z" | "No seconds"
+        "2000-01-01"                || "2000-01-01T00:00:00Z" | "No time"
+        "2000 01 01"                || "2000-01-01T00:00:00Z" | "Date with spaces"
+        "2000/01/01"                || "2000-01-01T00:00:00Z" | "Date with slashes"
+        "20000101"                  || "2000-01-01T00:00:00Z" | "Date with no separator"
+        "2000-01-01 00:00:00.000Z"  || "2000-01-01T00:00:00Z" | "Replace 'T' with space"
+        "2000-01-01T000000000Z"     || "2000-01-01T00:00:00Z" | "Time with no separator"
+        "2000-01-01T00000000Z"      || "2000-01-01T00:00:00Z" | "Time with no separator, shorter millis"
+        "2000-01-01T0000000Z"       || "2000-01-01T00:00:00Z" | "Time with no separator, shorter millis"
+        "2000-01-01T000000Z"        || "2000-01-01T00:00:00Z" | "Time with no separator, no millis"
+        "2000-01-01T0000Z"          || "2000-01-01T00:00:00Z" | "Time with no separator, no seconds"
+        "2000-01-01T00:00:00:000Z"  || "2000-01-01T00:00:00Z" | "Time with millis replace '.' with ':'"
+        "2000-01-01T00:00:00:00Z"   || "2000-01-01T00:00:00Z" | "Time with millis replace '.' with ':', shorter millis"
+        "2000-01-01T00:00:00:0Z"    || "2000-01-01T00:00:00Z" | "Time with millis replace '.' with ':', shorter millis"
+        "2000-01-01T00:00:00-05"    || "2000-01-01T05:00:00Z" | "Timezone conforming to X format w/ negative"
+        "2000-01-01T00:00:00-0500"  || "2000-01-01T05:00:00Z" | "Timezone conforming to XX format w/ negative"
+        "2000-01-01T00:00:00-05:00" || "2000-01-01T05:00:00Z" | "Timezone conforming to XXX format w/ negative"
+        "2000-01-01T00:00:00+00"    || "2000-01-01T00:00:00Z" | "Timezone conforming to X format w/ zero"
+        "2000-01-01T00:00:00+0000"  || "2000-01-01T00:00:00Z" | "Timezone conforming to XX format w/ zero"
+        "2000-01-01T00:00:00+00:00" || "2000-01-01T00:00:00Z" | "Timezone conforming to XXX format w/ zero"
+        "2000-01-01T00:00:00+05"    || "1999-12-31T19:00:00Z" | "Timezone conforming to X format w/ positive"
+        "2000-01-01T00:00:00+0500"  || "1999-12-31T19:00:00Z" | "Timezone conforming to XX format w/ positive"
+        "2000-01-01T00:00:00+05:00" || "1999-12-31T19:00:00Z" | "Timezone conforming to XXX format w/ positive"
+    }
+}

--- a/src/test/groovy/unit/org/pih/warehouse/utils/databinding/LocalDateValueConverterSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/utils/databinding/LocalDateValueConverterSpec.groovy
@@ -17,7 +17,7 @@ class LocalDateValueConverterSpec extends Specification {
         converter = new LocalDateValueConverter()
     }
 
-    void 'convertString should successfully parse in valid strings: #scenario'() {
+    void 'convertString should successfully parse valid strings for case: #scenario'() {
         expect:
         assert converter.convertString(givenDate).toString() == expectedResult
 
@@ -29,7 +29,7 @@ class LocalDateValueConverterSpec extends Specification {
         "20000101"   || "2000-01-01"   | "Date with no separator"
     }
 
-    void 'convertString should fail to parse invalid strings because: #failureReason'() {
+    void 'convertString should fail to parse invalid strings for case: #failureReason'() {
         when:
         converter.convertString(givenDate)
 
@@ -42,5 +42,6 @@ class LocalDateValueConverterSpec extends Specification {
         "2000-01-32"       || "day out of range"
         "2000-13-01"       || "month out of range"
         "10000-13-01"      || "year out of range"
+        "00-01-01"         || "two digit year format not supported"
     }
 }

--- a/src/test/groovy/unit/org/pih/warehouse/utils/databinding/LocalDateValueConverterSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/utils/databinding/LocalDateValueConverterSpec.groovy
@@ -1,0 +1,46 @@
+package unit.org.pih.warehouse.utils.databinding
+
+import java.time.format.DateTimeParseException
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import org.pih.warehouse.databinding.LocalDateValueConverter
+
+@Unroll
+class LocalDateValueConverterSpec extends Specification {
+
+    @Shared
+    LocalDateValueConverter converter
+
+    void setupSpec() {
+        converter = new LocalDateValueConverter()
+    }
+
+    void 'convertString should successfully parse in valid strings: #scenario'() {
+        expect:
+        assert converter.convertString(givenDate).toString() == expectedResult
+
+        where:
+        givenDate    || expectedResult | scenario
+        "2000-01-01" || "2000-01-01"   | "Date with dashes"
+        "2000 01 01" || "2000-01-01"   | "Date with spaces"
+        "2000/01/01" || "2000-01-01"   | "Date with slashes"
+        "20000101"   || "2000-01-01"   | "Date with no separator"
+    }
+
+    void 'convertString should fail to parse invalid strings because: #failureReason'() {
+        when:
+        converter.convertString(givenDate)
+
+        then:
+        thrown(DateTimeParseException)
+
+        where:
+        givenDate          || failureReason
+        "2000-01-01T00:00" || "LocalDate should have no time component"
+        "2000-01-32"       || "day out of range"
+        "2000-13-01"       || "month out of range"
+        "10000-13-01"      || "year out of range"
+    }
+}


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6965

**Description:**

Add support for java.time.Instant and java.time.LocalDate data binding. With this change we can now use those data types in our Domain classes and DTO/Command objects. This is important because java.util.Date is functionally deprecated as of Java 8, so going forward we should stop using it if possible.

See my other PR for an example implementation that uses this change: https://github.com/openboxes/openboxes/pull/5022

This is based off [the discovery work I did on java.time in OBPIH-6916](https://pihemr.atlassian.net/wiki/spaces/OB/pages/3382542337/OBPIH-6916+Standardizing+datetime+parsing). I encourage you to read that if you want some background information on this change.