### PR TITLE
OBPIH-6939 Show minimum of cycle count date and inventory in Last Counted date column

### DIFF
--- a/grails-app/migrations/views/changelog.xml
+++ b/grails-app/migrations/views/changelog.xml
@@ -107,6 +107,19 @@
   <changeSet id="1580848680306-30" author="awalkowiak" runOnChange="true" runAlways="true" failOnError="true">
     <sqlFile path="views/order-item-details.sql"/>
   </changeSet>
+  <!-- views used by the cycle count feature -->
+  <changeSet id="1740696149645-1" author="jmiranda" runOnChange="true" runAlways="true" failOnError="true">
+    <sqlFile path="views/product-cycle-count-history.sql"/>
+  </changeSet>
+  <changeSet id="1740696149645-2" author="jmiranda" runOnChange="true" runAlways="true" failOnError="true">
+    <sqlFile path="views/product-physical-count-history.sql"/>
+  </changeSet>
+  <changeSet id="1740696149645-3" author="jmiranda" runOnChange="true" runAlways="true" failOnError="true">
+    <sqlFile path="views/product-receipt-history.sql"/>
+  </changeSet>
+  <changeSet id="1740696149645-4" author="jmiranda" runOnChange="true" runAlways="true" failOnError="true">
+    <sqlFile path="views/product-count-history.sql"/>
+  </changeSet>
   <changeSet id="1580848680306-31" author="kchelstowski" runOnChange="true" runAlways="true" failOnError="true">
     <sqlFile path="views/cycle-count-session.sql"/>
   </changeSet>

--- a/grails-app/migrations/views/cycle-count-session.sql
+++ b/grails-app/migrations/views/cycle-count-session.sql
@@ -11,10 +11,16 @@ SELECT
     cycle_count_request_summary.cycle_count_request_id                               as cycle_count_request_id,
 
     -- ABC Classification
-    MAX(COALESCE(inventory_level_summary.abc_class, product.abc_class))              as abc_class,
+    -- FIXME Using a grouping operator due to a GROUP BY issue. This isn't the best approach sicne it'll return an
+    --  empty string or NULL value ahead of valid ABC classes (A, B, C, etc). But I don't have a better solution and
+    --  this will likely work for 99% of cases.
+    MIN(COALESCE(inventory_level_summary.abc_class, product.abc_class))              as abc_class,
 
     -- Status of any pending cycle counts
     -- Consolidate the statuses down to a single field representing the status of the candidate itself.
+    -- FIXME Using a grouping operator because the SQL is invalid otherwise. There's probably a better way to handle
+    --  this (perhaps pulling this into a separate domain that can be joined to the CycleCountSession when needed for
+    --  certain queries).
     MAX(cycle_count_request_summary.status)                                          as status,
 
     # Inventory Item Count

