### PR TITLE
OBPIH-7117 duplicate items error should also show on lot number field

### DIFF
--- a/src/js/hooks/cycleCount/useInventoryValidation.js
+++ b/src/js/hooks/cycleCount/useInventoryValidation.js
@@ -27,10 +27,16 @@ const useInventoryValidation = ({ tableData }) => {
       );
       const key = `${row?.binLocation?.id}-${row?.inventoryItem?.lotNumber}`;
       if (dataGroupedByBinLocationAndLotNumber[key]?.length > 1) {
+        // Display the error on both the bin and lot because uniqueness is based on both of them.
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: translate('react.cycleCount.duplicatedRow.label', 'Duplicate rows for this inventory item.'),
           path: [index, 'binLocation'],
+        });
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: translate('react.cycleCount.duplicatedRow.label', 'Duplicate rows for this inventory item.'),
+          path: [index, 'inventoryItem.lotNumber'],
         });
       }
     });


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7117

**Description:** When one or more custom rows have the same [bin + lot] as another row, display an error on both the bin and lot fields for that row. Previously we were just displaying the error on the bin field, which isn't present for facilities with bin disabled, and so the error wasn't visible.

---
### :camera: Screenshots & Recordings (optional)

For facility with bin location enabled:
![Screenshot from 2025-03-20 10-15-30](https://github.com/user-attachments/assets/affdc29b-1e00-44d3-bb00-ef97cb06538e)

For facility with bin location disabled:
![Screenshot from 2025-03-20 10-13-16](https://github.com/user-attachments/assets/f0151351-9192-475a-b8bb-ba0dc83d5e83)
