### PR TITLE
OBPIH-6940 Adjust display of product name in cycle count tables to 2 rows only (to resolve tab)

### DIFF
--- a/src/js/hooks/cycleCount/useToResolveTab.jsx
+++ b/src/js/hooks/cycleCount/useToResolveTab.jsx
@@ -158,10 +158,14 @@ const useToResolveTab = ({
       ),
       cell: ({ getValue, row }) => (
         <TableCell
+          tooltip
+          tooltipLabel={getValue()}
           link={INVENTORY_ITEM_URL.showStockCard(row.original.product.id)}
           className="rt-td multiline-cell"
         >
-          {getValue()}
+          <div className="limit-lines-2">
+            {getValue()}
+          </div>
         </TableCell>
       ),
     }),


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:**

**Description:**


---
### :camera: Screenshots & Recordings (optional)

> *If this PR contains a UI change, consider adding one or more screenshots here or link to a screen recording to help reviewers visualize the change. Otherwise, you can remove this section.*