--- a/grails-app/migrations/views/cycle-count-session.sql
+++ b/grails-app/migrations/views/cycle-count-session.sql
@@ -1,40 +1,56 @@
-CREATE OR REPLACE VIEW cycle_count_session AS (
-	SELECT
-		# ID hash of product.id and location.id
-		CRC32(CONCAT(location.id, product.id)) as id,
-        inventory.id as inventory_id,
-		product.id as product_id,
-		location.id as facility_id,
-        cycle_count_request.id as cycle_count_request_id,
-        COALESCE(inventory_level.abc_class, product.abc_class) as abc_class,
+CREATE OR REPLACE VIEW cycle_count_session AS
+(
+SELECT
+    # ID hash of product.id and location.id
+    CRC32(CONCAT(location.id, product.id))                                       as id,
+    inventory.id                                                                 as inventory_id,
+    product.id                                                                   as product_id,
+    location.id                                                                  as facility_id,
+    #cycle_count_request.id as cycle_count_request_id,
+    NULL                                                                         as cycle_count_request_id,
+    COALESCE(inventory_level_summary.abc_class, product.abc_class)                       as abc_class,
 
-        # Consolidate the statuses down to a single field representing the status of the candidate itself.
-        COALESCE(cycle_count.status, cycle_count_request.status) as status,
+    # Consolidate the statuses down to a single field representing the status of the candidate itself.
+    NULL                                                                         as status, # COALESCE(cycle_count.status, cycle_count_request.status) as status,
 
-		# Inventory Item Count
-		count(*) as inventory_item_count,
+    # Inventory Item Count
+    count(product_availability.id)                                               as inventory_item_count,
 
-		# Comma-separated list of internal locations
-		GROUP_CONCAT(DISTINCT product_availability.bin_location_name) as internal_locations,
+    # Comma-separated list of internal locations
+    GROUP_CONCAT(DISTINCT product_availability.bin_location_name)                as internal_locations,
 
-		# Quantities by SKU
-		sum(product_availability.quantity_on_hand) as quantity_on_hand,
-		sum(product_availability.quantity_available_to_promise) as quantity_available,
+    # Quantities by SKU
+    sum(product_availability.quantity_on_hand)                                   as quantity_on_hand,
+    sum(product_availability.quantity_available_to_promise)                      as quantity_available,
 
-        # Stuff we need to include now or wait for the materialized view
-		NULL as negative_item_count,
-		NULL as date_last_count,
-		NULL as date_next_count,
-		NULL as date_latest_inventory
-	FROM product_availability
-	JOIN location on product_availability.location_id = location.id
-	JOIN product on product_availability.product_id = product.id
-	JOIN inventory on location.inventory_id = inventory.id
-    LEFT OUTER JOIN inventory_level on product.id = inventory_level.product_id AND inventory.id = inventory_level.inventory_id
-    LEFT OUTER JOIN cycle_count_request ON product.id = cycle_count_request.product_id AND location.id = cycle_count_request.facility_id
-    LEFT OUTER JOIN cycle_count ON cycle_count_request.cycle_count_id = cycle_count.id
-    WHERE product_availability.quantity_on_hand > 0
-       AND (cycle_count_request.id IS NULL OR (cycle_count_request.status <> 'COMPLETED' AND cycle_count_request.status <> 'CANCELED'))
-	GROUP BY location.id, product.id, abc_class, cycle_count_request.id
-    ORDER BY abc_class, inventory_item_count desc
-);
+    # Stuff we need to include now or wait for the materialized view
+    -- Negative item count
+    (SELECT SUM(CASE WHEN pai.quantity_on_hand < 0 THEN 1 ELSE 0 END)
+     FROM product_availability pai
+     WHERE pai.product_id = product_availability.product_id
+       AND pai.location_id = product_availability.location_id)                   as negative_item_count,
+
+    (select date_counted
+     from product_count_history
+     where product_count_history.product_id = product_availability.product_id
+       and product_count_history.facility_id = product_availability.location_id) as date_last_count,
+
+    NULL                                                                         as date_next_count,
+    NULL                                                                         as date_latest_inventory
+FROM product_availability
+         JOIN location on product_availability.location_id = location.id
+         JOIN inventory on location.inventory_id = inventory.id
+         JOIN product on product_availability.product_id = product.id
+    # FIXME need to add a unique constraint to prevent duplicate inventory levels for a single facility / product
+    # Using min(abc_class) means we'll return the highest value if there are multiple inventory levels with different abc classes (A, B, C)
+         LEFT OUTER JOIN (select inventory_id, product_id, min(abc_class) as abc_class
+                          from inventory_level where inventory_level.internal_location_id IS NULL
+                          group by inventory_id, product_id) as inventory_level_summary
+                         ON product_availability.product_id = inventory_level_summary.product_id AND inventory.id = inventory_level_summary.inventory_id
+    # FIXME need to add the status as a subquery or a
+        #LEFT OUTER JOIN cycle_count_request ON product.id = cycle_count_request.product_id AND location.id = cycle_count_request.facility_id
+        #   AND (cycle_count_request.id IS NULL OR (cycle_count_request.status <> 'COMPLETED' AND cycle_count_request.status <> 'CANCELED'))
+GROUP BY location.id, product.id
+HAVING sum(product_availability.quantity_on_hand) > 0
+ORDER BY NULL
+    );

