### PR TITLE
OBPIH-7255: add support for ZonedDateTime to backend

### DIFF
--- a/grails-app/utils/org/pih/warehouse/DateUtil.groovy
+++ b/grails-app/utils/org/pih/warehouse/DateUtil.groovy
@@ -12,9 +12,11 @@ package org.pih.warehouse
 import grails.validation.ValidationException
 import java.text.SimpleDateFormat
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import org.apache.commons.lang.StringUtils
 
 import org.pih.warehouse.databinding.DataBindingConstants
@@ -41,6 +43,79 @@ import org.pih.warehouse.databinding.DataBindingConstants
  */
 class DateUtil {
 
+    /*
+     * Formatters for displaying dates. These should only be used by GSPs and file exporters. Everything else should
+     * return the date object itself to the frontend (which will get formatted to an ISO formatted string).
+     *
+     * We should strive to only ever use a single format per date type. For example, we should only have one format
+     * for displaying day + month + year. This allows us to be consistent in how we display date fields in the app.
+     */
+    static final DateTimeFormatter DISPLAY_DATE_FORMATTER = DateTimeFormatter.ofPattern("dd/MMM/yyyy")
+    static final DateTimeFormatter DISPLAY_DATE_TIME_OFFSET_FORMATTER = DateTimeFormatter.ofPattern("dd/MMM/yyyy HH:mm XXX")
+
+    /**
+     * Converts a LocalDate to a date-only string for display. This method should only be used by GSPs and file
+     * exporters. Otherwise we should return the date object as is and let the frontend decide the display format.
+     *
+     * @return a formatted date String. Ex: "01/Jan/2025"
+     */
+    static String asDateForDisplay(LocalDate date) {
+        return DISPLAY_DATE_FORMATTER.format(date)
+    }
+
+    /**
+     * Converts a Date to a date-only string for display. This method should only be used by GSPs and file exporters.
+     * Otherwise we should return the date object as is and let the frontend decide the display format.
+     * Useful when working with old code that uses the old Date format.
+     *
+     * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example. Defaults to the system timezone.
+     * @return a formatted date String. Ex: "01/Jan/2025"
+     */
+    static String asDateForDisplay(Date date, ZoneId zone=null) {
+        return asDateForDisplay(asLocalDate(date, zone))
+    }
+
+    /**
+     * Converts an Instant to a date + time + offset string for display. This method should only be used by GSPs and
+     * file exporters. Otherwise we should return the date object as is and let the frontend decide the display format.
+     *
+     * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example. Defaults to the system timezone.
+     * @return a formatted datetime String. Ex: "01/Jan/2025 00:00 +05:00"
+     */
+    static String asDateTimeForDisplay(Instant instant, ZoneId zone=null) {
+        ZoneId zoneToUse = zone ?: getSystemZoneOffset()
+        return asDateTimeForDisplay(instant.atZone(zoneToUse))
+    }
+
+    /**
+     * Converts a ZonedDateTime to a date + time + offset string for display. This method should only be used by GSPs
+     * and file exporters. Otherwise we should return the date object as is and let the frontend decide the display
+     * format.
+     *
+     * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example. Defaults to the existing timezone
+     *        of the ZonedDateTime.
+     * @return a formatted datetime String. Ex: "01/Jan/2025 00:00 +05:00"
+     */
+    static String asDateTimeForDisplay(ZonedDateTime zonedDateTime, ZoneId zone=null) {
+        // If we're not given a zone to display, we retain the zone as defined in the ZonedDateTime. We could have
+        // converted it to the system timezone, but it felt safer to preserve the ZDT's state. In most cases we'll be
+        // specifying the timezone, and when we don't, the ZDT will be in server time anyways, so it shouldn't matter.
+        ZonedDateTime zonedDateTimeToUse = zone ? zonedDateTime.withZoneSameInstant(zone) : zonedDateTime
+        return DISPLAY_DATE_TIME_OFFSET_FORMATTER.format(zonedDateTimeToUse)
+    }
+
+    /**
+     * Converts a Date to a date + time + offset string for display. This method should only be used by GSPs and file
+     * exporters. Otherwise we should return the date object as is and let the frontend decide the display format.
+     * Useful when working with old code that uses the old Date format.
+     *
+     * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example. Defaults to the system timezone.
+     * @return a formatted datetime String. Ex: "01/Jan/2025 00:00 +05:00"
+     */
+    static String asDateTimeForDisplay(Date date, ZoneId zone=null) {
+        return asDateTimeForDisplay(asInstant(date), zone)
+    }
+
     /**
      * Null-safe conversion of a (deprecated) java.util.Date to an Instant.
      * Useful when working with old code that uses the old format.
@@ -59,20 +134,33 @@ class DateUtil {
     /**
      * Null-safe conversion of an Instant to a ZonedDateTime. If no timezone is provided, we assume UTC.
      *
-     * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example.
+     * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example. Defaults to the system timezone.
      */
-    static ZonedDateTime asZonedDateTime(Instant instant, ZoneId zone=ZoneOffset.UTC) {
-        return instant ? instant.atZone(zone) : null
+    static ZonedDateTime asZonedDateTime(Instant instant, ZoneId zone=null) {
+        ZoneId zoneToUse = zone ?: getSystemZoneOffset()
+        return instant ? instant.atZone(zoneToUse) : null
     }
 
     /**
      * Null-safe conversion of a (deprecated) java.util.Date to an ZonedDateTime. If no timezone is provided,
      * we assume UTC. Useful when working with old code that uses the old format.
      *
-     * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example.
+     * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example. Defaults to the system timezone.
      */
-    static ZonedDateTime asZonedDateTime(Date date, ZoneId zone=ZoneOffset.UTC) {
-        return date ? asInstant(date).atZone(zone) : null
+    static ZonedDateTime asZonedDateTime(Date date, ZoneId zone=null) {
+        ZoneId zoneToUse = zone ?: getSystemZoneOffset()
+        return date ? asInstant(date).atZone(zoneToUse) : null
+    }
+
+    /**
+     * Null-safe conversion of a (deprecated) java.util.Date to a LocalDate.
+     * Useful when working with old code that uses the old format.
+     *
+     * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example. Defaults to the system timezone.
+     */
+    static LocalDate asLocalDate(Date date, ZoneId zone=null) {
+        ZoneId zoneToUse = zone ?: getSystemZoneOffset()
+        return date ? asInstant(date).atZone(zoneToUse).toLocalDate() : null
     }
 
     /**
@@ -97,7 +185,16 @@ class DateUtil {
 
         // Otherwise, try to parse using our flexible list of supported formats. We parse to an Instant and then convert
         // to a Date since it allows us to use DateTimeFormatter, which is less error-prone than SimpleDateFormat.
-        Instant instant = Instant.from(DataBindingConstants.FLEXIBLE_DATE_TIME_ZONE_FORMAT.parse(dateSanitized))
+        Instant instant = Instant.from(DataBindingConstants.FLEXIBLE_DATE_TIME_ZONE_FORMAT
+                // We calculate the timezone offset dynamically instead of putting it directly into the formatter
+                // in the rare case that the server is configured in a system timezone that is sensitive to daylight
+                // savings time (ex: America/Vancouver is PST (-08:00) from November-March and PDT (-07:00) otherwise).
+                // This way, we can gracefully handle DST rollovers.
+                // TODO: A bug in JDK 8 prevents us from being able to do this. Once we upgrade to Java 9+, we can
+                //       re-enable this line and remove the "parseDefaulting" in the FLEXIBLE_DATE_TIME_ZONE_FORMAT
+                //       https://stackoverflow.com/questions/41999421/how-does-datetimeformatters-override-zone-work-when-parsing
+                //.withZone(getSystemZoneOffset())
+                .parse(dateSanitized))
         return Date.from(instant)
     }
 
@@ -115,6 +212,28 @@ class DateUtil {
      */
     static Date asDate(ZonedDateTime zonedDateTime) {
         return zonedDateTime ? asDate(zonedDateTime.toInstant()) : null
+    }
+
+    /**
+     * Null-safe conversion of a LocalDate to a (deprecated) java.util.Date.
+     * Useful when working with old code that uses the old format.
+     *
+     * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example. Defaults to the system timezone.
+     */
+    static Date asDate(LocalDate localDate, ZoneId zone=null) {
+        ZoneId zoneToUse = zone ?: getSystemZoneOffset()
+        return localDate ? asDate(localDate.atStartOfDay(zoneToUse)) : null
+    }
+
+    /**
+     * Fetches the ZoneOffset of the system at a given point in time. If no instant is provided, will return
+     * the current timezone offset of the system.
+     */
+    static ZoneOffset getSystemZoneOffset(Instant instant=null) {
+        // Extracts the offset rules for the timezone (ie what the offset is for a zone for a given time of year),
+        // then uses those rules to determine the offset (ex: '-05:00') for the given instant. This check is required
+        // because a zone can be in one of many offsets depending on the time of year due to daylight savings.
+        return ZoneId.systemDefault().getRules().getOffset(instant ?: Instant.now())
     }
 
     static Date clearTime(Date date) {

--- a/grails-app/utils/org/pih/warehouse/databinding/DataBindingConstants.groovy
+++ b/grails-app/utils/org/pih/warehouse/databinding/DataBindingConstants.groovy
@@ -1,9 +1,13 @@
 package org.pih.warehouse.databinding
 
+import java.time.Instant
+import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
 import java.time.temporal.ChronoField
+
+import org.pih.warehouse.DateUtil
 
 /**
  * Constants relating to binding request input strings to objects.
@@ -14,8 +18,8 @@ class DataBindingConstants {
      * Patterns that follow the ISO-8601 + RPC 3339 date formats while allowing for slight variation in the pattern
      * for the sake of flexibility. For example, we also allow MM/dd/yyyy, which is the default date format for Excel.
      *
-     * Ex: "2000-01-01", "2000/01/01", "20000101" are all valid strings according to FLEXIBLE_DATE_PATTERN.
-     * Ex: both "2000-01-01" and "2000-01-01T00:00:00Z" are valid strings according to FLEXIBLE_DATE_TIME_ZONE_PATTERN.
+     * Ex: "2000-01-01", "01/01/2000", "20000101" are all valid strings according to FLEXIBLE_DATE_PATTERN.
+     * Ex: "2000-01-01T00:00:00Z", "01/01/2000 00:00Z" are valid strings according to FLEXIBLE_DATE_TIME_ZONE_PATTERN.
      *
      * We do this mainly to support a wider range of user input, making our parsing logic more flexible.
      * Internally, we should strive to use a consistent structure and to always output the same format.
@@ -24,8 +28,8 @@ class DataBindingConstants {
      * not [HH:mm][HH:mm:ss]).
      *
      * Also note that depending on what date type you're parsing into, this can trigger an error. For example, Instant
-     * requires time and timezone information, and so FLEXIBLE_DATE_TIME_ZONE_PATTERN will fail to parse "2000-01-01"
-     * unless the associated DateTimeFormatter provides a default for time and zone (via "parseDefaulting").
+     * and ZonedDateTime require time and timezone information, and so FLEXIBLE_DATE_TIME_ZONE_PATTERN will fail to
+     * parse "2000-01-01" unless the DateTimeFormatter provides a default for time and zone (via "parseDefaulting").
      */
     static final String FLEXIBLE_DATE_PATTERN = "[yyyy-MM-dd][MM/dd/yyyy][yyyy/MM/dd][yyyy MM dd][yyyyMMdd]"
     static final String FLEXIBLE_TIME_PATTERN =
@@ -38,16 +42,66 @@ class DataBindingConstants {
             "${FLEXIBLE_DATE_PATTERN}[['T'][ ]${FLEXIBLE_TIME_PATTERN}][[ ][XXX][XX][X]]"
 
     /**
-     * DateTimeFormatter used to parse a String to a datetime class, such as java.time.Instant.
+     * A DateTimeFormatter used to parse a String to a date-only class, such as java.time.LocalDate.
+     *
+     * If a full datetime string containing time and zone information, parsing will fail. Use DATE_TIME_ZONE_FORMAT
+     * instead for strings of that format.
      */
+    static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern(FLEXIBLE_DATE_PATTERN)
+
+    /**
+     * A DateTimeFormatter used to parse a String to a datetime class, such as java.time.Instant or ZonedDateTime.
+     *
+     * Note that this formatter does not provide defaults for time or zone. If either is missing, parsing will fail.
+     * We do this because we've had timezone issues in the past, and so have decided to force the given string to
+     * contain all the information required to build the datetime.
+     */
+    static final DateTimeFormatter DATE_TIME_ZONE_FORMAT = new DateTimeFormatterBuilder()
+            .appendPattern(DataBindingConstants.FLEXIBLE_DATE_TIME_ZONE_PATTERN)
+            // Default to HH:mm:00.000 if seconds and milliseconds are excluded in the string because we often don't
+            // require that amount of precision.
+            .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+            .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0)
+            .toFormatter()
+
+    /**
+     * @deprecated for use only by existing endpoints that mix and match date formats (and so need a more flexible
+     *             formatter). New endpoints should avoid Date and should use DATE_FORMAT or DATE_TIME_ZONE_FORMAT.
+     *
+     * A DateTimeFormatter used to parse a String to a java.util.Date.
+     *
+     * Note that the behaviour isn't consistent when handling input that doesn't provide a timezone. This is due
+     * to weirdness around DST (daylight savings time).
+     *
+     * Ex: Due to DST, the "America/Vancouver" timezone is PST (-08:00) from November-March and PDT (-07:00) from
+     *     March-November while DST is in effect. So if the server is in the "America/Vancouver" timezone, and we're
+     *     given a string "2000-01-01", which is in PST (-08:00), if the current date is within March-November, it'll
+     *     parse that date as PDT (-07:00). This means we'll get the Date equivalent of "2000-01-01T00:00:00-07:00",
+     *     aka "1999-12-31T23:00:00-08:00". And if the current date is within November-March it'll parse that date as
+     *     PST (-08:00), resulting in a Date like "2000-01-01T00:00:00-08:00", aka "2000-01-01T01:00:00-07:00.
+     *
+     * For date-only fields, the above is fine because time and zone get stripped out so as long as the frontend has
+     * the same timezone as the backend, we'll always end up with "2000-01-01", but for datetime fields that don't also
+     * specify timezone, the behaviour is inconsistent. This is a main reason why we avoid using Date, why we should
+     * always pass full date + time + zone for datetime fields, and why we suggest configuring the server to use UTC.
+     */
+    @Deprecated
     static final DateTimeFormatter FLEXIBLE_DATE_TIME_ZONE_FORMAT = new DateTimeFormatterBuilder()
             .appendPattern(DataBindingConstants.FLEXIBLE_DATE_TIME_ZONE_PATTERN)
-            // Defaults to 00:00:00.000 if time is not provided in the String
+            // Defaults to 00:00:00.000 (aka midnight) if time is not provided in the String.
             .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
             .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
             .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
             .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0)
-            // Defaults to UTC if timezone is not provided in the String
-            .parseDefaulting(ChronoField.OFFSET_SECONDS, ZoneOffset.UTC.getTotalSeconds())
+            // Defaults to the current timezone offset of the system if timezone is not provided in the String.
+            .parseDefaulting(ChronoField.OFFSET_SECONDS, getSystemZoneOffset().getTotalSeconds())
             .toFormatter()
+
+    /**
+     * Fetches the ZoneOffset of the system at a given point in time. If no instant is provided, will return
+     * the current timezone offset of the system.
+     */
+    static ZoneOffset getSystemZoneOffset(Instant instant=null) {
+        return ZoneId.systemDefault().getRules().getOffset(instant ?: Instant.now())
+    }
 }

--- a/grails-app/utils/org/pih/warehouse/databinding/DataBindingConstants.groovy
+++ b/grails-app/utils/org/pih/warehouse/databinding/DataBindingConstants.groovy
@@ -1,8 +1,5 @@
 package org.pih.warehouse.databinding
 
-import java.time.Instant
-import java.time.ZoneId
-import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
 import java.time.temporal.ChronoField
@@ -93,15 +90,12 @@ class DataBindingConstants {
             .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
             .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
             .parseDefaulting(ChronoField.MILLI_OF_SECOND, 0)
+            // TODO: This is imperfect because if the server is in a timezone that has multiple offsets depending on the
+            //       the time of year (due to daylight savings time), this will break. It's unlikely that a server would
+            //       be configured this way, but still worth noting. Once we upgrade to Java 9+, remove this offset
+            //       default and replace it with "withZone" when parsing (see DateUtil.asDate).
+            //       https://stackoverflow.com/questions/41999421/how-does-datetimeformatters-override-zone-work-when-parsing
             // Defaults to the current timezone offset of the system if timezone is not provided in the String.
-            .parseDefaulting(ChronoField.OFFSET_SECONDS, getSystemZoneOffset().getTotalSeconds())
+            .parseDefaulting(ChronoField.OFFSET_SECONDS, DateUtil.getSystemZoneOffset().getTotalSeconds())
             .toFormatter()
-
-    /**
-     * Fetches the ZoneOffset of the system at a given point in time. If no instant is provided, will return
-     * the current timezone offset of the system.
-     */
-    static ZoneOffset getSystemZoneOffset(Instant instant=null) {
-        return ZoneId.systemDefault().getRules().getOffset(instant ?: Instant.now())
-    }
 }

--- a/grails-app/utils/org/pih/warehouse/databinding/InstantValueConverter.groovy
+++ b/grails-app/utils/org/pih/warehouse/databinding/InstantValueConverter.groovy
@@ -16,23 +16,18 @@ class InstantValueConverter extends StringValueConverter<Instant> {
      * Binds a given user-input String to an Instant.
      *
      * An Instant is an absolute moment in time, so to construct it we need a full datetime with timezone included.
-     * As such, if the given string doesn't provide a time, we default to "00:00.000" (aka the start of the day),
-     * and if it doesn't provide a timezone, we default to "Z" (aka UTC).
+     * As such, if the given string doesn't provide time or timezone information, we error.
      *
-     * This defaulting to UTC is important. We don't want to rely on the system local time, which can vary from host
-     * to host, and can change over time within a single host. Our app should behave the same way no matter where it is
-     * hosted. We also don't want to make assumptions about the timezone that the end user is sending data in/from.
+     * We could have been more forgiving and allow for time and time zone to be omitted (and default the resulting
+     * Instant to midnight server time), but we've encountered many timezone related issues in the past, so to be safe
+     * we require the client to always provide all the information required to build the Instant.
      *
-     * The universally accepted "default" timezone is UTC, so for the sake of simplicity, we use that as a fallback if
-     * the client doesn't provide timezone information. However, as much as possible we should insist that the client
-     * DOES provide timezone information so that there is no ambiguity as to the precise datetime being provided.
-     *
-     * @param value "2000-01-01", "2000-01-01T00:00", "2000-01-01T00:00Z", "2000-01-01T00:00+05:00" for example
+     * @param value "2000-01-01T00:00Z", or "2000-01-01T00:00+05:00" for example
      */
     @Override
     Instant convertString(String value) {
         return StringUtils.isBlank(value) ?
                 null :
-                Instant.from(DataBindingConstants.FLEXIBLE_DATE_TIME_ZONE_FORMAT.parse(value.trim()))
+                Instant.from(DataBindingConstants.DATE_TIME_ZONE_FORMAT.parse(value.trim()))
     }
 }

--- a/grails-app/utils/org/pih/warehouse/databinding/LocalDateValueConverter.groovy
+++ b/grails-app/utils/org/pih/warehouse/databinding/LocalDateValueConverter.groovy
@@ -1,7 +1,6 @@
 package org.pih.warehouse.databinding
 
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 import org.apache.commons.lang.StringUtils
 import org.springframework.stereotype.Component
 
@@ -13,21 +12,18 @@ import org.springframework.stereotype.Component
 @Component
 class LocalDateValueConverter extends StringValueConverter<LocalDate> {
 
-    private static final DateTimeFormatter FLEXIBLE_DATE_FORMAT = DateTimeFormatter.ofPattern(
-            DataBindingConstants.FLEXIBLE_DATE_PATTERN)
-
     /**
      * Parse a given String into a LocalDate of the given format.
      *
      * Because LocalDate is time and timezone agnostic, the String only expects day, month, and year elements. To avoid
      * any timezone related confusion, Any additional data provided (such as time and timezone) will trigger an error.
      *
-     * @param value "2000/01/01" for example
+     * @param value "2000-12-31", "12/31/2000" for example
      */
     @Override
     LocalDate convertString(String value) {
         return StringUtils.isBlank(value) ?
                 null :
-                LocalDate.parse(value.trim(), FLEXIBLE_DATE_FORMAT)
+                LocalDate.parse(value.trim(), DataBindingConstants.DATE_FORMAT)
     }
 }

--- a/grails-app/utils/org/pih/warehouse/databinding/ZonedDateTimeValueConverter.groovy
+++ b/grails-app/utils/org/pih/warehouse/databinding/ZonedDateTimeValueConverter.groovy
@@ -1,0 +1,33 @@
+package org.pih.warehouse.databinding
+
+import java.time.ZonedDateTime
+import org.apache.commons.lang.StringUtils
+import org.springframework.stereotype.Component
+
+/**
+ * As of Java 8, Java.util.Date is functionally replaced with the java.time classes, but Grails 4 and older does not
+ * support databinding a datetime String to an Instant (only timestamps) so we need to add support ourselves.
+ * https://github.com/grails/grails-core/issues/11811
+ */
+@Component
+class ZonedDateTimeValueConverter extends StringValueConverter<ZonedDateTime> {
+
+    /**
+     * Binds a given user-input String to a ZonedDateTime.
+     *
+     * A ZonedDateTime is an absolute moment in time in a specific locale, so to construct it we need a full datetime
+     * with timezone included. As such, if the given string doesn't provide time or timezone information, we error.
+     *
+     * We could have been more forgiving and allow for time and time zone to be omitted (and default the resulting
+     * ZonedDateTime to midnight server time), but we've encountered many timezone related issues in the past, so to
+     * be safe  we require the client to always provide all the information required to build the ZonedDateTime.
+     *
+     * @param value "2000-01-01T00:00Z", or "2000-01-01T00:00+05:00" for example
+     */
+    @Override
+    ZonedDateTime convertString(String value) {
+        return StringUtils.isBlank(value) ?
+                null :
+                ZonedDateTime.from(DataBindingConstants.DATE_TIME_ZONE_FORMAT.parse(value.trim()))
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/Constants.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/Constants.groovy
@@ -25,11 +25,11 @@ class Constants {
     static final adminControllers = ['createProduct', 'admin']
     static final adminActions = ['product': ['create'], 'person': ['list'], 'user': ['list'], 'location': ['edit'], 'shipper': ['create'], 'locationGroup': ['create'], 'locationType': ['create'], '*': ['delete']]
 
-    // TODO: Don't add more dates here! We should refactor all backend usages (old gsp pages can continue using these)
-    //       of these constants to use the DateUtil.asDate(String) method to parse in Date types and then return Date
-    //       objects unformatted in our responses. The backend should always return dates in the same format so that
-    //       the frontend can easily parse response objects. Let the frontend decide what the display format of each
-    //       individual field should be.
+    // TODO: Don't add more dates here! When reading in date objects from API calls, use DateUtil.asZonedDateTime or
+    //       asInstant (or asDate for old code that still uses the Date type). When returning dates to the client,
+    //       GSPs and file exporters should use DateUtil.toDisplayFormat, and everything else should simply return date
+    //       objects unformatted (which results in them being ISO format) so that the frontend can easily parse
+    //       response objects. The frontend can decide what the display format of each individual field should be.
     static final String DEFAULT_YEAR_FORMAT = "yyyy"
     static final String DEFAULT_DATE_FORMAT = "dd/MMM/yyyy"
     static final String DEFAULT_DATE_TIME_FORMAT = "dd/MMM/yyyy HH:mm:ss"

--- a/src/test/groovy/unit/org/pih/warehouse/utils/DateUtilSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/utils/DateUtilSpec.groovy
@@ -2,28 +2,29 @@ package unit.org.pih.warehouse.utils
 
 import java.text.SimpleDateFormat
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 import spock.lang.Specification
 import spock.lang.Unroll
 
 import org.pih.warehouse.DateUtil
-import org.pih.warehouse.databinding.DataBindingConstants
 
 @Unroll
 class DateUtilSpec extends Specification {
 
     void 'asDate should successfully parse using the default format for case: #scenario'() {
-        given: 'a format to use when making assertions on the Date (we force UTC to avoid system time inconsistency)'
+        given:
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
         format.setTimeZone(TimeZone.getTimeZone(ZoneOffset.UTC))
 
-        when:
+        when: 'we parse to a Date in the system local timezone'
         Date date = DateUtil.asDate(givenDate)
 
-        then:
+        then: 'we format the Date to UTC for asserting against'
         assert expectedConvertedDate == format.format(date)
 
         where:
@@ -58,26 +59,25 @@ class DateUtilSpec extends Specification {
     }
 
     void 'asDate should successfully parse when no timezone is given for case: #scenario'() {
-        given: 'we parse to the server timezone for making assertions so that we can get consistent results'
+        given: 'the current timezone offset of the system'
+        ZoneOffset zone = DateUtil.getSystemZoneOffset()
+
+        and: 'a format to make assertions with'
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
-        ZoneOffset zone = DataBindingConstants.getSystemZoneOffset()
         format.setTimeZone(TimeZone.getTimeZone(zone))
 
-        when: 'we append zone dynamically based on the current server timezone'
-        String expectedConvertedDateWithZone = expectedConvertedDate + zone
-
-        and:
+        when:'we parse to a Date in the system local timezone'
         Date date = DateUtil.asDate(givenDate)
 
-        then:
-        assert expectedConvertedDateWithZone == format.format(date)
+        then: 'we format the Date (still in the system local time) for asserting against'
+        assert expectedConvertedDate + zone == format.format(date)
 
         where:
-        givenDate                   || expectedConvertedDate | scenario
-        "01/01/2000 00:00"          || "2000-01-01T00:00:00" | "No timezone our format"
-        "2000-01-01 00:00"          || "2000-01-01T00:00:00" | "No timezone ISO format"
-        "01/01/2000"                || "2000-01-01T00:00:00" | "No time or timezone our format"
-        "2000-01-01"                || "2000-01-01T00:00:00" | "No time or timezone ISO format"
+        givenDate          || expectedConvertedDate | scenario
+        "01/01/2000 00:00" || "2000-01-01T00:00:00" | "No timezone our format"
+        "2000-01-01 00:00" || "2000-01-01T00:00:00" | "No timezone ISO format"
+        "01/01/2000"       || "2000-01-01T00:00:00" | "No time or timezone our format"
+        "2000-01-01"       || "2000-01-01T00:00:00" | "No time or timezone ISO format"
     }
 
     void 'asDate should fail to parse using the default format for case: #failureReason'() {
@@ -93,18 +93,36 @@ class DateUtilSpec extends Specification {
         "01/01/00"   || DateTimeParseException | "two digit year format not supported"
     }
 
+    void 'asDate should successfully convert a LocalDate to a Date'(){
+        given:
+        LocalDate localDate = LocalDate.of(2000, 1, 1)
+
+        and: 'the current timezone offset of the system'
+        ZoneOffset offset = DateUtil.getSystemZoneOffset()
+
+        and: 'a format to make assertions with'
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
+        format.setTimeZone(TimeZone.getTimeZone(offset))
+
+        when:
+        Date date = DateUtil.asDate(localDate)
+
+        then: 'format the Date to a string in current the system offset for asserting against'
+        assert format.format(date) == '2000-01-01T00:00:00' + offset
+    }
+
     void 'asInstant should successfully convert a Date to an Instant for case: #scenario'() {
         given:
-        Date date = new Date(givenDate)
+        Date date = newDate(givenDate)
 
         expect:
         assert DateUtil.asInstant(date).toString() == expectedConvertedDate
 
         where:
-        givenDate                          || expectedConvertedDate  | scenario
-        "Sat, 01 Jan 2000 00:00:00 UTC"    || "2000-01-01T00:00:00Z" | "UTC timezone"
-        "Sat, 01 Jan 2000 00:00:00 UTC+05" || "1999-12-31T19:00:00Z" | "timezone ahead of UTC"
-        "Sat, 01 Jan 2000 00:00:00 UTC-05" || "2000-01-01T05:00:00Z" | "timezone behind UTC"
+        givenDate                || expectedConvertedDate  | scenario
+        "2000-01-01T00:00Z"      || "2000-01-01T00:00:00Z" | "UTC timezone"
+        "2000-01-01T00:00+05:00" || "1999-12-31T19:00:00Z" | "timezone ahead of UTC"
+        "2000-01-01T00:00-05:00" || "2000-01-01T05:00:00Z" | "timezone behind UTC"
     }
 
     void 'asInstant should successfully convert a ZonedDateTime to an Instant for case: #scenario'() {
@@ -127,42 +145,222 @@ class DateUtilSpec extends Specification {
         given:
         Instant instant = Instant.parse(givenDate)
 
-        expect:
-        assert DateUtil.asZonedDateTime(instant).toString() == expectedConvertedDate
+        and:
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneOffset.UTC)
+
+        when: 'we parse to a ZonedDateTime in the system local timezone'
+        ZonedDateTime zdt = DateUtil.asZonedDateTime(instant)
+
+        then: 'we format the ZonedDateTime to UTC for asserting against'
+        assert formatter.format(zdt) == expectedConvertedDate
 
         where:
         givenDate                   || expectedConvertedDate      | scenario
         "2000-01-01T00:00:11.111Z"  || "2000-01-01T00:00:11.111Z" | "Full string in proper ISO format"
         "2000-01-01T00:00:11.000Z"  || "2000-01-01T00:00:11Z"     | "Empty millis are removed"
         "2000-01-01T00:00:11Z"      || "2000-01-01T00:00:11Z"     | "No millis provided"
-        "2000-01-01T00:00:00Z"      || "2000-01-01T00:00Z"        | "Empty seconds are removed"
     }
 
-    void 'asZonedDateTime should successfully convert an Instant to a ZonedDateTime with tz for case: #scenario'() {
+    void 'asZonedDateTime should successfully convert an Instant with tz to a ZonedDateTime for case: #scenario'() {
         given:
         Instant instant = Instant.parse(givenDate)
+        ZoneId zone = ZoneId.of(timezoneToDisplay)
 
-        expect:
-        assert DateUtil.asZonedDateTime(instant, givenTimezone).toString() == expectedConvertedDate
+        when:
+        ZonedDateTime zdt = DateUtil.asZonedDateTime(instant, zone)
+
+        then:
+        assert zdt.toString() == expectedConvertedDate
 
         where:
-        givenDate              | givenTimezone      || expectedConvertedDate    | scenario
-        "2000-01-01T00:00:00Z" | ZoneId.of('Z')     || "2000-01-01T00:00Z"      | "UTC timezone"
-        "2000-01-01T00:00:00Z" | ZoneId.of('+05')   || "2000-01-01T05:00+05:00" | "timezone ahead of UTC"
-        "2000-01-01T00:00:00Z" | ZoneId.of('-05')   || "1999-12-31T19:00-05:00" | "timezone behind UTC"
+        givenDate              | timezoneToDisplay || expectedConvertedDate    | scenario
+        "2000-01-01T00:00:00Z" | 'Z'               || "2000-01-01T00:00Z"      | "UTC timezone"
+        "2000-01-01T00:00:00Z" | '+05:00'          || "2000-01-01T05:00+05:00" | "timezone ahead of UTC"
+        "2000-01-01T00:00:00Z" | '-05:00'          || "1999-12-31T19:00-05:00" | "timezone behind UTC"
     }
 
     void 'asZonedDateTime should successfully convert a Date to a ZonedDateTime for case: #scenario'() {
         given:
-        Date date = new Date(givenDate)
+        Date date = newDate(givenDate)
 
-        expect:
-        assert DateUtil.asZonedDateTime(date).toString() == expectedConvertedDate
+        and:
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneOffset.UTC)
+
+        when: 'we parse to a ZonedDateTime in the system local timezone'
+        ZonedDateTime zdt = DateUtil.asZonedDateTime(date)
+
+        then: 'we format the ZonedDateTime to UTC for asserting against'
+        assert formatter.format(zdt) == expectedConvertedDate
 
         where:
-        givenDate                          || expectedConvertedDate | scenario
-        "Sat, 01 Jan 2000 00:00:00 UTC"    || "2000-01-01T00:00Z"   | "UTC timezone"
-        "Sat, 01 Jan 2000 00:00:00 UTC+05" || "1999-12-31T19:00Z"   | "timezone ahead of UTC"
-        "Sat, 01 Jan 2000 00:00:00 UTC-05" || "2000-01-01T05:00Z"   | "timezone behind UTC"
+        givenDate                || expectedConvertedDate  | scenario
+        "2000-01-01T00:00Z"      || "2000-01-01T00:00:00Z" | "UTC timezone"
+        "2000-01-01T00:00+05:00" || "1999-12-31T19:00:00Z" | "timezone ahead of UTC"
+        "2000-01-01T00:00-05:00" || "2000-01-01T05:00:00Z" | "timezone behind UTC"
+    }
+
+    void 'asZonedDateTime should successfully convert a Date with tz to a ZonedDateTime for case: #scenario'() {
+        given:
+        Date date = newDate(givenDate)
+        ZoneId zone = ZoneId.of(timezoneToDisplay)
+
+        when:
+        ZonedDateTime zdt = DateUtil.asZonedDateTime(date, zone)
+
+        then:
+        assert zdt.toString() == expectedConvertedDate
+
+        where:
+        givenDate                | timezoneToDisplay || expectedConvertedDate    | scenario
+        "2000-01-01T00:00Z"      | 'Z'               || "2000-01-01T00:00Z"      | "UTC to UTC (no conversion)"
+        "2000-01-01T00:00+05:00" | 'Z'               || "1999-12-31T19:00Z"      | "+05 to UTC (backwards conversion)"
+        "2000-01-01T00:00-05:00" | 'Z'               || "2000-01-01T05:00Z"      | "-05 to UTC (forwards conversion)"
+        "2000-01-01T00:00Z"      | '+05:00'          || "2000-01-01T05:00+05:00" | "UTC to +05 (forwards conversion)"
+        "2000-01-01T00:00+05:00" | '+05:00'          || "2000-01-01T00:00+05:00" | "+05 to +05 (no conversion)"
+        "2000-01-01T00:00+06:00" | '+05:00'          || "1999-12-31T23:00+05:00" | "+06 to +05 (backwards conversion)"
+    }
+
+    void 'asLocalDate should successfully convert a Date to a LocalDate'() {
+        given: 'a date with the current timezone offset of the system'
+        ZoneOffset offset = DateUtil.getSystemZoneOffset()
+        Date date = newDate("2000-01-01T00:00${offset}")
+
+        expect:
+        assert DateUtil.asLocalDate(date).toString() == "2000-01-01"
+    }
+
+    void 'asLocalDate should successfully convert a Date with tz to a LocalDate for case: #scenario'(){
+        given:
+        Date date = newDate(givenDate)
+        ZoneId zone = ZoneId.of(timezoneToDisplay)
+
+        when:
+        LocalDate localDate = DateUtil.asLocalDate(date, zone)
+
+        then:
+        assert localDate.toString() == expectedConvertedDate
+
+        where:
+        givenDate                | timezoneToDisplay || expectedConvertedDate | scenario
+        "2000-01-01T00:00Z"      | 'Z'               || "2000-01-01"          | "UTC to UTC (no conversion)"
+        "2000-01-01T00:00+05:00" | 'Z'               || "1999-12-31"          | "+05 to UTC (backwards conversion)"
+        "2000-01-01T00:00-05:00" | 'Z'               || "2000-01-01"          | "-05 to UTC (forwards conversion)"
+        "2000-01-01T00:00Z"      | '+05:00'          || "2000-01-01"          | "UTC to +05 (forwards conversion)"
+        "2000-01-01T00:00+05:00" | '+05:00'          || "2000-01-01"          | "+05 to +05 (no conversion)"
+        "2000-01-01T00:00+06:00" | '+05:00'          || "1999-12-31"          | "+06 to +05 (backwards conversion)"
+    }
+
+    void 'asDateForDisplay should successfully convert a LocalDate to a String'() {
+        given:
+        LocalDate localDate = LocalDate.of(2000, 1, 1)
+
+        expect:
+        assert DateUtil.asDateForDisplay(localDate) == '01/Jan/2000'
+    }
+
+    void 'asDateTimeForDisplay should successfully convert an Instant to a String'() {
+        given: 'an Instant in the current timezone offset of the system (will internally get converted to UTC)'
+        ZoneOffset offset = DateUtil.getSystemZoneOffset()
+        Instant instant = ZonedDateTime.parse("2000-01-01T00:00:00" + offset).toInstant()
+
+        expect: 'the date time is coverted back to the system timezone for display'
+        assert DateUtil.asDateTimeForDisplay(instant) == "01/Jan/2000 00:00 " + offset
+    }
+
+    void 'asDateTimeForDisplay should successfully convert an Instant with a tz to a String for case: #scenario'() {
+        given:
+        Instant instant = Instant.parse(givenDate)
+        ZoneId zone = ZoneId.of(timezoneToDisplay)
+
+        expect:
+        assert DateUtil.asDateTimeForDisplay(instant, zone) == expectedConvertedDate
+
+        where:
+        givenDate              | timezoneToDisplay || expectedConvertedDate      | scenario
+        "2000-01-01T00:00:00Z" | 'Z'               || "01/Jan/2000 00:00 Z"      | "UTC timezone"
+        "2000-01-01T00:00:00Z" | '+05:00'          || "01/Jan/2000 05:00 +05:00" | "timezone ahead of UTC"
+        "2000-01-01T00:00:00Z" | '-05:00'          || "31/Dec/1999 19:00 -05:00" | "timezone behind UTC"
+    }
+
+    void 'asDateTimeForDisplay should successfully convert a ZonedDateTime to a String'() {
+        given: 'a ZonedDateTime in the current timezone offset of the system'
+        ZoneOffset offset = DateUtil.getSystemZoneOffset()
+        ZonedDateTime zonedDateTime = ZonedDateTime.parse("2000-01-01T00:00:00" + offset)
+
+        expect:
+        assert DateUtil.asDateTimeForDisplay(zonedDateTime) == "01/Jan/2000 00:00 " + offset
+    }
+
+    void 'asDateTimeForDisplay should successfully convert a ZonedDateTime with a tz to a String for case: #scenario'() {
+        given:
+        ZonedDateTime zonedDateTime = ZonedDateTime.parse(givenDate)
+        ZoneId zone = ZoneId.of(timezoneToDisplay)
+
+        expect:
+        assert DateUtil.asDateTimeForDisplay(zonedDateTime, zone) == expectedConvertedDate
+
+        where:
+        givenDate                | timezoneToDisplay || expectedConvertedDate      | scenario
+        "2000-01-01T00:00Z"      | 'Z'               || "01/Jan/2000 00:00 Z"      | "UTC to UTC (no conversion)"
+        "2000-01-01T00:00+05:00" | 'Z'               || "31/Dec/1999 19:00 Z"      | "+05 to UTC (backwards conversion)"
+        "2000-01-01T00:00-05:00" | 'Z'               || "01/Jan/2000 05:00 Z"      | "-05 to UTC (forwards conversion)"
+        "2000-01-01T00:00Z"      | '+05:00'          || "01/Jan/2000 05:00 +05:00" | "UTC to +05 (forwards conversion)"
+        "2000-01-01T00:00+05:00" | '+05:00'          || "01/Jan/2000 00:00 +05:00" | "+05 to +05 (no conversion)"
+        "2000-01-01T00:00+06:00" | '+05:00'          || "31/Dec/1999 23:00 +05:00" | "+06 to +05 (backwards conversion)"
+    }
+
+    void 'asDateTimeForDisplay should successfully convert a Date to a String'() {
+        given: 'a Date in the current timezone offset of the system'
+        ZoneOffset offset = DateUtil.getSystemZoneOffset()
+        Date date = newDate("2000-01-01T00:00" + offset)
+
+        expect:
+        assert DateUtil.asDateTimeForDisplay(date) == "01/Jan/2000 00:00 " + offset
+    }
+
+    void 'asDateTimeForDisplay should successfully convert a Date with a tz to a String for case: #scenario'() {
+        given:
+        Date date = newDate(givenDate)
+        ZoneId zone = ZoneId.of(timezoneToDisplay)
+
+        expect:
+        assert DateUtil.asDateTimeForDisplay(date, zone) == expectedConvertedDate
+
+        where:
+        givenDate              | timezoneToDisplay || expectedConvertedDate      | scenario
+        "2000-01-01T00:00:00Z" | 'Z'               || "01/Jan/2000 00:00 Z"      | "UTC timezone"
+        "2000-01-01T00:00:00Z" | '+05:00'          || "01/Jan/2000 05:00 +05:00" | "timezone ahead of UTC"
+        "2000-01-01T00:00:00Z" | '-05:00'          || "31/Dec/1999 19:00 -05:00" | "timezone behind UTC"
+    }
+
+    void 'asDateForDisplay should successfully convert a Date to a String'() {
+        given: 'a Date in the current timezone offset of the system'
+        ZoneOffset offset = DateUtil.getSystemZoneOffset()
+        Date date = newDate("2000-01-01T00:00" + offset)
+
+        expect:
+        assert DateUtil.asDateForDisplay(date) == "01/Jan/2000"
+    }
+
+    void 'asDateForDisplay should successfully convert a Date with a tz to a String for case: #scenario'() {
+        given:
+        Date date = newDate(givenDate)
+        ZoneId zone = ZoneId.of(timezoneToDisplay)
+
+        expect:
+        assert DateUtil.asDateForDisplay(date, zone) == expectedConvertedDate
+
+        where:
+        givenDate           | timezoneToDisplay || expectedConvertedDate | scenario
+        "2000-01-01T00:00Z" | 'Z'               || "01/Jan/2000"         | "UTC timezone"
+        "2000-01-01T00:00Z" | '+05:00'          || "01/Jan/2000"         | "timezone ahead of UTC"
+        "2000-01-01T00:00Z" | '-05:00'          || "31/Dec/1999"         | "timezone behind UTC"
+    }
+
+    /**
+     * Convenience method to build a Date for tests.
+     */
+    Date newDate(String date){
+        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mmXXX").parse(date)
     }
 }

--- a/src/test/groovy/unit/org/pih/warehouse/utils/DateUtilSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/utils/DateUtilSpec.groovy
@@ -327,10 +327,10 @@ class DateUtilSpec extends Specification {
         assert DateUtil.asDateTimeForDisplay(date, zone) == expectedConvertedDate
 
         where:
-        givenDate              | timezoneToDisplay || expectedConvertedDate      | scenario
-        "2000-01-01T00:00:00Z" | 'Z'               || "01/Jan/2000 00:00 Z"      | "UTC timezone"
-        "2000-01-01T00:00:00Z" | '+05:00'          || "01/Jan/2000 05:00 +05:00" | "timezone ahead of UTC"
-        "2000-01-01T00:00:00Z" | '-05:00'          || "31/Dec/1999 19:00 -05:00" | "timezone behind UTC"
+        givenDate           | timezoneToDisplay || expectedConvertedDate      | scenario
+        "2000-01-01T00:00Z" | 'Z'               || "01/Jan/2000 00:00 Z"      | "UTC timezone"
+        "2000-01-01T00:00Z" | '+05:00'          || "01/Jan/2000 05:00 +05:00" | "timezone ahead of UTC"
+        "2000-01-01T00:00Z" | '-05:00'          || "31/Dec/1999 19:00 -05:00" | "timezone behind UTC"
     }
 
     void 'asDateForDisplay should successfully convert a Date to a String'() {

--- a/src/test/groovy/unit/org/pih/warehouse/utils/databinding/ZonedDateTimeValueConverterSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/utils/databinding/ZonedDateTimeValueConverterSpec.groovy
@@ -1,0 +1,75 @@
+package unit.org.pih.warehouse.utils.databinding
+
+import java.time.DateTimeException
+import java.time.format.DateTimeParseException
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import org.pih.warehouse.databinding.ZonedDateTimeValueConverter
+
+@Unroll
+class ZonedDateTimeValueConverterSpec extends Specification {
+
+    @Shared
+    ZonedDateTimeValueConverter converter
+
+    void setupSpec() {
+        converter = new ZonedDateTimeValueConverter()
+    }
+
+    void 'convertString should successfully parse valid strings for case: #scenario'() {
+        expect:
+        assert converter.convertString(givenDate).toString() == expectedConvertedDate
+
+        where:
+        givenDate                   || expectedConvertedDate    | scenario
+        "2000-01-01T00:00:00.000Z"  || "2000-01-01T00:00Z"      | "Full string in proper ISO format"
+        "2000-01-01T00:00:00.000 Z" || "2000-01-01T00:00Z"      | "Full string, space before timezone"
+        "2000-01-01 00:00:00.000Z"  || "2000-01-01T00:00Z"      | "Replace 'T' with space"
+        "2000-01-01T000000000Z"     || "2000-01-01T00:00Z"      | "Time with no separator"
+        "2000-01-01T00000000Z"      || "2000-01-01T00:00Z"      | "Time with no separator, shorter millis"
+        "2000-01-01T0000000Z"       || "2000-01-01T00:00Z"      | "Time with no separator, shorter millis"
+        "2000-01-01T000000Z"        || "2000-01-01T00:00Z"      | "Time with no separator, no millis"
+        "2000-01-01T0000Z"          || "2000-01-01T00:00Z"      | "Time with no separator, no seconds"
+        "2000-01-01T00:00:00:000Z"  || "2000-01-01T00:00Z"      | "Time with millis replace '.' with ':'"
+        "2000-01-01T00:00:00:00Z"   || "2000-01-01T00:00Z"      | "Time with millis replace '.' with ':', shorter millis"
+        "2000-01-01T00:00:00:0Z"    || "2000-01-01T00:00Z"      | "Time with millis replace '.' with ':', shorter millis"
+
+        // Note that (unlike Instant) timezone information is preserved.
+        "2000-01-01T00:00:00-05"    || "2000-01-01T00:00-05:00" | "Timezone conforming to X format w/ negative"
+        "2000-01-01T00:00:00-0500"  || "2000-01-01T00:00-05:00" | "Timezone conforming to XX format w/ negative"
+        "2000-01-01T00:00:00-05:00" || "2000-01-01T00:00-05:00" | "Timezone conforming to XXX format w/ negative"
+        "2000-01-01T00:00:00+00"    || "2000-01-01T00:00Z"      | "Timezone conforming to X format w/ zero"
+        "2000-01-01T00:00:00+0000"  || "2000-01-01T00:00Z"      | "Timezone conforming to XX format w/ zero"
+        "2000-01-01T00:00:00+00:00" || "2000-01-01T00:00Z"      | "Timezone conforming to XXX format w/ zero"
+        "2000-01-01T00:00:00+05"    || "2000-01-01T00:00+05:00" | "Timezone conforming to X format w/ positive"
+        "2000-01-01T00:00:00+0500"  || "2000-01-01T00:00+05:00" | "Timezone conforming to XX format w/ positive"
+        "2000-01-01T00:00:00+05:00" || "2000-01-01T00:00+05:00" | "Timezone conforming to XXX format w/ positive"
+    }
+
+    void 'convertString should fail to parse invalid strings for case: #failureReason'() {
+        when:
+        converter.convertString(givenDate)
+
+        then:
+        thrown(exception)
+
+        where:
+        givenDate                 || exception              | failureReason
+        "2000-01-32T00:00Z"       || DateTimeParseException | "day out of range"
+        "2000-13-01T00:00Z"       || DateTimeParseException | "month out of range"
+        "10000-13-01T00:00Z"      || DateTimeParseException | "year out of range"
+        "00-01-01T00:00Z"         || DateTimeParseException | "two digit year format not supported"
+        "2000-01-01T00:00:00.000" || DateTimeException      | "full datetime, no timezone"
+        "2000-01-01T00:00:00.00"  || DateTimeException      | "Shorter millis, no timezone"
+        "2000-01-01T00:00:00.0"   || DateTimeException      | "Ever shorter millis, no timezone"
+        "2000-01-01T00:00:00"     || DateTimeException      | "No millis, no timezone"
+        "2000-01-01T00:00"        || DateTimeException      | "No seconds, no timezone"
+        "2000-01-01"              || DateTimeException      | "No time"
+        "2000 01 01"              || DateTimeException      | "Date with spaces, no time"
+        "2000/01/01"              || DateTimeException      | "Date with slashes, no time"
+        "01/01/2000"              || DateTimeException      | "Date with slashes, Excel format, no time"
+        "20000101"                || DateTimeException      | "Date with no separator, no time"
+    }
+}


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7255

**Description:**
- Switch Instant to error if time or zone aren't provided instead of defaulting to midnight UTC (Instant isn't being used anywhere yet so this is safe to do)
- Add support for parsing ZonedDateTime. ZDT is like Instant except it preserves timezone (Instant is only a UTC timestamp) so is needed for exports and GSPs where we need the backend to know what timezone to display
- Add XForDisplay methods for converting these data types to Strings for display (used by GSPs, and data exporters).
