### PR TITLE
OBPIH-7096 force adjustment transactions to be after product inventory ones

### DIFF
--- a/src/test/groovy/unit/org/pih/warehouse/inventory/CycleCountTransactionServiceSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/inventory/CycleCountTransactionServiceSpec.groovy
@@ -11,7 +11,6 @@ import org.pih.warehouse.inventory.CycleCount
 import org.pih.warehouse.inventory.CycleCountItem
 import org.pih.warehouse.inventory.CycleCountItemStatus
 import org.pih.warehouse.inventory.CycleCountProductAvailabilityService
-import org.pih.warehouse.inventory.CycleCountStatus
 import org.pih.warehouse.inventory.CycleCountTransactionService
 import org.pih.warehouse.inventory.Inventory
 import org.pih.warehouse.inventory.InventoryItem
@@ -223,6 +222,8 @@ class CycleCountTransactionServiceSpec extends Specification implements DataTest
         assert adjustmentTransaction.source == facility
         assert adjustmentTransaction.inventory == facility.inventory
         assert adjustmentTransaction.cycleCount == cycleCount
+        // The order of the transactions matters! The adjustment should always be applied after the product inventory.
+        assert adjustmentTransaction.transactionDate > productInventoryTransaction.transactionDate
 
         // We expect two entries because we had two discrepancy.
         List<TransactionEntry> entries = adjustmentTransaction.transactionEntries as List<TransactionEntry>


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7096

**Description:** Force any adjustment transactions to always come after the product inventory transaction by setting the transaction date for the product inventory to be before the adjustment transaction date.


---
### :camera: Screenshots & Recordings (optional)

Before the change (adjustment comes first sometimes):
![image](https://github.com/user-attachments/assets/582b72da-b2e6-4d47-aba0-194fbe406bb8)

After (adjustment is always after):
![image](https://github.com/user-attachments/assets/a9e9d89e-6ad6-418e-a308-cda76f3f1e88)