--- a/grails-app/migrations/views/cycle-count-session.sql
+++ b/grails-app/migrations/views/cycle-count-session.sql
@@ -7,7 +7,7 @@ SELECT
     product.id                                                                   as product_id,
     location.id                                                                  as facility_id,
 
-    -- Cycle count request ID (deprecated)
+    -- Cycle count request ID
     cycle_count_request_summary.cycle_count_request_id as cycle_count_request_id,
 
     -- ABC Classification

--- a/grails-app/migrations/views/cycle-count-session.sql
+++ b/grails-app/migrations/views/cycle-count-session.sql
@@ -2,73 +2,75 @@ CREATE OR REPLACE VIEW cycle_count_session AS
 (
 SELECT
     # ID hash of product.id and location.id
-    CRC32(CONCAT(location.id, product.id))                                       as id,
-    location.inventory_id                                                                 as inventory_id,
-    product.id                                                                   as product_id,
-    location.id                                                                  as facility_id,
+    CRC32(CONCAT(product_availability.location_id, product_availability.product_id)) as id,
+    location.inventory_id                                                            as inventory_id,
+    product_availability.product_id                                                  as product_id,
+    product_availability.location_id                                                 as facility_id,
 
     -- Cycle count request ID
-    cycle_count_request_summary.cycle_count_request_id as cycle_count_request_id,
+    cycle_count_request_summary.cycle_count_request_id                               as cycle_count_request_id,
 
     -- ABC Classification
-    COALESCE(inventory_level_summary.abc_class, product.abc_class)               as abc_class,
+    MAX(COALESCE(inventory_level_summary.abc_class, product.abc_class))              as abc_class,
 
     -- Status of any pending cycle counts
     -- Consolidate the statuses down to a single field representing the status of the candidate itself.
-    cycle_count_request_summary.status as status,
+    MAX(cycle_count_request_summary.status)                                          as status,
 
     # Inventory Item Count
-    count(product_availability.id)                                               as inventory_item_count,
+    count(product_availability.id)                                                   as inventory_item_count,
 
     # Comma-separated list of internal locations
-    GROUP_CONCAT(DISTINCT product_availability.bin_location_name)                as internal_locations,
+    GROUP_CONCAT(DISTINCT product_availability.bin_location_name)                    as internal_locations,
 
     # Quantities by SKU
-    sum(product_availability.quantity_on_hand)                                   as quantity_on_hand,
-    sum(product_availability.quantity_available_to_promise)                      as quantity_available,
+    sum(product_availability.quantity_on_hand)                                       as quantity_on_hand,
+    sum(product_availability.quantity_available_to_promise)                          as quantity_available,
 
     # Stuff we need to include now or wait for the materialized view
     -- Negative item count
     (SELECT SUM(CASE WHEN pai.quantity_on_hand < 0 THEN 1 ELSE 0 END)
      FROM product_availability pai
      WHERE pai.product_id = product_availability.product_id
-       AND pai.location_id = product_availability.location_id)                   as negative_item_count,
+       AND pai.location_id = product_availability.location_id)                       as negative_item_count,
 
     -- Date last counted
-    (select date_counted
+    (select max(date_counted)
      from product_count_history
      where product_count_history.product_id = product_availability.product_id
-       and product_count_history.inventory_id = location.inventory_id) as date_last_count,
+       and product_count_history.inventory_id = location.inventory_id
+     group by inventory_id, product_id)                                              as date_last_count,
 
-    NULL                                                                         as date_next_count,
-    NULL                                                                         as date_latest_inventory
+    NULL                                                                             as date_next_count,
+    NULL                                                                             as date_latest_inventory
 FROM product_availability
          JOIN location on product_availability.location_id = location.id
          JOIN product ON product_availability.product_id = product.id
     # FIXME need to add a unique constraint to prevent duplicate inventory levels for a single facility / product
     # Using min(abc_class) means we'll return the highest value if there are multiple inventory levels with different abc classes (A, B, C)
