### PR TITLE
OBPIH-7101 FIX. Handle null when comparing expiration dates

### DIFF
--- a/src/js/hooks/cycleCount/useInventoryValidation.js
+++ b/src/js/hooks/cycleCount/useInventoryValidation.js
@@ -58,7 +58,10 @@ const useInventoryValidation = ({ tableData }) => {
         const expirationDate = item?.inventoryItem?.expirationDate;
         return expirationDate == null ? null : moment.utc(expirationDate);
       });
-      const uniqueDates = _.uniqWith(expirationDates, (arrVal, othVal) => arrVal?.isSame(othVal));
+      const uniqueDates = _.uniqWith(
+        expirationDates,
+        (arrVal, othVal) => (arrVal == null ? othVal == null : arrVal.isSame(othVal)),
+      );
       if (uniqueDates.length > 1) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,

--- a/src/js/hooks/cycleCount/useInventoryValidation.js
+++ b/src/js/hooks/cycleCount/useInventoryValidation.js
@@ -60,7 +60,7 @@ const useInventoryValidation = ({ tableData }) => {
       });
       const uniqueDates = _.uniqWith(
         expirationDates,
-        (arrVal, othVal) => (arrVal == null ? othVal == null : arrVal.isSame(othVal)),
+        (arrVal, othVal) => (arrVal === null ? othVal === null : arrVal.isSame(othVal)),
       );
       if (uniqueDates.length > 1) {
         ctx.addIssue({


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7101

**Description:** Duplicate expiry date validation error was incorrectly triggering when two bins had the same lot and expiration date was null. https://jam.dev/c/1e1680e8-e3c6-44b9-994d-46d2b19af8e1


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

Fixed:
![image](https://github.com/user-attachments/assets/742415d7-2f7a-4dec-8077-69a8a840488b)
