### PR TITLE
OBPIH-7195 fix: error creating baseline if a transaction already exists for given date

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
@@ -2670,7 +2670,7 @@ class InventoryService implements ApplicationContextAware {
      *         ordered by transaction date to make it easy to iterate through them chronologically.
      */
     List<TransactionEntry> getTransactionEntriesBeforeDate(Location facility, List<Product> products, Date date) {
-        if (!date) {
+        if (!date || !products) {
             return []
         }
 
@@ -2685,6 +2685,34 @@ class InventoryService implements ApplicationContextAware {
                 lt("transactionDate", date)
                 eq("inventory", facility?.inventory)
                 order("transactionDate", "asc")
+                order("dateCreated", "asc")
+            }
+        } as List<TransactionEntry>
+    }
+
+    /**
+     * @return True if there are any transactions on the given inventory items at a facility at a specific moment
+     *         in time.
+     */
+    boolean hasTransactionEntriesOnDate(Location facility, Date date, List<InventoryItem> inventoryItems) {
+        return getTransactionEntriesOnDate(facility, date, inventoryItems).size() > 0
+    }
+
+    /**
+     * @return All transaction entries for the given inventory items at a facility at a specific moment in time.
+     */
+    List<TransactionEntry> getTransactionEntriesOnDate(
+            Location facility, Date date, List<InventoryItem> inventoryItems) {
+        if (!date || !inventoryItems) {
+            return []
+        }
+
+        def criteria = TransactionEntry.createCriteria()
+        return criteria.list {
+            'in'("inventoryItem", inventoryItems)
+            transaction {
+                eq("transactionDate", date)
+                eq("inventory", facility?.inventory)
                 order("dateCreated", "asc")
             }
         } as List<TransactionEntry>

--- a/src/test/groovy/unit/org/pih/warehouse/inventory/CycleCountProductInventoryTransactionServiceSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/inventory/CycleCountProductInventoryTransactionServiceSpec.groovy
@@ -12,6 +12,7 @@ import org.pih.warehouse.inventory.CycleCount
 import org.pih.warehouse.inventory.CycleCountProductInventoryTransactionService
 import org.pih.warehouse.inventory.Inventory
 import org.pih.warehouse.inventory.InventoryItem
+import org.pih.warehouse.inventory.InventoryService
 import org.pih.warehouse.inventory.ProductAvailabilityService
 import org.pih.warehouse.inventory.Transaction
 import org.pih.warehouse.inventory.TransactionEntry
@@ -24,6 +25,9 @@ class CycleCountProductInventoryTransactionServiceSpec extends Specification imp
 
     @Shared
     CycleCountProductInventoryTransactionService cycleCountProductInventoryTransactionService
+
+    @Shared
+    InventoryService inventoryServiceStub
 
     @Shared
     ProductAvailabilityService productAvailabilityServiceStub
@@ -41,6 +45,9 @@ class CycleCountProductInventoryTransactionServiceSpec extends Specification imp
     void setup() {
         cycleCountProductInventoryTransactionService = new CycleCountProductInventoryTransactionService()
 
+        inventoryServiceStub = Stub(InventoryService)
+        cycleCountProductInventoryTransactionService.inventoryService = inventoryServiceStub
+
         productAvailabilityServiceStub = Stub(ProductAvailabilityService)
         cycleCountProductInventoryTransactionService.productAvailabilityService = productAvailabilityServiceStub
 
@@ -53,7 +60,7 @@ class CycleCountProductInventoryTransactionServiceSpec extends Specification imp
         productInventoryTransactionType.save(validate: false)
     }
 
-    void 'createInventoryBaselineTransaction should succeed when some items are available'() {
+    void 'createInventoryBaselineTransaction should succeed when some items are available and date is not provided'() {
         given: 'mocked inputs'
         Location facility = new Location(inventory: new Inventory())
         Product product = new Product()
@@ -78,19 +85,114 @@ class CycleCountProductInventoryTransactionServiceSpec extends Specification imp
                         quantityOnHand: 25,
                 )
         ]
+        List<InventoryItem> inventoryItems = availableItems.collect{ it.inventoryItem }
         productAvailabilityServiceStub.getAvailableItemsAtDate(facility, [product], null) >> availableItems
 
-        when:
+        and: 'no other transactions exist at that time'
+        inventoryServiceStub.hasTransactionEntriesOnDate(facility, _ as Date, inventoryItems) >> false
+
+        when: 'we create a baseline with no date provided'
         Transaction transaction = cycleCountProductInventoryTransactionService.createInventoryBaselineTransaction(
-                facility, cycleCount, [product])
+                facility, cycleCount, [product], null, "TEST COMMENT")
 
         then:
         assert transaction.transactionType == productInventoryTransactionType
         assert transaction.transactionDate >= date  // The transaction date should be "now"
         assert transaction.transactionNumber == "123ABC"
+        assert transaction.comment == "TEST COMMENT"
 
         List<TransactionEntry> transactionEntries = transaction.transactionEntries as List<TransactionEntry>
         assert transactionEntries.size() == 2
         assert transactionEntries.collect{ it.quantity }.containsAll([50, 25])
+    }
+
+    void 'createInventoryBaselineTransaction should succeed when some items are available and date is provided'() {
+        given: 'mocked inputs'
+        Location facility = new Location(inventory: new Inventory())
+        Product product = new Product()
+        CycleCount cycleCount = new CycleCount(cycleCountItems: [])
+        Date transactionDate = new Date()
+
+        and: 'a mocked transaction number'
+        transactionIdentifierServiceStub.generate(_ as Transaction) >> "123ABC"
+
+        and: 'mocked available items'
+        List<AvailableItem> availableItems = [
+                new AvailableItem(
+                        inventoryItem: new InventoryItem(),
+                        binLocation: new Location(),
+                        quantityOnHand: 50,
+                ),
+                new AvailableItem(
+                        inventoryItem: new InventoryItem(),
+                        binLocation: new Location(),
+                        quantityOnHand: 25,
+                )
+        ]
+        List<InventoryItem> inventoryItems = availableItems.collect{ it.inventoryItem }
+        productAvailabilityServiceStub.getAvailableItemsAtDate(facility, [product], transactionDate) >> availableItems
+
+        and: 'no other transactions exist at that time'
+        inventoryServiceStub.hasTransactionEntriesOnDate(facility, transactionDate, inventoryItems) >> false
+
+        when: 'we create a baseline with date provided'
+        Transaction transaction = cycleCountProductInventoryTransactionService.createInventoryBaselineTransaction(
+                facility, cycleCount, [product], transactionDate, "TEST COMMENT")
+
+        then:
+        assert transaction.transactionType == productInventoryTransactionType
+        assert transaction.transactionDate == transactionDate
+        assert transaction.transactionNumber == "123ABC"
+        assert transaction.comment == "TEST COMMENT"
+
+        List<TransactionEntry> transactionEntries = transaction.transactionEntries as List<TransactionEntry>
+        assert transactionEntries.size() == 2
+        assert transactionEntries.collect{ it.quantity }.containsAll([50, 25])
+    }
+
+    void 'createInventoryBaselineTransaction should do nothing when there are no available items'() {
+        given: 'mocked inputs'
+        Location facility = new Location(inventory: new Inventory())
+        Product product = new Product()
+        CycleCount cycleCount = new CycleCount(cycleCountItems: [])
+
+        and: 'no mocked available items'
+        productAvailabilityServiceStub.getAvailableItemsAtDate(facility, [product], null) >> []
+
+        and: 'no other transactions exist at that time'
+        inventoryServiceStub.hasTransactionEntriesOnDate(facility, _ as Date, []) >> false
+
+        expect:
+        assert cycleCountProductInventoryTransactionService.createInventoryBaselineTransaction(
+                facility, cycleCount, [product], null, null) == null
+    }
+
+    void 'createInventoryBaselineTransaction should fail when other transactions exist for that date'() {
+        given: 'mocked inputs'
+        Location facility = new Location(inventory: new Inventory())
+        Product product = new Product()
+        CycleCount cycleCount = new CycleCount(cycleCountItems: [])
+        Date transactionDate = new Date()
+
+        and: 'mocked available items'
+        List<AvailableItem> availableItems = [
+                new AvailableItem(
+                        inventoryItem: new InventoryItem(),
+                        binLocation: new Location(),
+                        quantityOnHand: 50,
+                ),
+        ]
+        List<InventoryItem> inventoryItems = availableItems.collect{ it.inventoryItem }
+        productAvailabilityServiceStub.getAvailableItemsAtDate(facility, [product], transactionDate) >> availableItems
+
+        and: 'other transactions do exist at that time'
+        inventoryServiceStub.hasTransactionEntriesOnDate(facility, transactionDate, inventoryItems) >> true
+
+        when:
+        cycleCountProductInventoryTransactionService.createInventoryBaselineTransaction(
+                facility, cycleCount, [product], transactionDate, null)
+
+        then:
+        thrown(IllegalArgumentException)
     }
 }


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7195

**Description:** Two fixes:
1) Error creating a baseline transaction if a transaction already exists for the given transaction date
2) Exclude any items where QoH == 0 from the baseline transaction

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

![Screenshot from 2025-05-28 09-38-14](https://github.com/user-attachments/assets/96bd9b49-bf51-46c8-b386-74495270253e)