-        LEFT OUTER JOIN (select
-                              inventory_id,
-                              product_id,
-                              min(abc_class) as abc_class
-                          from inventory_level where inventory_level.internal_location_id IS NULL
+         LEFT OUTER JOIN (select inventory_id,
+                                 product_id,
+                                 min(abc_class) as abc_class
+                          from inventory_level
+                          where inventory_level.internal_location_id IS NULL
                           group by inventory_id, product_id) as inventory_level_summary
-                         ON product_availability.product_id = inventory_level_summary.product_id AND location.inventory_id = inventory_level_summary.inventory_id
+                         ON product_availability.product_id = inventory_level_summary.product_id AND
+                            location.inventory_id = inventory_level_summary.inventory_id
 
-        LEFT OUTER JOIN (select cycle_count_request.facility_id                          as facility_id,
-                                cycle_count_request.product_id                           as product_id,
-                                cycle_count_request.id                                   as cycle_count_request_id,
-                                COALESCE(cycle_count.status, cycle_count_request.status) as status
-                         from cycle_count_request
-                                  left outer join cycle_count on cycle_count_request.cycle_count_id = cycle_count.id
-                         where cycle_count_request.id IS NULL
-                            OR (cycle_count_request.status <> 'COMPLETED'
-                                    AND cycle_count_request.status <> 'CANCELED')) as cycle_count_request_summary
-            on cycle_count_request_summary.product_id = product_availability.product_id
-                   and cycle_count_request_summary.facility_id = product_availability.location_id
+         LEFT OUTER JOIN (select cycle_count_request.facility_id                          as facility_id,
+                                 cycle_count_request.product_id                           as product_id,
+                                 cycle_count_request.id                                   as cycle_count_request_id,
+                                 COALESCE(cycle_count.status, cycle_count_request.status) as status
+                          from cycle_count_request
+                                   left outer join cycle_count on cycle_count_request.cycle_count_id = cycle_count.id
+                          where cycle_count_request.id IS NULL
+                             OR (cycle_count_request.status <> 'COMPLETED'
+                              AND cycle_count_request.status <> 'CANCELED')) as cycle_count_request_summary
+                         on cycle_count_request_summary.product_id = product_availability.product_id
+                             and cycle_count_request_summary.facility_id = product_availability.location_id
 
 
-GROUP BY product_availability.location_id, product_availability.product_id
+GROUP BY product_availability.location_id, product_availability.product_id, location.inventory_id
 HAVING sum(product_availability.quantity_on_hand) > 0
 ORDER BY NULL
     );

--- a/grails-app/migrations/views/cycle-count-session.sql
+++ b/grails-app/migrations/views/cycle-count-session.sql
@@ -3,15 +3,19 @@ CREATE OR REPLACE VIEW cycle_count_session AS
 SELECT
     # ID hash of product.id and location.id
     CRC32(CONCAT(location.id, product.id))                                       as id,
-    inventory.id                                                                 as inventory_id,
+    location.inventory_id                                                                 as inventory_id,
     product.id                                                                   as product_id,
     location.id                                                                  as facility_id,
-    #cycle_count_request.id as cycle_count_request_id,
-    NULL                                                                         as cycle_count_request_id,
-    COALESCE(inventory_level_summary.abc_class, product.abc_class)                       as abc_class,
 
-    # Consolidate the statuses down to a single field representing the status of the candidate itself.
-    NULL                                                                         as status, # COALESCE(cycle_count.status, cycle_count_request.status) as status,
+    -- Cycle count request ID (deprecated)
+    cycle_count_request_summary.cycle_count_request_id as cycle_count_request_id,
+
+    -- ABC Classification
+    COALESCE(inventory_level_summary.abc_class, product.abc_class)               as abc_class,
+
+    -- Status of any pending cycle counts
+    -- Consolidate the statuses down to a single field representing the status of the candidate itself.
+    cycle_count_request_summary.status as status,
 
     # Inventory Item Count
     count(product_availability.id)                                               as inventory_item_count,
