### PR TITLE
OBPIH-7074 bugfix. Prevent stack trace when adding to count items list within loop

### DIFF
--- a/grails-app/domain/org/pih/warehouse/inventory/CycleCount.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/CycleCount.groovy
@@ -127,8 +127,11 @@ class CycleCount {
     /**
      * @return the cycle count item matching the given input (which uniquely identifies the item within the count).
      */
-    CycleCountItem getCycleCountItem(Location binLocation, InventoryItem inventoryItem, int countIndex) {
+    CycleCountItem getCycleCountItem(
+            Product product, Location binLocation, InventoryItem inventoryItem, int countIndex) {
+
         return cycleCountItems.find{
+                    it.product == product &&
                     it.location == binLocation &&
                     it.inventoryItem == inventoryItem &&
                     it.countIndex == countIndex }

--- a/src/test/groovy/unit/org/pih/warehouse/inventory/CycleCountProductAvailabilityServiceSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/inventory/CycleCountProductAvailabilityServiceSpec.groovy
@@ -81,7 +81,7 @@ class CycleCountProductAvailabilityServiceSpec extends Specification implements 
         assert !changedItems.itemsHaveChanged()
         assert cycleCount.cycleCountItems.size() == 1
 
-        CycleCountItem cycleCountItem = cycleCount.getCycleCountItem(binLocation, inventoryItem, 0)
+        CycleCountItem cycleCountItem = cycleCount.getCycleCountItem(product, binLocation, inventoryItem, 0)
         assert cycleCountItem.quantityOnHand == 20  // QoH is unchanged
     }
 
@@ -124,7 +124,7 @@ class CycleCountProductAvailabilityServiceSpec extends Specification implements 
         assert changedItems.itemsHaveChanged()
         assert cycleCount.cycleCountItems.size() == 1
 
-        CycleCountItem cycleCountItem = cycleCount.getCycleCountItem(binLocation, inventoryItem, 0)
+        CycleCountItem cycleCountItem = cycleCount.getCycleCountItem(product, binLocation, inventoryItem, 0)
         assert cycleCountItem.quantityOnHand == 30  // QoH is updated
     }
 
@@ -179,10 +179,11 @@ class CycleCountProductAvailabilityServiceSpec extends Specification implements 
         assert changedItems.itemsHaveChanged()
         assert cycleCount.cycleCountItems.size() == 2
 
-        CycleCountItem existingCycleCountItem = cycleCount.getCycleCountItem(existingBinLocation, existingInventoryItem, 0)
+        CycleCountItem existingCycleCountItem = cycleCount.getCycleCountItem(
+                product, existingBinLocation, existingInventoryItem, 0)
         assert existingCycleCountItem.quantityOnHand == 20  // QoH is unchanged
 
-        CycleCountItem newCycleCountItem = cycleCount.getCycleCountItem(newBinLocation, newInventoryItem, 0)
+        CycleCountItem newCycleCountItem = cycleCount.getCycleCountItem(product, newBinLocation, newInventoryItem, 0)
         assert newCycleCountItem.status == CycleCountItemStatus.INVESTIGATING
         assert newCycleCountItem.countIndex == 0
         assert newCycleCountItem.quantityOnHand == 30
@@ -307,7 +308,7 @@ class CycleCountProductAvailabilityServiceSpec extends Specification implements 
         assert changedItems.itemsHaveChanged()
         assert cycleCount.cycleCountItems.size() == 1  // The item has not been removed!
 
-        CycleCountItem cycleCountItem = cycleCount.getCycleCountItem(binLocation, inventoryItem, 0)
+        CycleCountItem cycleCountItem = cycleCount.getCycleCountItem(product, binLocation, inventoryItem, 0)
         assert cycleCountItem.quantityOnHand == 0  // QoH is changed
     }
 
@@ -350,7 +351,7 @@ class CycleCountProductAvailabilityServiceSpec extends Specification implements 
         assert changedItems.itemsHaveChanged()
         assert cycleCount.cycleCountItems.size() == 1  // The item has not been removed!
 
-        CycleCountItem cycleCountItem = cycleCount.getCycleCountItem(binLocation, inventoryItem, 0)
+        CycleCountItem cycleCountItem = cycleCount.getCycleCountItem(product, binLocation, inventoryItem, 0)
         assert cycleCountItem.quantityOnHand == 0  // QoH is changed
     }
 
@@ -401,10 +402,10 @@ class CycleCountProductAvailabilityServiceSpec extends Specification implements 
         assert changedItems.itemsHaveChanged()
         assert cycleCount.cycleCountItems.size() == 2
 
-        CycleCountItem countCycleCountItem = cycleCount.getCycleCountItem(binLocation, inventoryItem, 0)
+        CycleCountItem countCycleCountItem = cycleCount.getCycleCountItem(product, binLocation, inventoryItem, 0)
         assert countCycleCountItem.quantityOnHand == 20  // QoH is unchanged
 
-        CycleCountItem recountCycleCountItem = cycleCount.getCycleCountItem(binLocation, inventoryItem, 1)
+        CycleCountItem recountCycleCountItem = cycleCount.getCycleCountItem(product, binLocation, inventoryItem, 1)
         assert recountCycleCountItem.quantityOnHand == 40  // QoH is updated
     }
 }


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7074

**Description:** Follow up fix to https://github.com/openboxes/openboxes/pull/5125

Submitting a count with a custom item threw an error because we were adding to the customItemsOfLastCount list while looping through it:
```
for (CycleCountItem customCycleCountItem : customItemsOfLastCount) {
    ...
    cycleCount.addToCycleCountItems(cycleCountItem)  // adds to customItemsOfLastCount. Errors!
}
```

I tested the following scenario:
- add custom item to count
- submit count
- start recount successfully, it has QoH == 0

and:
- add custom item to count
- submit count
- record stock, adding 20 quantity to the bin + lot of the custom item
- start recount successfully, it has QoH == 20