### PR TITLE
OBPIH-6994 don't auto fill global search input when hover over results

### DIFF
--- a/grails-app/views/taglib/_globalSearch.gsp
+++ b/grails-app/views/taglib/_globalSearch.gsp
@@ -70,8 +70,7 @@
             window.location = ui.item.url;
             return false;
           },
-          focus: function (event, ui) {
-            this.value = ui.item.label;
+          focus: function (event) {
             event.preventDefault(); // Prevent the default focus behavior.
           }
         })

--- a/grails-app/views/taglib/_globalSearchStatic.gsp
+++ b/grails-app/views/taglib/_globalSearchStatic.gsp
@@ -49,8 +49,7 @@
             window.location = ui.item.url;
             return false;
           },
-          focus: function (event, ui) {
-            this.value = ui.item.label;
+          focus: function (event) {
             event.preventDefault(); // Prevent the default focus behavior.
           }
         })


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6994

**Description:** Currently when hovering over an item in the global search results the search input is replaced with that item's display text. My change prevents that (and preserves the original input)


---
### :camera: Screenshots & Recordings (optional)

an example of the undesired behaviour: https://jam.dev/c/f000d33d-c70c-41a3-b5fe-45cf2c3e3daf

[1482e703-66b1-4ba3-a3dc-7e168990678e.webm](https://github.com/user-attachments/assets/08636c0d-3a71-440d-8249-f6316bd1ae2a)