@@ -30,27 +34,41 @@ SELECT
      WHERE pai.product_id = product_availability.product_id
        AND pai.location_id = product_availability.location_id)                   as negative_item_count,
 
+    -- Date last counted
     (select date_counted
      from product_count_history
      where product_count_history.product_id = product_availability.product_id
-       and product_count_history.facility_id = product_availability.location_id) as date_last_count,
+       and product_count_history.inventory_id = location.inventory_id) as date_last_count,
 
     NULL                                                                         as date_next_count,
     NULL                                                                         as date_latest_inventory
 FROM product_availability
          JOIN location on product_availability.location_id = location.id
-         JOIN inventory on location.inventory_id = inventory.id
-         JOIN product on product_availability.product_id = product.id
+         JOIN product ON product_availability.product_id = product.id
     # FIXME need to add a unique constraint to prevent duplicate inventory levels for a single facility / product
     # Using min(abc_class) means we'll return the highest value if there are multiple inventory levels with different abc classes (A, B, C)
-         LEFT OUTER JOIN (select inventory_id, product_id, min(abc_class) as abc_class
+        LEFT OUTER JOIN (select
+                              inventory_id,
+                              product_id,
+                              min(abc_class) as abc_class
                           from inventory_level where inventory_level.internal_location_id IS NULL
                           group by inventory_id, product_id) as inventory_level_summary
-                         ON product_availability.product_id = inventory_level_summary.product_id AND inventory.id = inventory_level_summary.inventory_id
-    # FIXME need to add the status as a subquery or a
-        #LEFT OUTER JOIN cycle_count_request ON product.id = cycle_count_request.product_id AND location.id = cycle_count_request.facility_id
-        #   AND (cycle_count_request.id IS NULL OR (cycle_count_request.status <> 'COMPLETED' AND cycle_count_request.status <> 'CANCELED'))
-GROUP BY location.id, product.id
+                         ON product_availability.product_id = inventory_level_summary.product_id AND location.inventory_id = inventory_level_summary.inventory_id
+
+        LEFT OUTER JOIN (select cycle_count_request.facility_id                          as facility_id,
+                                cycle_count_request.product_id                           as product_id,
+                                cycle_count_request.id                                   as cycle_count_request_id,
+                                COALESCE(cycle_count.status, cycle_count_request.status) as status
+                         from cycle_count_request
+                                  left outer join cycle_count on cycle_count_request.cycle_count_id = cycle_count.id
+                         where cycle_count_request.id IS NULL
+                            OR (cycle_count_request.status <> 'COMPLETED'
+                                    AND cycle_count_request.status <> 'CANCELED')) as cycle_count_request_summary
+            on cycle_count_request_summary.product_id = product_availability.product_id
+                   and cycle_count_request_summary.facility_id = product_availability.location_id
+
+
+GROUP BY product_availability.location_id, product_availability.product_id
 HAVING sum(product_availability.quantity_on_hand) > 0
 ORDER BY NULL
     );

