### PR TITLE
OBPIH-7193: add product inventory snapshot transaction type

### DIFF
--- a/grails-app/migrations/0.9.x/changelog-2025-04-29-0000-add-inventory-baseline-transaction-type.xml
+++ b/grails-app/migrations/0.9.x/changelog-2025-04-29-0000-add-inventory-baseline-transaction-type.xml
@@ -11,7 +11,7 @@
         <insert tableName="transaction_type">
             <column name="id" value="12" />
             <column name="version" value="0" />
-            <column name="name" value="Product Inventory Snapshot" />
+            <column name="name" value="Inventory Baseline" />
             <column name="sort_order" value="0" />
             <column name="date_created" value="2025-04-29T00:00" />
             <column name="last_updated" value="2025-04-29T00:00" />

--- a/grails-app/migrations/0.9.x/changelog-2025-04-29-0000-add-product-inventory-snapshot-transaction-type.xml
+++ b/grails-app/migrations/0.9.x/changelog-2025-04-29-0000-add-product-inventory-snapshot-transaction-type.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+
+    <changeSet author="ewaterman" id="290420250000-0">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="transaction_type" />
+        </preConditions>
+
+        <insert tableName="transaction_type">
+            <column name="id" value="12" />
+            <column name="version" value="0" />
+            <column name="name" value="Product Inventory Snapshot" />
+            <column name="sort_order" value="0" />
+            <column name="date_created" value="2025-04-29T00:00" />
+            <column name="last_updated" value="2025-04-29T00:00" />
+            <column name="transaction_code" value="PRODUCT_INVENTORY" />
+        </insert>
+    </changeSet>
+</databaseChangeLog>

--- a/grails-app/migrations/0.9.x/changelog.xml
+++ b/grails-app/migrations/0.9.x/changelog.xml
@@ -30,4 +30,5 @@
     <include file="0.9.x/changelog-2025-03-11-1300-drop-user-foreign-key-from-assignee-in-cycle-count-item.xml" />
     <include file="0.9.x/changelog-2025-03-11-1400-add-person-foreign-key-for-assignee-in-cycle-count-item.xml" />
     <include file="0.9.x/changelog-2025-03-26-2057-update-abc-class-convert-empty-string-to-null.xml" />
+    <include file="0.9.x/changelog-2025-04-29-0000-add-product-inventory-snapshot-transaction-type.xml" />
 </databaseChangeLog>

--- a/grails-app/migrations/0.9.x/changelog.xml
+++ b/grails-app/migrations/0.9.x/changelog.xml
@@ -30,5 +30,5 @@
     <include file="0.9.x/changelog-2025-03-11-1300-drop-user-foreign-key-from-assignee-in-cycle-count-item.xml" />
     <include file="0.9.x/changelog-2025-03-11-1400-add-person-foreign-key-for-assignee-in-cycle-count-item.xml" />
     <include file="0.9.x/changelog-2025-03-26-2057-update-abc-class-convert-empty-string-to-null.xml" />
-    <include file="0.9.x/changelog-2025-04-29-0000-add-product-inventory-snapshot-transaction-type.xml" />
+    <include file="0.9.x/changelog-2025-04-29-0000-add-inventory-baseline-transaction-type.xml" />
 </databaseChangeLog>

--- a/grails-app/services/org/pih/warehouse/inventory/CycleCountProductInventoryTransactionService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/CycleCountProductInventoryTransactionService.groovy
@@ -1,0 +1,15 @@
+package org.pih.warehouse.inventory
+
+import grails.gorm.transactions.Transactional
+
+/**
+ * Responsible for managing product inventory transactions for the Cycle Count feature.
+ */
+@Transactional
+class CycleCountProductInventoryTransactionService extends ProductInventoryTransactionService<CycleCount> {
+
+    @Override
+    void setSourceObject(Transaction transaction, CycleCount sourceObject) {
+        transaction.cycleCount = sourceObject
+    }
+}

