### PR TITLE
OBPIH-7041: prepend zone to bin location in CC tables

### DIFF
--- a/grails-app/domain/org/pih/warehouse/inventory/CycleCountItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/CycleCountItem.groovy
@@ -53,7 +53,7 @@ class CycleCountItem implements Comparable {
                 facility: facility.toBaseJson(),
                 product: product,
                 inventoryItem: inventoryItem,
-                binLocation: location?.toBaseJson(),
+                binLocation: location?.toJson(),
                 countIndex: countIndex,
                 status: status,
                 quantityOnHand: quantityOnHand,

--- a/grails-app/migrations/views/cycle-count-session.sql
+++ b/grails-app/migrations/views/cycle-count-session.sql
@@ -5,7 +5,7 @@ SELECT
     CRC32(CONCAT(product_availability.location_id, product_availability.product_id)) as id,
 
     # Core properties
-    location.inventory_id                                                            as inventory_id,
+    facility.inventory_id                                                            as inventory_id,
     product_availability.product_id                                                  as product_id,
     product_availability.location_id                                                 as facility_id,
 
@@ -37,14 +37,14 @@ SELECT
     # Inventory Item Count
     count(product_availability.id)                                                   as inventory_item_count,
 
-    # Comma-separated list of internal locations
+    -- A comma-separated list of internal locations in the format <zone>:<bin location name>
     GROUP_CONCAT(DISTINCT (
-        CASE
-            WHEN product_availability.quantity_on_hand != 0 THEN product_availability.bin_location_name
-            ELSE NULL
-            END
+        IF(
+            product_availability.quantity_on_hand != 0,
+            CONCAT_WS(':', zone.name, product_availability.bin_location_name),
+            NULL
         )
-    )                                                                                as internal_locations,
+    ))                                                                                as internal_locations,
 
     # Quantities by SKU
     -- FIXME The sum could include both positive and negative quantities since we no longer exclude negative
@@ -64,14 +64,17 @@ SELECT
     NULL                                                                             as date_latest_inventory
 
 FROM product_availability
-         JOIN location ON product_availability.location_id = location.id
+         JOIN location facility ON product_availability.location_id = facility.id
          JOIN product ON product_availability.product_id = product.id
+
+         LEFT OUTER JOIN location bin_location ON product_availability.bin_location_id = bin_location.id
+         LEFT OUTER JOIN location zone ON bin_location.zone_id = zone.id
 
     # FIXME need to add a unique constraint to prevent duplicate inventory levels for a single facility / product
     # Using min(abc_class) means we'll return the highest value if there are multiple inventory levels with different abc classes (A, B, C)
          LEFT OUTER JOIN product_classification
                          ON product_availability.product_id = product_classification.product_id AND
-                            location.inventory_id = product_classification.inventory_id
+                            facility.inventory_id = product_classification.inventory_id
 
     -- The following subquery pulls the latest cycle count request data
          LEFT OUTER JOIN (SELECT cycle_count_request.facility_id                          as facility_id,
@@ -97,9 +100,9 @@ FROM product_availability
                                  max(days_until_next_count) as days_until_next_count
                           FROM cycle_count_metadata
                           GROUP BY inventory_id, product_id) as cycle_count_metadata
-                         on cycle_count_metadata.inventory_id = location.inventory_id and
+                         on cycle_count_metadata.inventory_id = facility.inventory_id and
                             cycle_count_metadata.product_id = product_availability.product_id
 
-GROUP BY product_availability.location_id, product_availability.product_id, location.inventory_id
+GROUP BY product_availability.location_id, product_availability.product_id, facility.inventory_id
     );
 

--- a/grails-app/migrations/views/pending_cycle_count_request.sql
+++ b/grails-app/migrations/views/pending_cycle_count_request.sql
@@ -15,13 +15,10 @@ CREATE OR REPLACE VIEW pending_cycle_count_request AS
         product_classification.abc_class as abc_class,
         SUM(pa.quantity_on_hand) AS quantity_on_hand,
         SUM(CASE WHEN pa.quantity_on_hand < 0 THEN 1 ELSE 0 END) as negative_item_count,
