### PR TITLE
Arm64 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,21 @@ https://openboxes.atlassian.net/wiki/spaces/OBW/pages/1719435265/Push-button+dep
 * The database we use in production won't run natively on modern Macs.
   * Easiest way to install a compatible database is by using [`brew install mariadb`](https://mariadb.com/kb/en/installing-mariadb-on-macos-using-homebrew/).
   * Alternatively, ARM builds of MySQL 8 are available. Consider downloading [8.x LTS here](https://dev.mysql.com/downloads/mysql/).
+* No ARM build of Node 14 exists either.
+  * But you can run it via x86 emulation as follows:
+    1. `/usr/sbin/softwareupdate --install-rosetta --agree-to-license`
+    2. Install `nvm` (_only_ – do _not_ install `node` itself) using [these instructions](https://nodejs.org/en/download)
+    3. Launch a terminal that uses Rosetta to pretend to be an x86 host: `arch -x86_64 bash`
+    4. Within that terminal, run `nvm install 14`
+    5. Open up a new terminal and run the following command; you should see an `x86_64` binary, which should be able to run successfully on an ARM host.
+      ```bash
+      $ hash -r && type node | awk '{print $3}' | xargs file
+      \*\*/.nvm/versions/node/v14.21.3/bin/node: Mach-O 64-bit executable x86_64
+      $ arch; node --version
+      arm64
+      v14.21.3
+      ```
+
 #### Optional
 * [IntelliJ IDEA](https://www.jetbrains.com/idea/download/)
 * Chrome

--- a/README.md
+++ b/README.md
@@ -195,13 +195,8 @@ npm run watch
 ```
 
 #### 9. Upgrade the project to the currently installed grails version 
-Either of the following actions (upgrade, compile, run-app) should generate the all important Spring configuration 
+Either of the following actions (compile, run-app) should generate the all important Spring configuration 
 (`/WEB-INF/applicationContext.xml`) and start the dependency resolution process.  
-
-```    
-grails upgrade
-```
-OR
 
 ```    
 grails compile

--- a/README.md
+++ b/README.md
@@ -91,13 +91,18 @@ https://openboxes.atlassian.net/wiki/spaces/OBW/pages/1719435265/Push-button+dep
 #### Required
 * [Java 8 (must install Java 8)](https://www.oracle.com/pl/java/technologies/javase/javase8-archive-downloads.html) or via SDK
 * [MySQL 5.7 or MySQL 8.0](https://downloads.mysql.com/archives/community/) or [MariaDB 10.11.4](https://mariadb.com/kb/en/mariadb-10-11-4-release-notes/)
-  * Mac users: 5.7.31 is the latest 5.7.x with a pre-built installer and works fine
+  * Mac users: 5.7.31 is the latest 5.7.x with a pre-built installer. However, it will not work on a modern machine that uses Apple Silicon.
   * Issues related to the MySQL 8 upgrade could be found [here](https://github.com/openboxes/openboxes/issues?q=is%3Aissue+mysql+8+is%3Aopen+)
 * [SDK Man](https://sdkman.io/install)
 * [Grails 3.3.18](https://grails.org/download.html)
 * NPM 6.14.6
 * Node 14+
 
+##### Installation notes for M-series (Apple Silicon) Macs
+
+* The database we use in production won't run natively on modern Macs.
+  * Easiest way to install a compatible database is by using [`brew install mariadb`](https://mariadb.com/kb/en/installing-mariadb-on-macos-using-homebrew/).
+  * Alternatively, ARM builds of MySQL 8 are available. Consider downloading [8.x LTS here](https://dev.mysql.com/downloads/mysql/).
 #### Optional
 * [IntelliJ IDEA](https://www.jetbrains.com/idea/download/)
 * Chrome
@@ -173,6 +178,15 @@ NOTE: If you are running in development mode with a copy of an existing producti
 instruct the application to not setup test fixtures automatically by uncommenting the above property:
 ```
 openboxes.fixtures.enabled=false
+```
+
+##### Note for MariaDB users
+
+If using MariaDB the configuration file needs to be slightly different. You'll need to edit `dataSource.url` and specify `dataSource.driverClassName`, as follows.
+
+```conf
+dataSource.url=jdbc:mariadb://localhost:3306/openboxes?serverTimezone=UTC
+dataSource.driverClassName: org.mariadb.jdbc.Driver
 ```
 
 #### 6. Install NPM dependencies

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ https://openboxes.atlassian.net/wiki/spaces/OBW/pages/1719435265/Push-button+dep
   * Mac users: 5.7.31 is the latest 5.7.x with a pre-built installer and works fine
   * Issues related to the MySQL 8 upgrade could be found [here](https://github.com/openboxes/openboxes/issues?q=is%3Aissue+mysql+8+is%3Aopen+)
 * [SDK Man](https://sdkman.io/install)
-* [Grails 3.3.17](https://grails.org/download.html)
+* [Grails 3.3.18](https://grails.org/download.html)
 * NPM 6.14.6
 * Node 14+
 
@@ -117,14 +117,14 @@ $ sdk version
 SDKMAN 5.13.2
 ```
 
-Install Grails 3.3.10
+Install Grails 3.3.18
 ```
-$ sdk install grails 3.3.10
+$ sdk install grails 3.3.18
 ```
 
 Install Java 8*
 ```
-$ sdk install java 8.0.332-zulu
+$ sdk install java 8.0.452-zulu
 ```
 
 `*` - in case you have not installed Java yet.

--- a/build.gradle
+++ b/build.gradle
@@ -225,6 +225,11 @@ configurations {
                     }
                 }
 
+                if (details.requested.group == 'net.java.dev.jna') {
+                    details.because 'enforce consistent JNA versioning and aarch64 support'
+                    details.useVersion(jnaVersion)
+                }
+
                 if (details.requested.group == 'org.apache.httpcomponents') {
                     details.because 'enforce consistent httpcomponents versioning'
                     if (details.requested.name == 'httpcore') {

--- a/build.gradle
+++ b/build.gradle
@@ -135,6 +135,8 @@ bootRun {
         '-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005'
     ]
     systemProperties System.properties
+    // instruct Spring Boot to set catalina.base for embedded Tomcat
+    systemProperty "server.tomcat.basedir", "${projectDir}"
 }
 
 configurations {

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,8 @@ htmlUnitVersion=2.70.0
 httpComponentsVersion=4.5.14
 httpCoreVersion=4.4.16
 jacksonVersion=2.9.10
+# some packages ask for 4.2.x, others for 5.8.0 -- only the latter supports arm64
+jnaVersion=5.8.0
 # Grails's Spring Boot dependency doesn't play well with Logback 1.3+
 logbackVersion=1.2.12
 tomcatVersion=8.5.88

--- a/src/main/groovy/org/pih/warehouse/config/EmbeddedTomcatConfig.groovy
+++ b/src/main/groovy/org/pih/warehouse/config/EmbeddedTomcatConfig.groovy
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2025 Partners In Health.  All rights reserved.
+ * The use and distribution terms for this software are covered by the
+ * Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+ * which can be found in the file epl-v10.html at the root of this distribution.
+ * By using this software in any fashion, you are agreeing to be bound by
+ * the terms of this license.
+ * You must not remove this notice, or any other, from this software.
+ **/
+
+package org.pih.warehouse.config
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer
+import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory
+import org.springframework.boot.context.embedded.tomcat.TomcatContextCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Configure the embedded Tomcat server to use the project's webapp directory for static resources.
+ *
+ * In some environments, user.dir is set to the Gradle daemon's working directory,
+ * even when build.gradle specifies the workingDir. There seems to be a conflict
+ * between Spring Boot, Gradle and JNA on Apple Silicon-based hosts. Here, we
+ * look in catalina.base for a potential webapp directory and set docBase to that
+ * directory, if it isn't already.
+ *
+ * Note that catalina.base is set by Spring Boot's server.tomcat.basedir property.
+ */
+ @Configuration
+class EmbeddedTomcatConfig {
+
+    private final static Logger log = LoggerFactory.getLogger(EmbeddedTomcatConfig)
+
+    @Bean
+    EmbeddedServletContainerCustomizer containerCustomizer() {
+
+        return { container ->
+            if (container instanceof TomcatEmbeddedServletContainerFactory) {
+
+                TomcatContextCustomizer customizer = new TomcatContextCustomizer() {
+                    @Override
+                    void customize(org.apache.catalina.Context context) {
+                        try {
+                            def projectDocBase = new File("${System.getProperty('catalina.base')}/src/main/webapp")
+                            if (projectDocBase.exists()) {
+                                if (projectDocBase.absolutePath != context.docBase) {
+                                    log.info("Changing docBase from ${context.docBase} to ${projectDocBase.absolutePath}")
+                                    context.docBase = projectDocBase.absolutePath
+                                } else {
+                                    log.debug("docBase ${context.docBase} appears correctly configured")
+                                }
+                            } else {
+                                log.warn("cannot find project static resources: leaving docBase as-is ${context.docBase}")
+                            }
+                        } catch (SecurityException e) {
+                            log.error("Security exception accessing webapp directory: ${e.message}", e)
+                        } catch (IllegalArgumentException e) {
+                            log.error("Invalid argument setting docBase: ${e.message}", e)
+                        } catch (IllegalStateException e) {
+                            log.error("Tomcat context in invalid state: ${e.message}", e)
+                        }
+                    }
+                }
+
+                container.addContextCustomizers(customizer)
+            }
+        }
+    }
+}


### PR DESCRIPTION
### :sparkles: Support for ARM64-based platforms

This PR makes OpenBoxes run correctly on Macs running Apple Silicon (or, at least, _my_ Mac running Apple Silicon ;-) )

**Link to GitHub issue or Jira ticket:** _What should I use for tickets?_

#### Description

I ran into a few gotchas with OpenBoxes on an ARM-based Mac, namely:
1. Node 14 only has x86-based builds.
2. MySQL 5 only has x86-based builds.
3. Different parts of the project try to pull in different JNA builds (4.2.2 and 5.8.0). Only the latter one works on ARM.
4. There's some mysterious interaction between Spring Boot, Gradle and possibly JNA on ARM that causes the app to look in the gradle daemon's working directory for project static assets.

This PR fixes all of them with a mix of documentation and code. Unfortunately it doesn't pass the tests cleanly; I thought it would be easier to discuss these problems here rather than in Slack.

#### Issues for discussion

I'm still seeing 28 test failures of the 0.9.4 build.

##### "No GORM implementations configured"
###### 17 test failures

- `org.pih.warehouse.api.spec.auth.AuthApiSpec`
- `org.pih.warehouse.api.spec.product.CategoryApiCRUDSpec`
- `org.pih.warehouse.api.spec.product.ProductApiCRUDSpec`
- `org.pih.warehouse.api.spec.product.ProductApiDemandSpec`
- `org.pih.warehouse.api.spec.product.ProductClassificationApiCRUDSpec`
- `org.pih.warehouse.api.spec.product.ProductClassificationApiListFiltersOutEmptySpec`

```stacktrace
java.lang.IllegalStateException: No GORM implementations configured. Ensure GORM has been initialized correctly
	at org.grails.datastore.gorm.GormEnhancer.findSingleDatastore(GormEnhancer.groovy:378)
	at org.grails.datastore.gorm.GormEnhancer.findSingleTransactionManager(GormEnhancer.groovy:397)
	at org.pih.warehouse.api.spec.base.ApiSpec.setup(ApiSpec.groovy)
```

##### "Cannot invoke method generate() on null object"
###### 10 test failures

- `org.pih.warehouse.smoke.spec.IdentifierSpec`

```stacktrace
java.lang.NullPointerException: Cannot invoke method generate() on null object
	at org.pih.warehouse.smoke.spec.IdentifierSpec.invoiceIdentifierService can generate identifiers with the current configuration(IdentifierSpec.groovy:79)
```

##### "GrailsApplication not found"
###### 1 test failure

- `org.pih.warehouse.smoke.spec.LiquibaseUtilSpec`

```stacktrace
java.lang.IllegalArgumentException: GrailsApplication not found
	at org.springframework.util.Assert.notNull(Assert.java:134)
	at grails.util.Holders.getGrailsApplication(Holders.java:129)
	at util.LiquibaseUtil.getCurrentVersionsByFolderName(LiquibaseUtil.groovy:106)
	at org.pih.warehouse.smoke.spec.LiquibaseUtilSpec.getCurrentVersionsByFolderName should only the newest version for new installs(LiquibaseUtilSpec.groovy:15)
```
