### PR TITLE
OBPIH-7143 return quantity allocated in cycle count pages

### DIFF
--- a/grails-app/domain/org/pih/warehouse/inventory/CycleCountCandidate.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/CycleCountCandidate.groovy
@@ -24,7 +24,7 @@ class CycleCountCandidate {
 
     Integer quantityOnHand
 
-    Integer quantityAvailable
+    Integer quantityAllocated
 
     Integer inventoryItemCount
 
@@ -66,6 +66,7 @@ class CycleCountCandidate {
                 productCatalogs: product.productCatalogs,
                 abcClass: abcClass,
                 quantityOnHand: quantityOnHand,
+                quantityAllocated: quantityAllocated,
                 cycleCountRequest: cycleCountRequest,
                 status: status.toString(),
                 inventoryItemCount: inventoryItemCount,

--- a/grails-app/domain/org/pih/warehouse/inventory/PendingCycleCountRequest.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/PendingCycleCountRequest.groovy
@@ -34,6 +34,8 @@ class PendingCycleCountRequest {
 
     Integer quantityOnHand
 
+    Integer quantityAllocated
+
     String internalLocations
 
     Integer negativeItemCount
@@ -62,6 +64,7 @@ class PendingCycleCountRequest {
                 productCatalogs: product.productCatalogs,
                 abcClass: abcClass,
                 quantityOnHand: quantityOnHand,
+                quantityAllocated: quantityAllocated,
                 status: status.toString(),
                 negativeItemCount: negativeItemCount,
                 requestType: requestType.toString(),

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -1134,6 +1134,7 @@ cycleCount.comments.label=Comments
 cycleCountItem.discrepancyReasonCode.invalid=Invalid root cause
 cycleCountItemCommand.discrepancyReasonCode.invalid=Invalid root cause
 cycleCountRequestCommand.product.duplicateExists=Cycle count request already exists for this product ({3})
+cycleCountRequestCommand.product.hasQuantityAllocated=Cannot request a count for a product ({3}) that is in a pending stock movement
 cycleCountRequestBatchCommand.requests.duplicateExists=Cycle count request already exists for this/these products ({3})
 cycleCountStartCommand.cycleCountRequest.invalidCycleCountStatus=Count cannot be started when cycle count status is ({3})
 cycleCountStartRecountCommand.cycleCountRequest.noCycleCountFound=Cannot start recount for cycle count that does not exist

--- a/grails-app/migrations/views/cycle-count-session.sql
+++ b/grails-app/migrations/views/cycle-count-session.sql
@@ -54,7 +54,7 @@ SELECT
     --  quantities in the main query. If we wanted to pull the sum for just on hand quantities we could do
     --  that via the on_hand_summary subquery JOIN.
     sum(product_availability.quantity_on_hand)                                       as quantity_on_hand,
-    sum(product_availability.quantity_available_to_promise)                          as quantity_available,
+    sum(product_availability.quantity_allocated)                                     as quantity_allocated,
 
     -- Negative item count
     SUM(CASE WHEN product_availability.quantity_on_hand < 0 THEN 1 ELSE 0 END)       as negative_item_count,

--- a/grails-app/migrations/views/pending_cycle_count_request.sql
+++ b/grails-app/migrations/views/pending_cycle_count_request.sql
@@ -14,6 +14,7 @@ CREATE OR REPLACE VIEW pending_cycle_count_request AS
         ccr.updated_by_id,
         product_classification.abc_class as abc_class,
         SUM(pa.quantity_on_hand) AS quantity_on_hand,
+        SUM(pa.quantity_allocated) AS quantity_allocated,
         SUM(CASE WHEN pa.quantity_on_hand < 0 THEN 1 ELSE 0 END) as negative_item_count,
         -- A comma-separated list of internal locations in the format "<zone>: <bin location name>"
         GROUP_CONCAT(DISTINCT (

--- a/src/main/groovy/org/pih/warehouse/inventory/CycleCountRequestCommand.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/CycleCountRequestCommand.groovy
@@ -20,11 +20,18 @@ class CycleCountRequestCommand implements Validateable {
 
     static constraints = {
         product(nullable: true, validator: { Product product, CycleCountRequestCommand obj ->
-            // TODO: Most probably, this will have to be modified not to include completed cycle counts
             CycleCountRequest cycleCountRequest = CycleCountRequest.findByProductAndFacilityAndStatusNotInList(product, obj.facility, [CycleCountRequestStatus.COMPLETED, CycleCountRequestStatus.CANCELED])
             if (cycleCountRequest) {
                 return ['duplicateExists', product.productCode]
             }
+
+            // If a product is in a pending outbound, we don't allow you to proceed with the count. There is too much
+            // stock uncertainty in that scenario so to avoid confusion we require the outbound to be resolved first.
+            CycleCountCandidate candidate = CycleCountCandidate.findByFacilityAndProduct(obj.facility, product)
+            if (candidate != null && candidate.quantityAllocated > 0) {
+                return ['hasQuantityAllocated', product.productCode]
+            }
+
             return true
         })
     }


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7143

**Description:**
1) On the backend, return quantityAllocated to the client for all rows in all cycle count tables (via PendingCycleCountRequest and CycleCountCandidate views) so that the client can grey out rows with quantityAllocated > 0
2) On the backend, prevent a count from being requested on a product with quantityAllocated > 0