### PR TITLE
OBS-1831 Fix unparseable date: "01/01/2025 " exception during stock movements

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -204,16 +204,17 @@ grails:
         # We now use the java.time classes instead (ex: Instant, LocalDate). Those fields define their own
         # ValueConverter classes and so don't use the formats defined here.
         dateFormats:
-            # Old date formats, don't use going forward! Kept first in the list to maintain backwards compatability.
+            # Date formats used by Excel and our old APIs. Kept first in the list to maintain backwards compatability.
             - 'MM/dd/yyyy HH:mm:ss XXX'
             - 'MM/dd/yyyy HH:mm:ss XX'
             - 'MM/dd/yyyy HH:mm:ss X'
             - 'MM/dd/yyyy HH:mm XXX'
             - 'MM/dd/yyyy HH:mm XX'
             - 'MM/dd/yyyy HH:mm X'
-            # Note that if this format is given, Grails will treat it as midnight in the local server timezone, which
-            # is ahead of UTC, can cause the date to actually be the next day. It can also cause inconsistencies across
-            # hosts/environments if they're configured for different local timezones. Avoid this format going forward!
+            # Note that Grails will treat this format as midnight in the local server timezone. For zones that are
+            # ahead of UTC, this can cause the date to actually become the next day. It can also cause
+            # inconsistencies across hosts/environments if they're configured for different local timezones.
+            # Avoid using this format going forward! Only kept to maintain backwards compatability.
             - 'MM/dd/yyyy'
             # ISO-8601 formats. These are better than the old formats, but new APIs should still use Instant instead
             # of Date whenever possible. Note that a format without time and timezone is NOT allowed here because that

--- a/grails-app/controllers/org/pih/warehouse/api/StockMovementApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/StockMovementApiController.groovy
@@ -14,7 +14,6 @@ import org.grails.web.json.JSONObject
 
 import org.pih.warehouse.DateUtil
 import org.pih.warehouse.core.ActivityCode
-import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.DocumentService
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.RoleType
@@ -361,14 +360,6 @@ class StockMovementApiController {
         render([data: pendingRequisitionDetails] as JSON)
     }
 
