### PR TITLE
Default logo returns a 404 error (fixes #5041)

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -570,7 +570,7 @@ openboxes:
 
     # Allow users to customize logo image url as well as label
     logo:
-        url: "/assets/openboxes_logo_40x40.jpg"
+        url: "${server.contextPath}/assets/openboxes_logo_40x40.jpg"
         label: ""
     report:
         logo:


### PR DESCRIPTION
Fixed a long-standing bug with 0.9.x releases where the default configuration leads to a 404 error when rendering the default logo. See #5041 for more information.

This was tested locally using grails run-app, but I have not tested this as part of an actual deployment. If we encounter any issues with this approach, I'm going to hard-code the context path. 