### PR TITLE
OBPIH-7101 fix unique expiration date validation

### DIFF
--- a/src/js/hooks/cycleCount/useInventoryValidation.js
+++ b/src/js/hooks/cycleCount/useInventoryValidation.js
@@ -45,15 +45,12 @@ const useInventoryValidation = ({ tableData }) => {
         cycleCountItems,
         (item) => item?.inventoryItem?.lotNumber,
       );
-      // The backend returns expiration date in the "MM/dd/yyyy" format, but we use the
-      // "yyyy-MM-dd'T'hh:mm:ssXXX" format when generating the dates on the frontend. We
-      // convert the dates to a moment for easy comparison.
+      // The backend returns expiration date in the "MM/dd/yyyy" format, but we use the ISO format
+      // "yyyy-MM-dd'T'hh:mm:ssXXX" when generating dates on the frontend. We convert the dates to
+      // a moment (defaulting to UTC if no timezone information is provided) for easy comparison.
       const expirationDates = dataGroupedByLotNumber[row?.inventoryItem?.lotNumber].map((item) => {
         const expirationDate = item?.inventoryItem?.expirationDate;
-        // TODO: isSame is returning false, even if the dates are the same! I suspect it's trying
-        //       to use local time when parsing "MM/dd/yyyy". Gotta find a way to make this default
-        //       to UTC. This kinda sucks though, maybe we need a more general solution to this...
-        return expirationDate == null ? null : moment(expirationDate);
+        return expirationDate == null ? null : moment.utc(expirationDate);
       });
       const uniqueDates = _.uniqWith(expirationDates, (arrVal, othVal) => arrVal?.isSame(othVal));
       if (uniqueDates.length > 1) {


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7101

**Description:** The specific issue brought up here is triggered when an existing (non-custom) row has an expiry and you try to add a new, custom row for the same lot and expiry. The error is caused by the fact that InventoryItems use a custom date format which the frontend doesn't use when adding new rows.

`InventoryItem.groovy`:
```
Map toJson() {
    [
        ...
        "expirationDate" : expirationDate?.format("MM/dd/yyyy"),
        ...
    ]
}
```
So when we’re validating in `useInventoryValidation.checkDifferentExpirationDatesForTheSameLot`, we get rows that have the same date but in different formats, so it thinks they’re different and throws a validation error:
```
"03/03/2027"                 -> existing row returned from the backend
"2027-03-03T17:00:00-08:00"  -> custom row not yet persisted to the backend
```

---
### :camera: Screenshots & Recordings (optional)

![image](https://github.com/user-attachments/assets/63fd91a4-5e94-4432-a6d9-7a86293a2896)