--- a/grails-app/migrations/views/product-count-history.sql
+++ b/grails-app/migrations/views/product-count-history.sql
@@ -1,28 +1,19 @@
 create or replace view product_count_history as
 (
 select
-    facility_id,
+    inventory_id,
     product_id,
-    max(date_counted) as date_counted,
-    max(date_received) as date_received
-from (select facility_id,
+    date_counted as date_counted
+from (
+select inventory_id,
              product_id,
-             date_counted as date_counted,
-             null         as date_received
+             date_counted as date_counted
       from product_cycle_count_history
       union
-      select facility_id,
+      select inventory_id,
              product_id,
-             date_counted,
-             null
+             date_counted
       from product_physical_count_history
---          union
---          select facility_id,
---                product_id,
---                null,
---                date_received
---          from product_receipt_history
      ) as inventory_level_summary_unions
-    group by facility_id, product_id
     )
 ;

--- a/grails-app/migrations/views/product-count-history.sql
+++ b/grails-app/migrations/views/product-count-history.sql
@@ -1,0 +1,28 @@
+create or replace view product_count_history as
+(
+select
+    facility_id,
+    product_id,
+    max(date_counted) as date_counted,
+    max(date_received) as date_received
+from (select facility_id,
+             product_id,
+             date_counted as date_counted,
+             null         as date_received
+      from product_cycle_count_history
+      union
+      select facility_id,
+             product_id,
+             date_counted,
+             null
+      from product_physical_count_history
+--          union
+--          select facility_id,
+--                product_id,
+--                null,
+--                date_received
+--          from product_receipt_history
+     ) as inventory_level_summary_unions
+    group by facility_id, product_id
+    )
+;

--- a/grails-app/migrations/views/product-count-history.sql
+++ b/grails-app/migrations/views/product-count-history.sql
@@ -5,7 +5,7 @@ select
     product_id,
     max(date_counted) as date_counted
 from (
-select inventory_id,
+    select inventory_id,
              product_id,
              date_counted as date_counted
       from product_cycle_count_history

--- a/grails-app/migrations/views/product-count-history.sql
+++ b/grails-app/migrations/views/product-count-history.sql
@@ -3,7 +3,7 @@ create or replace view product_count_history as
 select
     inventory_id,
     product_id,
-    date_counted as date_counted
+    max(date_counted) as date_counted
 from (
 select inventory_id,
              product_id,
@@ -15,5 +15,5 @@ select inventory_id,
              date_counted
       from product_physical_count_history
      ) as inventory_level_summary_unions
-    )
-;
+       group by inventory_id, product_id
+)

--- a/grails-app/migrations/views/product-cycle-count-history.sql
+++ b/grails-app/migrations/views/product-cycle-count-history.sql
@@ -2,14 +2,12 @@
 -- tables. However, this can be renamed if necessary.
 create or replace view product_cycle_count_history as (
     select
-        location.id as facility_id,
-        inventory_item.product_id,
-        -- FIXME need to set this to something that's not an auditing field
-        max(cycle_count.date_created) as date_counted
+        location.inventory_id as inventory_id,
+        cycle_count_item.product_id as product_id,
+        max(cycle_count_item.date_counted) as date_counted
     from cycle_count
-    join cycle_count_item on cycle_count_item.cycle_count_id = cycle_count.id
-    join inventory_item on inventory_item.id = cycle_count_item.inventory_item_id = inventory_item.id
-    join location on location.inventory_id = cycle_count.facility_id
+        join cycle_count_request on cycle_count.id = cycle_count_request.cycle_count_id
+        join cycle_count_item on cycle_count_item.cycle_count_id = cycle_count.id
+        join location on location.id = cycle_count.facility_id
     where cycle_count.status = 'COMPLETED'
-    group by location.id, inventory_item.product_id
 );

--- a/grails-app/migrations/views/product-cycle-count-history.sql
+++ b/grails-app/migrations/views/product-cycle-count-history.sql
@@ -10,4 +10,5 @@ create or replace view product_cycle_count_history as (
         join cycle_count_item on cycle_count_item.cycle_count_id = cycle_count.id
         join location on location.id = cycle_count.facility_id
     where cycle_count.status = 'COMPLETED'
+    group by location.inventory_id, cycle_count_item.product_id
 );

