### PR TITLE
Disable MySQL 5.7 test runner

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # If we start actively supporting other databases, they should be added here so that we can test against them.
-        testdatabase: ["mysql:5.7.44", "mysql:8.0.36", "mariadb:10.3.39"]
+        testdatabase: ["mysql:8.0.36", "mariadb:10.3.39"]
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION


### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** N/A

**Description:** We're not supporting MySQL 5.7 for 0.9.x releases any longer, and since we've started using CTEs (which are not supported in 5.7), this marks the final nail in the coffin for abandoning 5.7 support.