### PR TITLE
OBPIH-7177 Inventory has changed not detected when add line on recount and the same line on record stock 

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/CycleCountService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/CycleCountService.groovy
@@ -589,14 +589,13 @@ class CycleCountService {
             }
             command.inventoryItem.save()
         }
-        Integer currentQuantityOnHand = productAvailabilityService.getQuantityOnHandInBinLocation(command.inventoryItem, command.binLocation) ?: 0
         CycleCount cycleCount = command.cycleCount
 
         CycleCountItem cycleCountItem = new CycleCountItem(
                 facility: command.facility,
                 status: command.recount ? CycleCountItemStatus.INVESTIGATING : CycleCountItemStatus.COUNTING,
                 countIndex: command.recount ? 1 : 0,
-                quantityOnHand: currentQuantityOnHand,
+                quantityOnHand: 0,
                 quantityCounted: command.quantityCounted,
                 cycleCount: cycleCount,
                 location: command.binLocation,


### PR DESCRIPTION
The issue was caused by the fact that we are calling the save action for every item before submitting a recount. During save, we were looking for existing inventory to assign the already existing QoH for the newly created inventory on recount. So, it led to the inability to detect discrepancies because the QoH was the same on the record stock and in the cycle count item. As a fix, I am setting QoH for the newly created row to 0, so that the discrepancy can be found during submitting a recount, and after refreshing, the existing inventory data will be fetched and correctly displayed. In that case, the information about the discrepancy will be visible for every cycle count that includes newly created inventory.

- in case when we added a new inventory on record stock and the recount stays the same: discrepancy found
- in case when we added a new inventory on recount and not on the record stock: discrepancy not found