### PR TITLE
OBPIH-7173 Rows duplicated when add the same inventory with no lot as added on recount (fixes after QA)

### DIFF
--- a/grails-app/domain/org/pih/warehouse/inventory/InventoryItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/InventoryItem.groovy
@@ -82,7 +82,7 @@ class InventoryItem implements Serializable {
                 "inventoryItemId": id,
                 "productId"      : product?.id,
                 "productName"    : product?.name,
-                "lotNumber"      : lotNumber,
+                "lotNumber"      : lotNumber ?: null,
                 "expirationDate" : expirationDate?.format("MM/dd/yyyy"),
                 "quantityOnHand" : quantity ?: 0,
                 "quantityATP"    : quantity ?: 0,       //todo: quantity available to promise will coming soon

--- a/grails-app/init/org/pih/warehouse/BootStrap.groovy
+++ b/grails-app/init/org/pih/warehouse/BootStrap.groovy
@@ -212,7 +212,7 @@ class BootStrap {
                     name       : inventoryItem?.product?.name,
                     productCode: inventoryItem?.product?.productCode
                 ],
-                lotNumber     : inventoryItem.lotNumber,
+                lotNumber     : inventoryItem.lotNumber ?: null,
                 expirationDate: inventoryItem.expirationDate?.format("MM/dd/yyyy")
             ]
         }

--- a/src/js/hooks/cycleCount/useCountStep.jsx
+++ b/src/js/hooks/cycleCount/useCountStep.jsx
@@ -234,7 +234,7 @@ const useCountStep = () => {
         id: productId,
       },
       inventoryItem: {
-        lotNumber: '',
+        lotNumber: null,
         expirationDate: null,
       },
       binLocation: null,

--- a/src/js/hooks/cycleCount/useResolveStep.js
+++ b/src/js/hooks/cycleCount/useResolveStep.js
@@ -254,7 +254,7 @@ const useResolveStep = () => {
         id: productId,
       },
       inventoryItem: {
-        lotNumber: '',
+        lotNumber: null,
         expirationDate: null,
       },
       binLocation: null,

--- a/src/main/groovy/org/pih/warehouse/inventory/CycleCountItemCommand.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/CycleCountItemCommand.groovy
@@ -15,15 +15,16 @@ class CycleCountItemCommand implements Validateable {
 
     @BindUsing({ obj, source ->
         Product product = Product.read(source['inventoryItem']['product'])
-        InventoryItem inventoryItem = InventoryItem.findByProductAndLotNumber(product, source['inventoryItem']['lotNumber'])
+        String lotNumber = source['inventoryItem']['lotNumber']
+        InventoryItem inventoryItem = InventoryItem.findByProductAndLotNumber(product, lotNumber)
 
         // Currently default lotNumbers can be null or empty string,
         // to avoid the situation of not finding appropriate one
         // we are trying to find another inventoryItem with
         // empty lot
-        if (!inventoryItem && !source['inventoryItem']['lotNumber']) {
-            String lotNumber = source['inventoryItem']['lotNumber'] == null ? '' : null
-            inventoryItem = InventoryItem.findByProductAndLotNumber(product, lotNumber)
+        if (!inventoryItem && !lotNumber) {
+            String otherBlankLotNumber = lotNumber == null ? '' : null
+            inventoryItem = InventoryItem.findByProductAndLotNumber(product, otherBlankLotNumber)
         }
 
         return inventoryItem ?: new InventoryItem(

--- a/src/main/groovy/org/pih/warehouse/inventory/CycleCountItemCommand.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/CycleCountItemCommand.groovy
@@ -16,6 +16,16 @@ class CycleCountItemCommand implements Validateable {
     @BindUsing({ obj, source ->
         Product product = Product.read(source['inventoryItem']['product'])
         InventoryItem inventoryItem = InventoryItem.findByProductAndLotNumber(product, source['inventoryItem']['lotNumber'])
+
+        // Currently default lotNumbers can be null or empty string,
+        // to avoid the situation of not finding appropriate one
+        // we are trying to find another inventoryItem with
+        // empty lot
+        if (!inventoryItem && !source['inventoryItem']['lotNumber']) {
+            String lotNumber = source['inventoryItem']['lotNumber'] == null ? '' : null
+            inventoryItem = InventoryItem.findByProductAndLotNumber(product, lotNumber)
+        }
+
         return inventoryItem ?: new InventoryItem(
                 product: product,
                 lotNumber: source['inventoryItem']['lotNumber'],


### PR DESCRIPTION
I decided to change the default row values (lot number) to null instead of an empty string, because it looks more appropriate in that case. The main issue here is that we can have *TWO* different values for the default lot number. Sometimes I got null, and the other time I got an empty string. The empty strings come from record stock, but I noticed that I was able to create an inventory item with null (I don't know how; it happened just once). So to unify the behavior, I added null as a fallback to always get the same default lot.
The issue with grouping rows that caused the duplicated rows behaviour again existed because, during finding an inventory item, we searched for null, but the inventory item had an empty string (it was also achievable to reproduce this the other way.)