--- a/grails-app/services/org/pih/warehouse/inventory/CycleCountTransactionService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/CycleCountTransactionService.groovy
@@ -16,7 +16,7 @@ class CycleCountTransactionService {
 
     CycleCountProductAvailabilityService cycleCountProductAvailabilityService
     ProductAvailabilityService productAvailabilityService
-    ProductInventoryTransactionService productInventoryTransactionService
+    CycleCountProductInventoryTransactionService cycleCountProductInventoryTransactionService
     TransactionIdentifierService transactionIdentifierService
 
     /**
@@ -126,10 +126,9 @@ class CycleCountTransactionService {
             // quantity to be represented by a separate adjustment transaction. It's important to note that the quantity
             // values for this transaction will be a pure copy of QoH in product availability, NOT the quantityOnHand of
             // the cycle count items.
-            Transaction transaction = productInventoryTransactionService.createTransaction(
+            Transaction transaction = cycleCountProductInventoryTransactionService.createSnapshotTransaction(
                     cycleCount.facility,
                     product,
-                    ProductInventorySnapshotSource.CYCLE_COUNT,
                     cycleCount,
                     transactionDate)
 

--- a/grails-app/services/org/pih/warehouse/inventory/CycleCountTransactionService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/CycleCountTransactionService.groovy
@@ -126,7 +126,7 @@ class CycleCountTransactionService {
             // quantity to be represented by a separate adjustment transaction. It's important to note that the quantity
             // values for this transaction will be a pure copy of QoH in product availability, NOT the quantityOnHand of
             // the cycle count items.
-            Transaction transaction = cycleCountProductInventoryTransactionService.createSnapshotTransaction(
+            Transaction transaction = cycleCountProductInventoryTransactionService.createInventoryBaselineTransaction(
                     cycleCount.facility,
                     product,
                     cycleCount,

--- a/grails-app/services/org/pih/warehouse/inventory/ProductInventoryTransactionService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductInventoryTransactionService.groovy
@@ -9,13 +9,19 @@ import org.pih.warehouse.core.Location
 import org.pih.warehouse.product.Product
 
 /**
- * Responsible for managing product inventory transactions.
+ * Responsible for managing product inventory transactions. To be extended by feature-specific implementations.
  */
 @Transactional
-class ProductInventoryTransactionService {
+abstract class ProductInventoryTransactionService<T> {
 
     ProductAvailabilityService productAvailabilityService
     TransactionIdentifierService transactionIdentifierService
+
+    /**
+     * Transactions will often have a source object (not to be confused with the "source" field) that is responsible
+     * for the creation of the transaction. This method sets that source object on the given Transaction.
+     */
+    abstract void setSourceObject(Transaction transaction, T transactionSource)
 
     /**
      * Create a new product inventory transaction based on the current QoH in product availability.
@@ -26,19 +32,17 @@ class ProductInventoryTransactionService {
      *
      * @param facility The Location to take the product inventory snapshot at
      * @param product The Product to take the product inventory snapshot for
-     * @param sourceType The feature triggering the product inventory snapshot
-     * @param source The source object to be associated with the Transaction, such as CycleCount, Order, Requisition...
+     * @param sourceObject The source object that caused the Transaction. Ex: CycleCount, Order, Requisition...
      * @param transactionDate The datetime that the transaction should be marked with
      * @return The Transaction that was created
      */
-    Transaction createTransaction(
+    Transaction createSnapshotTransaction(
             Location facility,
             Product product,
-            ProductInventorySnapshotSource sourceType,
-            Object source,
+            T sourceObject,
             Date transactionDate=new Date()) {
 
-        TransactionType transactionType = TransactionType.read(Constants.PRODUCT_INVENTORY_TRANSACTION_TYPE_ID)
+        TransactionType transactionType = TransactionType.read(Constants.PRODUCT_INVENTORY_SNAPSHOT_TRANSACTION_TYPE_ID)
 
         Transaction transaction = new Transaction(
                 source: facility,
@@ -49,11 +53,7 @@ class ProductInventoryTransactionService {
 
         transaction.transactionNumber = transactionIdentifierService.generate(transaction)
 
-        switch (sourceType) {
-            case ProductInventorySnapshotSource.CYCLE_COUNT:
-                transaction.cycleCount = source as CycleCount
-                break
-        }
+        setSourceObject(transaction, sourceObject)
 
         // Create a transaction entry for every [bin location + lot number] pair that the product currently has.
         // We don't need to include zero quantity items. Excluding them from the transaction achieves the same result.

--- a/grails-app/services/org/pih/warehouse/inventory/ProductInventoryTransactionService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductInventoryTransactionService.groovy
@@ -24,11 +24,17 @@ abstract class ProductInventoryTransactionService<T> {
     abstract void setSourceObject(Transaction transaction, T transactionSource)
 
     /**
-     * Create a new product inventory transaction based on the current QoH in product availability.
+     * Create a new "inventory baseline" product inventory transaction based on the current QoH in product availability.
      *
-     * We refer to this transaction as a product inventory "snapshot" because it's functionally a copy of what the
-     * quantity on hand (determined by product availability) was for each [bin location + lot number] of the product at
-     * the time. As such, transactions created via this method should NOT result in any quantity changes/adjustments.
+     * We refer to this transaction as a "baseline" because it gives us two things:
+     *
+     * 1) It sets a new baseline for the stock of the product. Any transactions on the product that are backdated to
+     *    before the most recent baseline will NOT have any effect on quantity on hand.
+     *
+     * 2) It acts as a "snapshot" of what the quantity on hand (determined by product availability) was for each
+     *    [bin location + lot number] of the product at the time of the transaction. As such, transactions created via
+     *    this method should NOT result in any quantity changes/adjustments. (However if transactions are backdated to
+     *    before the baseline, the baseline will have an implied quantity adjustment.)
      *
      * @param facility The Location to take the product inventory snapshot at
      * @param product The Product to take the product inventory snapshot for
@@ -36,13 +42,13 @@ abstract class ProductInventoryTransactionService<T> {
      * @param transactionDate The datetime that the transaction should be marked with
      * @return The Transaction that was created
      */
-    Transaction createSnapshotTransaction(
+    Transaction createInventoryBaselineTransaction(
             Location facility,
             Product product,
             T sourceObject,
             Date transactionDate=new Date()) {
 
-        TransactionType transactionType = TransactionType.read(Constants.PRODUCT_INVENTORY_SNAPSHOT_TRANSACTION_TYPE_ID)
+        TransactionType transactionType = TransactionType.read(Constants.INVENTORY_BASELINE_TRANSACTION_TYPE_ID)
 
         Transaction transaction = new Transaction(
                 source: facility,

--- a/src/main/groovy/org/pih/warehouse/core/Constants.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/Constants.groovy
@@ -96,6 +96,7 @@ class Constants {
     static final String TRANSFER_OUT_TRANSACTION_TYPE_ID = "9"
     static final String ADJUSTMENT_DEBIT_TRANSACTION_TYPE_ID = "10"
     static final String PRODUCT_INVENTORY_TRANSACTION_TYPE_ID = "11"
+    static final String PRODUCT_INVENTORY_SNAPSHOT_TRANSACTION_TYPE_ID = "12"
 
     // direct references to locations by primary key
     static final String WAREHOUSE_LOCATION_TYPE_ID = "2"

--- a/src/main/groovy/org/pih/warehouse/core/Constants.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/Constants.groovy
@@ -96,7 +96,7 @@ class Constants {
     static final String TRANSFER_OUT_TRANSACTION_TYPE_ID = "9"
     static final String ADJUSTMENT_DEBIT_TRANSACTION_TYPE_ID = "10"
     static final String PRODUCT_INVENTORY_TRANSACTION_TYPE_ID = "11"
-    static final String PRODUCT_INVENTORY_SNAPSHOT_TRANSACTION_TYPE_ID = "12"
+    static final String INVENTORY_BASELINE_TRANSACTION_TYPE_ID = "12"
 
     // direct references to locations by primary key
     static final String WAREHOUSE_LOCATION_TYPE_ID = "2"

--- a/src/main/groovy/org/pih/warehouse/inventory/ProductInventorySnapshotSource.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/ProductInventorySnapshotSource.groovy
@@ -1,8 +1,0 @@
-package org.pih.warehouse.inventory
-
-/**
- * Enumerates the different features/sources that can trigger a "snapshot style" product inventory transaction.
- */
-enum ProductInventorySnapshotSource {
-    CYCLE_COUNT,
-}

--- a/src/test/groovy/unit/org/pih/warehouse/inventory/CycleCountProductInventoryTransactionServiceSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/inventory/CycleCountProductInventoryTransactionServiceSpec.groovy
@@ -49,11 +49,11 @@ class CycleCountProductInventoryTransactionServiceSpec extends Specification imp
 
         // Set up the transaction types
         productInventoryTransactionType = new TransactionType()
-        productInventoryTransactionType.id = Constants.PRODUCT_INVENTORY_SNAPSHOT_TRANSACTION_TYPE_ID
+        productInventoryTransactionType.id = Constants.INVENTORY_BASELINE_TRANSACTION_TYPE_ID
         productInventoryTransactionType.save(validate: false)
     }
 
-    void 'createSnapshotTransaction should succeed when some items are available'() {
+    void 'createInventoryBaselineTransaction should succeed when some items are available'() {
         given: 'mocked inputs'
         Location facility = new Location(inventory: new Inventory())
         Product product = new Product()
@@ -80,7 +80,7 @@ class CycleCountProductInventoryTransactionServiceSpec extends Specification imp
                 facility, [product.id], false, true) >> availableItems
 
         when:
-        Transaction transaction = cycleCountProductInventoryTransactionService.createSnapshotTransaction(
+        Transaction transaction = cycleCountProductInventoryTransactionService.createInventoryBaselineTransaction(
                 facility, product, cycleCount, date)
 
         then:

--- a/src/test/groovy/unit/org/pih/warehouse/inventory/CycleCountProductInventoryTransactionServiceSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/inventory/CycleCountProductInventoryTransactionServiceSpec.groovy
@@ -9,11 +9,10 @@ import org.pih.warehouse.api.AvailableItem
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.inventory.CycleCount
+import org.pih.warehouse.inventory.CycleCountProductInventoryTransactionService
 import org.pih.warehouse.inventory.Inventory
 import org.pih.warehouse.inventory.InventoryItem
 import org.pih.warehouse.inventory.ProductAvailabilityService
-import org.pih.warehouse.inventory.ProductInventorySnapshotSource
-import org.pih.warehouse.inventory.ProductInventoryTransactionService
 import org.pih.warehouse.inventory.Transaction
 import org.pih.warehouse.inventory.TransactionEntry
 import org.pih.warehouse.inventory.TransactionIdentifierService
@@ -21,10 +20,10 @@ import org.pih.warehouse.inventory.TransactionType
 import org.pih.warehouse.product.Product
 
 @Unroll
-class ProductInventoryTransactionServiceSpec extends Specification implements DataTest {
+class CycleCountProductInventoryTransactionServiceSpec extends Specification implements DataTest {
 
     @Shared
-    ProductInventoryTransactionService productInventoryTransactionService
+    CycleCountProductInventoryTransactionService cycleCountProductInventoryTransactionService
 
     @Shared
     ProductAvailabilityService productAvailabilityServiceStub
@@ -40,21 +39,21 @@ class ProductInventoryTransactionServiceSpec extends Specification implements Da
     }
 
     void setup() {
-        productInventoryTransactionService = new ProductInventoryTransactionService()
+        cycleCountProductInventoryTransactionService = new CycleCountProductInventoryTransactionService()
 
         productAvailabilityServiceStub = Stub(ProductAvailabilityService)
-        productInventoryTransactionService.productAvailabilityService = productAvailabilityServiceStub
+        cycleCountProductInventoryTransactionService.productAvailabilityService = productAvailabilityServiceStub
 
         transactionIdentifierServiceStub = Stub(TransactionIdentifierService)
-        productInventoryTransactionService.transactionIdentifierService = transactionIdentifierServiceStub
+        cycleCountProductInventoryTransactionService.transactionIdentifierService = transactionIdentifierServiceStub
 
         // Set up the transaction types
         productInventoryTransactionType = new TransactionType()
-        productInventoryTransactionType.id = Constants.PRODUCT_INVENTORY_TRANSACTION_TYPE_ID
+        productInventoryTransactionType.id = Constants.PRODUCT_INVENTORY_SNAPSHOT_TRANSACTION_TYPE_ID
         productInventoryTransactionType.save(validate: false)
     }
 
-    void 'createTransaction should succeed when some items are available'() {
+    void 'createSnapshotTransaction should succeed when some items are available'() {
         given: 'mocked inputs'
         Location facility = new Location(inventory: new Inventory())
         Product product = new Product()
@@ -81,8 +80,8 @@ class ProductInventoryTransactionServiceSpec extends Specification implements Da
                 facility, [product.id], false, true) >> availableItems
 
         when:
-        Transaction transaction = productInventoryTransactionService.createTransaction(
-                facility, product, ProductInventorySnapshotSource.CYCLE_COUNT, cycleCount, date)
+        Transaction transaction = cycleCountProductInventoryTransactionService.createSnapshotTransaction(
+                facility, product, cycleCount, date)
 
         then:
         assert transaction.transactionType == productInventoryTransactionType

--- a/src/test/groovy/unit/org/pih/warehouse/inventory/CycleCountTransactionServiceSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/inventory/CycleCountTransactionServiceSpec.groovy
@@ -249,7 +249,7 @@ class CycleCountTransactionServiceSpec extends Specification implements DataTest
                 transactionType: productInventoryTransactionType,
         )
 
-        cycleCountProductInventoryTransactionServiceStub.createSnapshotTransaction(
+        cycleCountProductInventoryTransactionServiceStub.createInventoryBaselineTransaction(
                 facility, product, cycleCount, date) >> transaction
 
         return transaction

--- a/src/test/groovy/unit/org/pih/warehouse/inventory/CycleCountTransactionServiceSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/inventory/CycleCountTransactionServiceSpec.groovy
@@ -11,12 +11,11 @@ import org.pih.warehouse.inventory.CycleCount
 import org.pih.warehouse.inventory.CycleCountItem
 import org.pih.warehouse.inventory.CycleCountItemStatus
 import org.pih.warehouse.inventory.CycleCountProductAvailabilityService
+import org.pih.warehouse.inventory.CycleCountProductInventoryTransactionService
 import org.pih.warehouse.inventory.CycleCountTransactionService
 import org.pih.warehouse.inventory.Inventory
 import org.pih.warehouse.inventory.InventoryItem
 import org.pih.warehouse.inventory.ProductAvailabilityService
-import org.pih.warehouse.inventory.ProductInventorySnapshotSource
-import org.pih.warehouse.inventory.ProductInventoryTransactionService
 import org.pih.warehouse.inventory.Transaction
 import org.pih.warehouse.inventory.TransactionEntry
 import org.pih.warehouse.inventory.TransactionIdentifierService
@@ -36,7 +35,7 @@ class CycleCountTransactionServiceSpec extends Specification implements DataTest
     ProductAvailabilityService productAvailabilityServiceStub
 
     @Shared
-    ProductInventoryTransactionService productInventoryTransactionServiceStub
+    CycleCountProductInventoryTransactionService cycleCountProductInventoryTransactionServiceStub
 
     @Shared
     TransactionIdentifierService transactionIdentifierServiceStub
@@ -60,8 +59,8 @@ class CycleCountTransactionServiceSpec extends Specification implements DataTest
         cycleCountProductAvailabilityServiceStub.refreshProductAvailability(_ as CycleCount) >>
                 new CycleCountProductAvailabilityService.CycleCountItemsForRefresh()
 
-        productInventoryTransactionServiceStub = Stub(ProductInventoryTransactionService)
-        cycleCountTransactionService.productInventoryTransactionService = productInventoryTransactionServiceStub
+        cycleCountProductInventoryTransactionServiceStub = Stub(CycleCountProductInventoryTransactionService)
+        cycleCountTransactionService.cycleCountProductInventoryTransactionService = cycleCountProductInventoryTransactionServiceStub
 
         productAvailabilityServiceStub = Stub(ProductAvailabilityService)
         cycleCountTransactionService.productAvailabilityService = productAvailabilityServiceStub
@@ -102,7 +101,7 @@ class CycleCountTransactionServiceSpec extends Specification implements DataTest
         )
 
         and: 'a mocked product inventory transaction'
-        createExpectedProductInventoryTransaction(facility, product, date)
+        createExpectedProductInventoryTransaction(facility, product, cycleCount, date)
 
         when:
         List<Transaction> transactions = cycleCountTransactionService.createTransactions(cycleCount, true)
@@ -147,8 +146,8 @@ class CycleCountTransactionServiceSpec extends Specification implements DataTest
         )
 
         and: 'mocked product inventory transactions'
-        createExpectedProductInventoryTransaction(facility, product1, date)
-        createExpectedProductInventoryTransaction(facility, product2, date)
+        createExpectedProductInventoryTransaction(facility, product1, cycleCount, date)
+        createExpectedProductInventoryTransaction(facility, product2, cycleCount, date)
 
         when:
         List<Transaction> transactions = cycleCountTransactionService.createTransactions(cycleCount, true)
@@ -205,7 +204,7 @@ class CycleCountTransactionServiceSpec extends Specification implements DataTest
         transactionIdentifierServiceStub.generate(_ as Transaction) >> "123ABC"
 
         and: 'a mocked product inventory transaction'
-        createExpectedProductInventoryTransaction(facility, product, date)
+        createExpectedProductInventoryTransaction(facility, product, cycleCount, date)
 
         when:
         List<Transaction> transactions = cycleCountTransactionService.createTransactions(cycleCount, true)
@@ -242,14 +241,16 @@ class CycleCountTransactionServiceSpec extends Specification implements DataTest
         assert positiveTransactionEntry.quantity == 3
     }
 
-    private Transaction createExpectedProductInventoryTransaction(Location facility, Product product, Date date) {
+    private Transaction createExpectedProductInventoryTransaction(
+            Location facility, Product product, CycleCount cycleCount, Date date) {
+
         // This is mocked data so we don't really care about any of the other fields, not even the transaction entries.
         Transaction transaction = new Transaction(
                 transactionType: productInventoryTransactionType,
         )
 
-        productInventoryTransactionServiceStub.createTransaction(
-                facility, product, ProductInventorySnapshotSource.CYCLE_COUNT, date) >> transaction
+        cycleCountProductInventoryTransactionServiceStub.createSnapshotTransaction(
+                facility, product, cycleCount, date) >> transaction
 
         return transaction
     }


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7193

**Description:** Add the new "Product Inventory Snapshot" transaction type and switch cycle count to use it.


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

Cycle counts can successfully create the new "product inventory snapshot" transactions after the count is submitted:

![Screenshot from 2025-04-29 11-54-19](https://github.com/user-attachments/assets/25a5f47a-7335-49d4-927d-5b4b3f5d6628)

And last counted date is still updated correctly:

![Screenshot from 2025-04-29 11-53-48](https://github.com/user-attachments/assets/972b751c-97fc-4ca8-b40c-b2b68009c906)