+        -- A comma-separated list of internal locations in the format <zone>:<bin location name>
         GROUP_CONCAT(DISTINCT (
-            CASE
-                WHEN pa.quantity_on_hand != 0 THEN pa.bin_location_name
-                ELSE NULL
-                END
-            )
-        ) as internal_locations
+            IF(pa.quantity_on_hand != 0, CONCAT_WS(':', zone.name, pa.bin_location_name), NULL)
+        )) as internal_locations
     FROM
         cycle_count_request ccr
             LEFT OUTER JOIN product_availability pa
@@ -29,10 +26,12 @@ CREATE OR REPLACE VIEW pending_cycle_count_request AS
                 AND ccr.facility_id = pa.location_id
             LEFT OUTER JOIN cycle_count cc
                 ON ccr.cycle_count_id = cc.id
-            JOIN location ON pa.location_id = location.id
+            JOIN location facility ON pa.location_id = facility.id
+            LEFT OUTER JOIN location bin_location ON pa.bin_location_id = bin_location.id
+            LEFT OUTER JOIN location zone ON bin_location.zone_id = zone.id
             LEFT OUTER JOIN product_classification
                          ON pa.product_id = product_classification.product_id AND
-                            location.inventory_id = product_classification.inventory_id
+                            facility.inventory_id = product_classification.inventory_id
     GROUP BY
         ccr.id,
         ccr.facility_id,

--- a/src/js/hooks/cycleCount/useCountStepTable.jsx
+++ b/src/js/hooks/cycleCount/useCountStepTable.jsx
@@ -15,7 +15,7 @@ import cycleCountColumn from 'consts/cycleCountColumn';
 import { DateFormat } from 'consts/timeFormat';
 import useArrowsNavigation from 'hooks/useArrowsNavigation';
 import useTranslate from 'hooks/useTranslate';
-import groupBinLocationsByZone from 'utils/groupBinLocationsByZone';
+import { getBinLocationToDisplay, groupBinLocationsByZone } from 'utils/groupBinLocationsByZone';
 import { checkBinLocationSupport } from 'utils/supportedActivitiesUtils';
 import CustomTooltip from 'wrappers/CustomTooltip';
 
