### PR TITLE
Obpih 7136

### DIFF
--- a/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy
@@ -10,8 +10,6 @@
 package org.pih.warehouse.inventory
 
 import grails.databinding.BindUsing
-import grails.plugins.csv.CSVWriter
-import org.grails.plugins.excelimport.ExpectedPropertyType
 import org.pih.warehouse.EmptyStringsToNullBinder
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.product.Product
@@ -70,6 +68,7 @@ class InventoryLevel {
     String binLocation
 
     // ABC analysis class
+    @BindUsing({ obj, source -> EmptyStringsToNullBinder.bindEmptyStringToNull(source, "abcClass") })
     String abcClass
 
     // Additional comments about

--- a/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy
@@ -103,7 +103,7 @@ class InventoryLevel {
         preferredBinLocation(nullable: true)
         replenishmentLocation(nullable: true)
         binLocation(nullable: true)
-        abcClass(nullable: true)
+        abcClass(nullable: true, blank: false)
         preferred(nullable: true)
         comments(nullable: true)
         replenishmentPeriodDays(nullable: true)

--- a/grails-app/domain/org/pih/warehouse/product/Product.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/Product.groovy
@@ -311,7 +311,7 @@ class Product implements Comparable, Serializable {
         upc(nullable: true, maxSize: 255)
         ndc(nullable: true, maxSize: 255)
 
-        abcClass(nullable: true)
+        abcClass(nullable: true, blank: false)
         packageSize(nullable: true)
         brandName(nullable: true, maxSize: 255)
         vendor(nullable: true, maxSize: 255)

--- a/grails-app/domain/org/pih/warehouse/product/Product.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/Product.groovy
@@ -9,12 +9,13 @@
  * */
 package org.pih.warehouse.product
 
+import grails.databinding.BindUsing
 import grails.util.Holders
 import org.apache.commons.collections.FactoryUtils
 import org.apache.commons.collections.list.LazyList
 import org.apache.commons.lang.NotImplementedException
 import org.grails.plugins.web.taglib.ApplicationTagLib
-import org.pih.warehouse.MessageTagLib
+import org.pih.warehouse.EmptyStringsToNullBinder
 import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.Document
@@ -154,6 +155,7 @@ class Product implements Comparable, Serializable {
     Category category
 
     // Default ABC Classification
+    @BindUsing({ obj, source -> EmptyStringsToNullBinder.bindEmptyStringToNull(source, "abcClass") })
     String abcClass
 
     // For better or worse, unit of measure and dosage form are used somewhat interchangeably

--- a/grails-app/migrations/0.9.x/changelog-2025-03-26-2057-update-abc-class-convert-empty-string-to-null.xml
+++ b/grails-app/migrations/0.9.x/changelog-2025-03-26-2057-update-abc-class-convert-empty-string-to-null.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+
+    <changeSet author="jmiranda" id="1743040916119-1">
+        <sql>
+            UPDATE product SET abc_class = NULL WHERE TRIM(abc_class) = '';
+        </sql>
+    </changeSet>
+    <changeSet author="jmiranda" id="1743040916119-2">
+        <sql>
+            UPDATE inventory_level SET abc_class = NULL WHERE TRIM(abc_class) = '';
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/grails-app/migrations/0.9.x/changelog.xml
+++ b/grails-app/migrations/0.9.x/changelog.xml
@@ -29,5 +29,5 @@
     <include file="0.9.x/changelog-2025-02-11-1530-add-column-cycle-count-to-transaction.xml" />
     <include file="0.9.x/changelog-2025-03-11-1300-drop-user-foreign-key-from-assignee-in-cycle-count-item.xml" />
     <include file="0.9.x/changelog-2025-03-11-1400-add-person-foreign-key-for-assignee-in-cycle-count-item.xml" />
-    <include file="0.9.x/changelog-2025-03-26-2057-convert-abc-class-empty-string-to-null.xml" />
+    <include file="0.9.x/changelog-2025-03-26-2057-update-abc-class-convert-empty-string-to-null.xml" />
 </databaseChangeLog>

--- a/grails-app/migrations/0.9.x/changelog.xml
+++ b/grails-app/migrations/0.9.x/changelog.xml
@@ -29,4 +29,5 @@
     <include file="0.9.x/changelog-2025-02-11-1530-add-column-cycle-count-to-transaction.xml" />
     <include file="0.9.x/changelog-2025-03-11-1300-drop-user-foreign-key-from-assignee-in-cycle-count-item.xml" />
     <include file="0.9.x/changelog-2025-03-11-1400-add-person-foreign-key-for-assignee-in-cycle-count-item.xml" />
+    <include file="0.9.x/changelog-2025-03-26-2057-convert-abc-class-empty-string-to-null.xml" />
 </databaseChangeLog>


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:**
https://pihemr.atlassian.net/browse/OBPIH-7020
https://pihemr.atlassian.net/browse/OBPIH-7136

**Description:**
The ABC class property is a nullable varchar(255) column. That means it currently supports values like NULL, empty string, and alphanumeric characters up to a size of 255.  The default sorting used by MySQL/MariaDB ORDER BY mechanism will sort NULL and empty strings ahead of valid ABC classes (i.e. A, B, C). This has caused issues with the cycle session and ranking algorithm which should be treating NULL and empty string as the default class that comes after A, B, C. The ranking algorithm (cycle count candidate view) handles the NULL case (see line 2 below) but does not handle the empty string.

```
ORDER BY sort_order,
         abc_class IS NULL asc,
         abc_class asc,
         days_until_next_count
```

We could implement this using a somewhat opaque solution like the following
```
ORDER BY sort_order
    COALESCE(TRIM(abc_class), '') = '' asc,
    abc_class asc,
    days_until_next_count
```
I preferred doing this in a way that cleans that data and keep the intent of the SQL clear with what we're expecting from the data i.e. no blank values allowed and sort NULLs last. 

Note: I've added the `blank: false` constraint on both abcClass properties. However, this is sort of a no-op since the data binding mechanism is already converting from blank to NULL. But you'll notice that multiple spaces (i.e. "    ") is not converted to NULL. I believe this is either expected behavior (i.e. multiple empty spaces != blank) or due to the fact that our default configuration doesn't support trimming the strings during data binding. 

We could potentially add the following configuration and hope that the combination of trimStrings and convertEmptyStringToNull would work to essentially turn any amount of whitespace to NULL. 
```
grails.databinding.trimStrings = true
```

However, I'm going to forgo this solution for now given the fact that adding a new configuration property would require a lot of testing and since I don't suspect this "multiple blanks" will be a huge problem.

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
