### PR TITLE
OBS-1866 prevent picking during outbounds with no product availability

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -1049,9 +1049,13 @@ class ProductAvailabilityService {
         }
     }
 
-    // Get quantity available to promise (with negative values)
-    def getQuantityAvailableToPromise(Location location, Location binLocation, InventoryItem inventoryItem) {
-         def quantityAvailableToPromise = ProductAvailability.createCriteria().get {
+    /**
+     * Fetches the quantity available to promise (QATP) for the given item in the given bin. QATP can become negative
+     * if quantity on hand (QoH) is lowered (via a record stock for example) to be less than the quantity allocated
+     * across all pending outbounds for the item + bin.
+     */
+    Integer getQuantityAvailableToPromise(Location location, Location binLocation, InventoryItem inventoryItem) {
+         return ProductAvailability.createCriteria().get {
             projections {
                 sum("quantityAvailableToPromise")
             }
@@ -1063,9 +1067,7 @@ class ProductAvailabilityService {
             } else {
                 isNull("binLocation")
             }
-        }
-
-        return quantityAvailableToPromise ?: 0
+        } as Integer
     }
 
     def getQuantityAvailableToPromiseByProductNotInBin(Location location, Location binLocation, Product product) {

--- a/grails-app/services/org/pih/warehouse/shipping/ShipmentService.groovy
+++ b/grails-app/services/org/pih/warehouse/shipping/ShipmentService.groovy
@@ -661,7 +661,7 @@ class ShipmentService {
         shipment.shipmentItems.each { shipmentItem ->
             // FIXME this seems a little expensive so we should rework validateShipmentItem to not throw an exception
             try {
-                validateShipmentItem(shipmentItem, true)
+                validateShipmentItem(shipmentItem)
             } catch (ValidationException e) {
                 log.warn("Validation error " + e.message)
                 if (!errors) {
@@ -700,25 +700,14 @@ class ShipmentService {
     }
 
     /**
-     *
-     * @param shipmentItem
-     * @return
-     */
-    boolean validateShipmentItem(ShipmentItem shipmentItem) {
-        boolean binLocationRequired = (shipmentItem.binLocation ?: false)
-        return validateShipmentItem(shipmentItem, binLocationRequired)
-    }
-
-    /**
      * Validate the shipment item when it's being added to the shipment.
      *
      * @param shipmentItem shipment item to validate
-     * @param binLocationRequired if shipment item has a bin location we validate quantity only against that bin
      * @return
      */
-    boolean validateShipmentItem(ShipmentItem shipmentItem, boolean binLocationRequired) {
+    boolean validateShipmentItem(ShipmentItem shipmentItem) {
         def origin = Location.get(shipmentItem?.shipment?.origin?.id)
-        log.info("Validating shipment item at ${origin?.name} for product=${shipmentItem.product}, lotNumber=${shipmentItem.inventoryItem}, binLocation=${shipmentItem.binLocation}, binLocationRequired=${binLocationRequired}")
+        log.info("Validating shipment item at ${origin?.name} for product=${shipmentItem.product}, lotNumber=${shipmentItem.inventoryItem}, binLocation=${shipmentItem.binLocation}")
 
         // Location must be locally managed and
         if (origin.requiresOutboundQuantityValidation()) {
@@ -727,7 +716,22 @@ class ShipmentService {
                 throw new ValidationException("Shipment item is invalid", shipmentItem.errors)
             }
 
-            def quantityAvailableToPromise = productAvailabilityService.getQuantityAvailableToPromise(origin, shipmentItem.binLocation, shipmentItem.inventoryItem)
+            // Because creating picklist items triggers updates to product availability, if we're editing an existing
+            // shipment/picklist item, the calculated QATP will have already subtracted the picked quantity of the
+            // current item (QATP == QoH - quantity allocated via pending outbounds). We need to factor that into our
+            // equation so as to not double count it when validating availability.
+            Integer quantityAvailableToPromise = productAvailabilityService.getQuantityAvailableToPromise(
+                    origin, shipmentItem.binLocation, shipmentItem.inventoryItem)
+
+            // OBS-1866: QATP should always have a value, but in case it doesn't (possibly due to a failed product
+            //           availability refresh), we need to handle that case gracefully.
+            if (quantityAvailableToPromise == null) {
+                // QATP == QoH - quantity allocated via pending outbounds. We assume QoH==0 when product availability
+                // does not exist for the item, so QATP will simply be a negation of the quantity picked (which will
+                // always cause an error if we've picked more than a zero quantity).
+                quantityAvailableToPromise = -shipmentItem.quantityPicked
+            }
+
             def quantityAvailableWithPicked = quantityAvailableToPromise + shipmentItem.quantityPicked - shipmentItem.unavailableQuantityPicked
 
             def duplicatedShipmentItemsQuantity = getDuplicatedShipmentItemsQuantity(shipmentItem.shipment, shipmentItem.binLocation, shipmentItem.inventoryItem)


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBS-1866

**Description:** There was a pending outbound that had a pick for product 10665 on the default bin, which I assume had non-zero quantity at the time it was picked. For some unknown reason, after an internal stock transfer that moved the stock to a different bin, the default bin no longer had a product inventory record. This allowed a user to submit the pending outbound which had a pick on the default bin, even though the bin had zero quantity. This caused the default bin to have a negative quantity.

What caused the product inventory record to not exist is unknown, but this code change handles the case where we're trying to pick from a bin that does not have a product inventory. We'll now throw an invalid pick error in that scenario.