@@ -116,7 +116,7 @@ const useCountStepTable = ({
     }
 
     if (columnPath === cycleCountColumn.BIN_LOCATION && showBinLocation) {
-      return value?.name;
+      return getBinLocationToDisplay(value);
     }
 
     return value;
@@ -234,7 +234,7 @@ const useCountStepTable = ({
           tooltip={showTooltip}
           tooltipForm={showTooltip}
           tooltipClassname={showTooltip && 'bin-location-tooltip'}
-          tooltipLabel={value?.name || translate('react.cycleCount.table.binLocation.label', 'Bin Location')}
+          tooltipLabel={getBinLocationToDisplay(value) || translate('react.cycleCount.table.binLocation.label', 'Bin Location')}
         >
           <Component
             disabled={isFieldDisabled}
@@ -269,7 +269,8 @@ const useCountStepTable = ({
 
   const columns = [
     columnHelper.accessor(
-      (row) => (row?.binLocation?.label ? row?.binLocation : row.binLocation?.name), {
+      // TODO: This doesn't seem to do anything?????? How to change the value???
+      (row) => getBinLocationToDisplay(row?.binLocation), {
         id: cycleCountColumn.BIN_LOCATION,
         header: () => (
           <TableHeaderCell className="rt-th-count-step">

--- a/src/js/hooks/cycleCount/useCycleCountFilters.js
+++ b/src/js/hooks/cycleCount/useCycleCountFilters.js
@@ -8,7 +8,7 @@ import { setShouldRebuildFilterParams } from 'actions';
 import cycleCountFilterFields from 'components/cycleCount/CycleCountFilterFields';
 import useCommonFiltersCleaner from 'hooks/list-pages/useCommonFiltersCleaner';
 import useTranslate from 'hooks/useTranslate';
-import groupBinLocationsByZone from 'utils/groupBinLocationsByZone';
+import { groupBinLocationsByZone } from 'utils/groupBinLocationsByZone';
 import { getParamList, transformFilterParams } from 'utils/list-utils';
 import {
   fetchBins,

--- a/src/js/hooks/cycleCount/useResolveStepTable.jsx
+++ b/src/js/hooks/cycleCount/useResolveStepTable.jsx
@@ -25,7 +25,7 @@ import cycleCountColumn from 'consts/cycleCountColumn';
 import { DateFormat } from 'consts/timeFormat';
 import useArrowsNavigation from 'hooks/useArrowsNavigation';
 import useTranslate from 'hooks/useTranslate';
-import groupBinLocationsByZone from 'utils/groupBinLocationsByZone';
+import { getBinLocationToDisplay, groupBinLocationsByZone } from 'utils/groupBinLocationsByZone';
 import { checkBinLocationSupport } from 'utils/supportedActivitiesUtils';
 import { formatDate } from 'utils/translation-utils';
 import CustomTooltip from 'wrappers/CustomTooltip';
@@ -175,7 +175,7 @@ const useResolveStepTable = ({
     }
 
     if (id === cycleCountColumn.BIN_LOCATION) {
-      return value?.name;
+      return getBinLocationToDisplay(value);
     }
 
     if (id === cycleCountColumn.ROOT_CAUSE) {
@@ -371,7 +371,8 @@ const useResolveStepTable = ({
 
   const columns = [
     columnHelper.accessor(
-      (row) => (row?.binLocation?.label ? row?.binLocation : row.binLocation?.name), {
+      // TODO: This doesn't seem to do anything?????? How to change the value???
+      (row) => getBinLocationToDisplay(row?.binLocation), {
         id: cycleCountColumn.BIN_LOCATION,
         header: useMemo(() => (
           <TableHeaderCell className="rt-th-count-step">

--- a/src/js/utils/groupBinLocationsByZone.jsx
+++ b/src/js/utils/groupBinLocationsByZone.jsx
@@ -2,6 +2,11 @@ import React from 'react';
 
 import _ from 'lodash';
 
+// Stringify a bin location for display, prepending the bin's zone if it has one.
+const getBinLocationToDisplay = (bin) => (
+  bin?.zoneName == null ? bin?.name : `${bin?.zoneName}: ${bin?.name}`
+);
+
 const groupBinLocationsByZone = (binLocations, translate) => {
   const groupedByZone = _.groupBy(binLocations, (bin) => bin.zoneId || 'no-zone');
   return Object.entries(groupedByZone)
@@ -16,8 +21,8 @@ const groupBinLocationsByZone = (binLocations, translate) => {
         options: bins
           .map((bin) => ({
             id: bin.id,
-            name: bin.name,
-            label: bin.name,
+            name: getBinLocationToDisplay(bin),
+            label: getBinLocationToDisplay(bin),
             value: bin.id,
           }))
           .sort((a, b) => a.name.localeCompare(b.name)),
@@ -34,4 +39,7 @@ const groupBinLocationsByZone = (binLocations, translate) => {
     });
 };
 
-export default groupBinLocationsByZone;
+export {
+  getBinLocationToDisplay,
+  groupBinLocationsByZone,
+};


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7041

**Description:** Prepend zone to bin location name in all cycle count table:
- All products, to count, and to recount tabs
- count and recount steps
- count and recount confirmation pages

CURRENTLY LEFT TO DO:
- add zone for bins on all products tab
- add zone for non-custom rows of count and recount steps
- recount step is including zone twice in name for custom rows

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

Bins now have zone (ex: "Container 1") prepended to their display name:
![Screenshot from 2025-04-25 09-32-54](https://github.com/user-attachments/assets/f8c0e397-e930-4801-9787-bb8fc37a2bfb)
