### PR TITLE
User timezone not taken into account when displaying timestamps (fixes #5038)

### DIFF
--- a/grails-app/taglib/org/pih/warehouse/FormatTagLib.groovy
+++ b/grails-app/taglib/org/pih/warehouse/FormatTagLib.groovy
@@ -26,6 +26,10 @@ class FormatTagLib {
     def date = { attrs, body ->
         if (attrs.obj != null) {
             DateFormat df = new SimpleDateFormat((attrs.format) ?: Constants.DEFAULT_DATE_FORMAT)
+            TimeZone tz = session.timezone
+            if (tz != null) {
+                df.setTimeZone(tz)
+            }
             out << df.format(attrs.obj)
         }
     }


### PR DESCRIPTION
This PR attempts to fix a bug (#5038) we noticed recently while performing a discovery on migrating our datetime dependencies from java.util to java.time.

Note: We'll end up consolidating the logic around displaying datetimes later. This is just to fix an annoying bug as unobtrusively as possible.