--- a/grails-app/migrations/views/product-cycle-count-history.sql
+++ b/grails-app/migrations/views/product-cycle-count-history.sql
@@ -1,0 +1,15 @@
+-- Using a generic view name in case we decide we need to return more data from cycle count
+-- tables. However, this can be renamed if necessary.
+create or replace view product_cycle_count_history as (
+    select
+        location.id as facility_id,
+        inventory_item.product_id,
+        -- FIXME need to set this to something that's not an auditing field
+        max(cycle_count.date_created) as date_counted
+    from cycle_count
+    join cycle_count_item on cycle_count_item.cycle_count_id = cycle_count.id
+    join inventory_item on inventory_item.id = cycle_count_item.inventory_item_id = inventory_item.id
+    join location on location.inventory_id = cycle_count.facility_id
+    where cycle_count.status = 'COMPLETED'
+    group by location.id, inventory_item.product_id
+);

--- a/grails-app/migrations/views/product-physical-count-history.sql
+++ b/grails-app/migrations/views/product-physical-count-history.sql
@@ -9,6 +9,8 @@ create or replace view product_physical_count_history as
     from transaction_entry
     join transaction on transaction.id = transaction_entry.transaction_id
     join inventory_item on transaction_entry.inventory_item_id = inventory_item.id
+    -- FIXME Hard-coding the transaction type to PRODUCT_INVENTORY in order to avoid an
+    --  additional JOIN to the transaction_type table.
     where transaction.transaction_type_id = '11'
     group by transaction.inventory_id, inventory_item.product_id
 );

--- a/grails-app/migrations/views/product-physical-count-history.sql
+++ b/grails-app/migrations/views/product-physical-count-history.sql
@@ -1,0 +1,22 @@
+-- Using a generic view name in case we decide we need to return more data from transaction
+-- tables. However, the name is not that important. We might need to use product availability
+create or replace view product_physical_count_history as
+(
+    select
+        location.id as facility_id,
+        inventory_item.product_id,
+        max(transaction.transaction_date) as date_counted
+    from transaction_entry
+    join transaction on transaction.id = transaction_entry.transaction_id
+    join inventory on inventory.id = transaction.inventory_id
+    join location on location.inventory_id = inventory.id
+    -- We might not need this JOIN if we can ensure that transaction_entry.product_id
+    -- is populated. At the moment it is not populated for all transactions. We should
+    -- add that as a tech debt issue if performance becomes an issue.
+    join inventory_item on inventory_item.id = transaction_entry.inventory_item_id
+    -- We can get a little better performance by using transaction.transaction_type_id = 11
+    -- but I wanted this to be more readable in the design
+    join transaction_type on transaction_type.id = transaction.transaction_type_id
+    where transaction_type.transaction_code = 'PRODUCT_INVENTORY'
+    group by location.id, transaction_entry.product_id
+);

--- a/grails-app/migrations/views/product-physical-count-history.sql
+++ b/grails-app/migrations/views/product-physical-count-history.sql
@@ -3,20 +3,11 @@
 create or replace view product_physical_count_history as
 (
     select
-        location.id as facility_id,
-        inventory_item.product_id,
+        transaction.inventory_id as inventory_id,
+        transaction_entry.product_id,
         max(transaction.transaction_date) as date_counted
     from transaction_entry
     join transaction on transaction.id = transaction_entry.transaction_id
-    join inventory on inventory.id = transaction.inventory_id
-    join location on location.inventory_id = inventory.id
-    -- We might not need this JOIN if we can ensure that transaction_entry.product_id
-    -- is populated. At the moment it is not populated for all transactions. We should
-    -- add that as a tech debt issue if performance becomes an issue.
-    join inventory_item on inventory_item.id = transaction_entry.inventory_item_id
-    -- We can get a little better performance by using transaction.transaction_type_id = 11
-    -- but I wanted this to be more readable in the design
-    join transaction_type on transaction_type.id = transaction.transaction_type_id
-    where transaction_type.transaction_code = 'PRODUCT_INVENTORY'
-    group by location.id, transaction_entry.product_id
+    where transaction.transaction_type_id = '11'
+    group by transaction.inventory_id, transaction_entry.product_id
 );

