### PR TITLE
OBPIH- 6901 bugfix. Make QuantityVariance properly handle 0 quantity

### DIFF
--- a/grails-app/domain/org/pih/warehouse/inventory/CycleCountItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/CycleCountItem.groovy
@@ -85,7 +85,7 @@ class CycleCountItem implements Comparable {
     }
 
     Integer getQuantityVariance() {
-        if (quantityCounted && quantityOnHand) {
+        if (quantityCounted != null && quantityOnHand != null) {
             return quantityCounted - quantityOnHand
         }
         return null


### PR DESCRIPTION
### :sparkles: Description of Change

> *A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary. If the issue/ticket already provides enough information, you can put "See ticket" as the description.*

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6901

**Description:** Fix `CycleCountItem.getQuantityVariance()` so that it doesn't return null when either `quantityCounted` or `quantityOnHand` == 0


---
### :camera: Screenshots & Recordings (optional)

https://jam.dev/c/ed162de1-0420-4c82-839d-fcc395b7f185

[8581a846-4b1e-49e0-90d6-37d28346d590.webm](https://github.com/user-attachments/assets/bd6d3c7b-7f40-480b-b569-14a090c5fa56)