-    private Date parseDateRequested(String date) {
-        return DateUtil.asDate(date, Constants.EXPIRATION_DATE_FORMATTER)
-    }
-
-    private Date parseDateShipped(String date) {
-        return DateUtil.asDate(date, Constants.DELIVERY_DATE_FORMATTER)
-    }
-
     private void bindStockMovement(StockMovement stockMovement, JSONObject jsonObject) {
         // Remove attributes that cause issues in the default grails data binder
         List lineItems = jsonObject.remove("lineItems")
@@ -376,11 +367,11 @@ class StockMovementApiController {
 
         // Dates aren't bound properly using default JSON binding
         if (jsonObject.containsKey("dateShipped")) {
-            stockMovement.dateShipped = parseDateShipped(jsonObject.remove("dateShipped"))
+            stockMovement.dateShipped = DateUtil.asDate(jsonObject.remove("dateShipped") as String)
         }
 
         if (jsonObject.containsKey("dateRequested")) {
-            stockMovement.dateRequested = parseDateRequested(jsonObject.remove("dateRequested"))
+            stockMovement.dateRequested = DateUtil.asDate(jsonObject.remove("dateRequested") as String)
         }
 
         // If the stocklist.id key is present and empty, then we need to remove the stocklist from the stock movement
@@ -449,8 +440,7 @@ class StockMovementApiController {
             // FIXME Lookup inventory item by product, lot number, expiration date
             stockMovementItem.inventoryItem = lineItem?.inventoryItem?.id ? InventoryItem.load(lineItem?.inventoryItem?.id) : null
             stockMovementItem.lotNumber = lineItem["lotNumber"]
-            stockMovementItem.expirationDate = (!isNull(lineItem["expirationDate"])) ?
-                    Constants.EXPIRATION_DATE_FORMATTER.parse(lineItem["expirationDate"]) : null
+            stockMovementItem.expirationDate = DateUtil.asDate(lineItem["expirationDate"] as String)
 
             // Sort order (optional)
             stockMovementItem.sortOrder = lineItem.sortOrder && !lineItem.isNull("sortOrder") ? new Integer(lineItem.sortOrder) : null

--- a/grails-app/utils/org/pih/warehouse/databinding/DataBindingConstants.groovy
+++ b/grails-app/utils/org/pih/warehouse/databinding/DataBindingConstants.groovy
@@ -1,13 +1,18 @@
 package org.pih.warehouse.databinding
 
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.ChronoField
+
 /**
  * Constants relating to binding request input strings to objects.
  */
 class DataBindingConstants {
 
     /*
-     * Patterns that follow the ISO-8601 + RPC 3339 date formats while allowing for some slight variation in
-     * the pattern.
+     * Patterns that follow the ISO-8601 + RPC 3339 date formats while allowing for slight variation in the pattern
+     * for the sake of flexibility. For example, we also allow MM/dd/yyyy, which is the default date format for Excel.
      *
      * Ex: "2000-01-01", "2000/01/01", "20000101" are all valid strings according to FLEXIBLE_DATE_PATTERN.
      * Ex: both "2000-01-01" and "2000-01-01T00:00:00Z" are valid strings according to FLEXIBLE_DATE_TIME_ZONE_PATTERN.
@@ -22,7 +27,7 @@ class DataBindingConstants {
      * requires time and timezone information, and so FLEXIBLE_DATE_TIME_ZONE_PATTERN will fail to parse "2000-01-01"
      * unless the associated DateTimeFormatter provides a default for time and zone (via "parseDefaulting").
      */
-    static final String FLEXIBLE_DATE_PATTERN = "[yyyy-MM-dd][yyyy/MM/dd][yyyy MM dd][yyyyMMdd]"
+    static final String FLEXIBLE_DATE_PATTERN = "[yyyy-MM-dd][MM/dd/yyyy][yyyy/MM/dd][yyyy MM dd][yyyyMMdd]"
     static final String FLEXIBLE_TIME_PATTERN =
             "[HH:mm:ss.SSS][HH:mm:ss:SSS][HHmmssSSS]" +
             "[HH:mm:ss.SS][HH:mm:ss:SS][HHmmssSS]" +
@@ -30,5 +35,19 @@ class DataBindingConstants {
             "[HH:mm:ss][HHmmss]" +
             "[HH:mm][HHmm]"
     static final String FLEXIBLE_DATE_TIME_ZONE_PATTERN =
-            "${FLEXIBLE_DATE_PATTERN}[['T'][ ]${FLEXIBLE_TIME_PATTERN}][[XXX][XX][X]]"
+            "${FLEXIBLE_DATE_PATTERN}[['T'][ ]${FLEXIBLE_TIME_PATTERN}][[ ][XXX][XX][X]]"
+
+    /**
+     * DateTimeFormatter used to parse a String to a datetime class, such as java.time.Instant.
+     */
+    static final DateTimeFormatter FLEXIBLE_DATE_TIME_ZONE_FORMAT = new DateTimeFormatterBuilder()
+            .appendPattern(DataBindingConstants.FLEXIBLE_DATE_TIME_ZONE_PATTERN)
+            // Defaults to 00:00:00.000 if time is not provided in the String
+            .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+            .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+            .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+            .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0)
+            // Defaults to UTC if timezone is not provided in the String
+            .parseDefaulting(ChronoField.OFFSET_SECONDS, ZoneOffset.UTC.getTotalSeconds())
+            .toFormatter()
 }

--- a/grails-app/utils/org/pih/warehouse/databinding/InstantValueConverter.groovy
+++ b/grails-app/utils/org/pih/warehouse/databinding/InstantValueConverter.groovy
@@ -1,10 +1,6 @@
 package org.pih.warehouse.databinding
 
 import java.time.Instant
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeFormatterBuilder
-import java.time.temporal.ChronoField
 import org.apache.commons.lang.StringUtils
 import org.springframework.stereotype.Component
 
@@ -15,17 +11,6 @@ import org.springframework.stereotype.Component
  */
 @Component
 class InstantValueConverter extends StringValueConverter<Instant> {
-
-    private static final DateTimeFormatter FLEXIBLE_DATE_TIME_ZONE_FORMAT = new DateTimeFormatterBuilder()
-            .appendPattern(DataBindingConstants.FLEXIBLE_DATE_TIME_ZONE_PATTERN)
-            // Defaults to 00:00:00.000 if time is not provided in the String
-            .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
-            .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
-            .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
-            .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0)
-            // Defaults to UTC if timezone is not provided in the String
-            .parseDefaulting(ChronoField.OFFSET_SECONDS, ZoneOffset.UTC.getTotalSeconds())
-            .toFormatter()
 
     /**
      * Binds a given user-input String to an Instant.
@@ -48,6 +33,6 @@ class InstantValueConverter extends StringValueConverter<Instant> {
     Instant convertString(String value) {
         return StringUtils.isBlank(value) ?
                 null :
-                Instant.from(FLEXIBLE_DATE_TIME_ZONE_FORMAT.parse(value.trim()))
+                Instant.from(DataBindingConstants.FLEXIBLE_DATE_TIME_ZONE_FORMAT.parse(value.trim()))
     }
 }

--- a/src/main/groovy/org/pih/warehouse/core/Constants.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/Constants.groovy
@@ -25,8 +25,9 @@ class Constants {
     static final adminControllers = ['createProduct', 'admin']
     static final adminActions = ['product': ['create'], 'person': ['list'], 'user': ['list'], 'location': ['edit'], 'shipper': ['create'], 'locationGroup': ['create'], 'locationType': ['create'], '*': ['delete']]
 
-    // TODO: Don't add more dates here! We should refactor all usages of these constants to instead use the
-    //       DateTimeFormatter constants in DateUtil. The backend should always return dates in the same format so that
+    // TODO: Don't add more dates here! We should refactor all backend usages (old gsp pages can continue using these)
+    //       of these constants to use the DateUtil.asDate(String) method to parse in Date types and then return Date
+    //       objects unformatted in our responses. The backend should always return dates in the same format so that
     //       the frontend can easily parse response objects. Let the frontend decide what the display format of each
     //       individual field should be.
     static final String DEFAULT_YEAR_FORMAT = "yyyy"

--- a/src/test/groovy/unit/org/pih/warehouse/utils/DateUtilSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/utils/DateUtilSpec.groovy
@@ -1,11 +1,11 @@
 package unit.org.pih.warehouse.utils
 
-import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
+import java.time.format.DateTimeParseException
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -51,15 +51,13 @@ class DateUtilSpec extends Specification {
         "01/01/2000 00:00 +0500"    || "1999-12-31T19:00:00Z" | "Timezone conforming to XX format w/ positive our format"
         "01/01/2000 00:00 +05:00"   || "1999-12-31T19:00:00Z" | "Timezone conforming to XXX format w/ positive our format"
 
-        // This case fails because when no timezone is provided to Date, it uses the system local timezone instead of
-        // UTC. This can cause unexpected behaviour! Adding "TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC))"
-        // to Bootstrap.groovy will change the default to always be UTC. This fixes the issue by making the behaviour
-        // consistent (and would allow us to re-enable this test).
-        //"01/01/2000"                || "2000-01-01T00:00:00Z" | "No time or timezone our format"
+        // When not given a timezone, we default to UTC.
+        "01/01/2000 00:00"          || "2000-01-01T00:00:00Z" | "No timezone our format"
+        "2000-01-01 00:00"          || "2000-01-01T00:00:00Z" | "No timezone ISO format"
 
-        // It's noteworthy that the "yyyy" format for java.util.Date supports a two year format but it is year 0 based,
-        // not based on the year of this century (ie "25" is year 25, not 2025)!
-        "01/01/00 00:00 Z"          || "0001-01-01T00:00:00Z" | "No time or timezone our format two digit year"
+        // When not given a time or timezone, we default to midnight UTC.
+        "01/01/2000"                || "2000-01-01T00:00:00Z" | "No time or timezone our format"
+        "2000-01-01"                || "2000-01-01T00:00:00Z" | "No time or timezone ISO format"
     }
 
     void 'asDate should fail to parse using the default format for case: #failureReason'() {
@@ -67,11 +65,12 @@ class DateUtilSpec extends Specification {
         DateUtil.asDate(givenDate)
 
         then:
-        thrown(ParseException)
+        thrown(DateTimeParseException)
 
         where:
         givenDate    || failureReason
         "01 01 2000" || "spaces not supported as separator"
+        "01/01/00"   || "two digit year format not supported"
     }
 
     void 'asInstant should successfully convert a Date to an Instant for case: #scenario'() {
@@ -86,12 +85,6 @@ class DateUtilSpec extends Specification {
         "Sat, 01 Jan 2000 00:00:00 UTC"    || "2000-01-01T00:00:00Z" | "UTC timezone"
         "Sat, 01 Jan 2000 00:00:00 UTC+05" || "1999-12-31T19:00:00Z" | "timezone ahead of UTC"
         "Sat, 01 Jan 2000 00:00:00 UTC-05" || "2000-01-01T05:00:00Z" | "timezone behind UTC"
-
-        // This case fails because when no timezone is provided to Date, it uses the system local timezone instead of
-        // UTC. This can cause unexpected behaviour! Adding "TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC))"
-        // to Bootstrap.groovy will change the default to always be UTC. This fixes the issue by making the behaviour
-        // consistent (and would allow us to re-enable this test).
-        //"Sat, 01 Jan 2000 00:00:00"        || "2000-01-01T00:00:00Z" | "no timezone given"
     }
 
     void 'asInstant should successfully convert a ZonedDateTime to an Instant for case: #scenario'() {
@@ -151,11 +144,5 @@ class DateUtilSpec extends Specification {
         "Sat, 01 Jan 2000 00:00:00 UTC"    || "2000-01-01T00:00Z"   | "UTC timezone"
         "Sat, 01 Jan 2000 00:00:00 UTC+05" || "1999-12-31T19:00Z"   | "timezone ahead of UTC"
         "Sat, 01 Jan 2000 00:00:00 UTC-05" || "2000-01-01T05:00Z"   | "timezone behind UTC"
-
-        // This case fails because when no timezone is provided to Date, it uses the system local timezone instead of
-        // UTC. This can cause unexpected behaviour! Adding "TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC))"
-        // to Bootstrap.groovy will change the default to always be UTC. This fixes the issue by making the behaviour
-        // consistent (and would allow us to re-enable this test).
-        //"Sat, 01 Jan 2000 00:00:00"        || "2000-01-01T00:00Z"   | "no timezone given"
     }
 }

--- a/src/test/groovy/unit/org/pih/warehouse/utils/databinding/InstantValueConverterSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/utils/databinding/InstantValueConverterSpec.groovy
@@ -24,6 +24,7 @@ class InstantValueConverterSpec extends Specification {
         where:
         givenDate                   || expectedConvertedDate  | scenario
         "2000-01-01T00:00:00.000Z"  || "2000-01-01T00:00:00Z" | "Full string in proper ISO format"
+        "2000-01-01T00:00:00.000 Z" || "2000-01-01T00:00:00Z" | "Full string, space before timezone"
         "2000-01-01T00:00:00.000"   || "2000-01-01T00:00:00Z" | "Full string, no timezone"
         "2000-01-01T00:00:00.00"    || "2000-01-01T00:00:00Z" | "Shorter millis"
         "2000-01-01T00:00:00.0"     || "2000-01-01T00:00:00Z" | "Shorter millis"
@@ -32,6 +33,7 @@ class InstantValueConverterSpec extends Specification {
         "2000-01-01"                || "2000-01-01T00:00:00Z" | "No time"
         "2000 01 01"                || "2000-01-01T00:00:00Z" | "Date with spaces"
         "2000/01/01"                || "2000-01-01T00:00:00Z" | "Date with slashes"
+        "01/01/2000"                || "2000-01-01T00:00:00Z" | "Date with slashes, Excel format"
         "20000101"                  || "2000-01-01T00:00:00Z" | "Date with no separator"
         "2000-01-01 00:00:00.000Z"  || "2000-01-01T00:00:00Z" | "Replace 'T' with space"
         "2000-01-01T000000000Z"     || "2000-01-01T00:00:00Z" | "Time with no separator"


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:**
- https://pihemr.atlassian.net/browse/OBS-1831
- https://pihemr.atlassian.net/browse/OBS-1815

**Description:** This change switches the parsing of dateShipped and dateRequested fields during stock movements to use the new DateUtil.asDate method (with no SimpleDateFormat provided so that it uses the flexible format).

I also modified how the method works so that it uses the same DateTimeFormatter that we use when parsing a String to an Instant. That way it gets around the issue with parsing "MM/dd/yyyy" and defaulting to the local timezone (now it always uses UTC).

---
### :camera: Screenshots & Recordings (optional)

![image-20241120-211537](https://github.com/user-attachments/assets/25973f2d-4600-4b26-bf04-87bf359ab6f8)