--- a/grails-app/migrations/views/product-physical-count-history.sql
+++ b/grails-app/migrations/views/product-physical-count-history.sql
@@ -4,10 +4,11 @@ create or replace view product_physical_count_history as
 (
     select
         transaction.inventory_id as inventory_id,
-        transaction_entry.product_id,
+        inventory_item.product_id,
         max(transaction.transaction_date) as date_counted
     from transaction_entry
     join transaction on transaction.id = transaction_entry.transaction_id
+    join inventory_item on transaction_entry.inventory_item_id = inventory_item.id
     where transaction.transaction_type_id = '11'
-    group by transaction.inventory_id, transaction_entry.product_id
+    group by transaction.inventory_id, inventory_item.product_id
 );

--- a/grails-app/migrations/views/product-receipt-history.sql
+++ b/grails-app/migrations/views/product-receipt-history.sql
@@ -1,0 +1,11 @@
+create or replace view product_receipt_history as
+(
+select shipment.destination_id as facility_id,
+       receipt_item.product_id,
+       receipt_item.inventory_item_id,
+       actual_delivery_date    as date_received
+from receipt_item
+         join receipt on receipt_item.receipt_id = receipt.id
+         join shipment on receipt.shipment_id = shipment.id
+         join location on shipment.destination_id = location.id
+    );

--- a/src/js/hooks/cycleCount/useAllProductsTab.jsx
+++ b/src/js/hooks/cycleCount/useAllProductsTab.jsx
@@ -11,6 +11,7 @@ import TableHeaderCell from 'components/DataTable/TableHeaderCell';
 import Checkbox from 'components/form-elements/v2/Checkbox';
 import { INVENTORY_ITEM_URL } from 'consts/applicationUrls';
 import { TO_COUNT_TAB } from 'consts/cycleCount';
+import { DateFormat } from 'consts/timeFormat';
 import useQueryParams from 'hooks/useQueryParams';
 import useSpinner from 'hooks/useSpinner';
 import useTableCheckboxes from 'hooks/useTableCheckboxes';
@@ -20,6 +21,7 @@ import useTranslate from 'hooks/useTranslate';
 import Badge from 'utils/Badge';
 import exportFileFromAPI from 'utils/file-download-util';
 import { mapStringToLimitedList } from 'utils/form-values-utils';
+import { formatDate } from 'utils/translation-utils';
 
 const useAllProductsTab = ({
   filterParams,
@@ -39,6 +41,12 @@ const useAllProductsTab = ({
   } = useSelector((state) => ({
     currentLocale: state.session.activeLanguage,
     currentLocation: state.session.currentLocation,
+  }));
+
+  const {
+    formatLocalizedDate,
+  } = useSelector((state) => ({
+    formatLocalizedDate: formatDate(state.localize),
   }));
 
   const {
@@ -139,7 +147,7 @@ const useAllProductsTab = ({
   });
 
   const columns = useMemo(() => [
-    columnHelper.accessor('lastCountDate', {
+    columnHelper.accessor('dateLastCount', {
       header: () => (
         <TableHeaderCell
           sortable
@@ -151,7 +159,7 @@ const useAllProductsTab = ({
       ),
       cell: ({ getValue }) => (
         <TableCell className="rt-td">
-          {getValue()}
+          {formatLocalizedDate(getValue(), DateFormat.DD_MMM_YYYY)}
         </TableCell>
       ),
       meta: {


### PR DESCRIPTION
### :sparkles: Description of Change

Added views to calculate the last count date based on cycle count and product inventory transaction data. Last count date is being pulled into to the the cycle count session view and displayed on the All Product tab. 

The performance is still really bad for some locations, so I'm going to look into ways to make it faster.

**Link to GitHub issue or Jira ticket:**
https://pihemr.atlassian.net/browse/OBPIH-6939

### :camera: Screenshots & Recordings (optional)
TBD


> [!TIP]  
> For the best viewing experience while reviewing this code, I would recommend enabling **Unified view** and **Hide whitespace** 
> 
> ![image](https://github.com/user-attachments/assets/3a7029b0-2ba5-42ef-84e9-769eee7471a7)
> 
> Not doing this will make it very difficult to understand what's going on. 