### PR TITLE
OBPIH-7048 filter out inactive products from cycle count tables

### DIFF
--- a/grails-app/migrations/views/cycle-count-candidate.sql
+++ b/grails-app/migrations/views/cycle-count-candidate.sql
@@ -14,6 +14,9 @@ SELECT *,
            ELSE 3
            END                                           as sort_order
 FROM cycle_count_session
+WHERE
+    -- if a product is inactive, it should not be countable, so filter inactive products out
+    product_active
 ORDER BY sort_order,
          abc_class IS NULL asc,
          abc_class asc,

--- a/grails-app/migrations/views/cycle-count-session.sql
+++ b/grails-app/migrations/views/cycle-count-session.sql
@@ -34,6 +34,9 @@ SELECT
     --  certain queries).
     MAX(cycle_count_request_summary.status)                                          as status,
 
+    -- Product fields
+    product.active                                                                   as product_active,
+
     # Inventory Item Count
     count(product_availability.id)                                                   as inventory_item_count,
 

--- a/grails-app/migrations/views/pending_cycle_count_request.sql
+++ b/grails-app/migrations/views/pending_cycle_count_request.sql
@@ -35,6 +35,7 @@ CREATE OR REPLACE VIEW pending_cycle_count_request AS
                             location.inventory_id = product_classification.inventory_id
             JOIN product ON ccr.product_id = product.id
     WHERE
+        -- if a product is inactive, hide any pending requests on it so that a count/recount cannot be started on it
         product.active
     GROUP BY
         ccr.id,

--- a/grails-app/migrations/views/pending_cycle_count_request.sql
+++ b/grails-app/migrations/views/pending_cycle_count_request.sql
@@ -33,6 +33,9 @@ CREATE OR REPLACE VIEW pending_cycle_count_request AS
             LEFT OUTER JOIN product_classification
                          ON pa.product_id = product_classification.product_id AND
                             location.inventory_id = product_classification.inventory_id
+            JOIN product ON ccr.product_id = product.id
+    WHERE
+        product.active
     GROUP BY
         ccr.id,
         ccr.facility_id,


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7048

**Description:** We don't want to display inactive products on the all products, to count, or to recount tabs. This change filters them out from display but still allows you to submit a count/recount on a product that was marked inactive while you already had the count/recount step open.

---
### :camera: Screenshots & Recordings (optional)

https://jam.dev/c/3d0830b0-34ea-4f3e-ad36-f7b937d5be64

[946cc7c0-57d0-4940-987c-81712e1099c4.webm](https://github.com/user-attachments/assets/dd0523ae-7191-4c0f-8c7f-3facb4cfee31)

