### PR TITLE
OBPIH-7195 fix2: error creating adjustment transaction if transaction already exists for given date

### DIFF
--- a/grails-app/conf/runtime.groovy
+++ b/grails-app/conf/runtime.groovy
@@ -89,8 +89,9 @@ openboxes.products.merge.enabled = false
 // Cycle Count configuration (OBPIH-7033)
 openboxes.cycleCount.products.maxAmount = 50
 
-// Inventory snapshot configuration (OBPIH-7194)
+// Inventory baseline transaction configuration (OBPIH-7194, OBPIH-7195)
 openboxes.transactions.inventoryBaseline.recordStock.enabled = true
+openboxes.transactions.inventoryBaseline.inventoryImport.enabled = true
 
 openboxes.security.rbac.rules = [
     [controller: '*', actions: ['delete'], accessRules: [ minimumRequiredRole: RoleType.ROLE_SUPERUSER ]],

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -1217,6 +1217,7 @@ import.purchaseOrderActualReadyDate.label=PO Actual Ready Date
 # Import Data Command
 importDataCommand.type.invalid=Please select a data import type
 importDataCommand.importFile.label=Import File (.csv)
+importDataCommand.date.future=The date cannot be in the future
 # Inventory Actions
 inventory.addInventoryItem.label=Add new line item
 inventory.addToShipment.label=Add to shipment

--- a/grails-app/services/org/pih/warehouse/inventory/InventoryImportProductInventoryTransactionService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventoryImportProductInventoryTransactionService.groovy
@@ -2,6 +2,7 @@ package org.pih.warehouse.inventory
 
 import grails.gorm.transactions.Transactional
 
+import org.pih.warehouse.core.ConfigService
 import org.pih.warehouse.importer.ImportDataCommand
 
 /**
@@ -10,8 +11,15 @@ import org.pih.warehouse.importer.ImportDataCommand
 @Transactional
 class InventoryImportProductInventoryTransactionService extends ProductInventoryTransactionService<ImportDataCommand> {
 
+    ConfigService configService
+
     @Override
     void setSourceObject(Transaction transaction, ImportDataCommand sourceObject) {
         // Inventory Import has no source object.
+    }
+
+    @Override
+    protected boolean baselineTransactionsEnabled() {
+        return configService.getProperty("openboxes.transactions.inventoryBaseline.inventoryImport.enabled", Boolean)
     }
 }

--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -702,10 +702,6 @@ class ProductAvailabilityService {
      * @param at The moment in time to fetch stock for. If not provided, will fetch the current stock of each item.
      */
     List<AvailableItem> getAvailableItemsAtDate(Location facility, List<Product> products, Date at=null) {
-        if (at != null && at > new Date()) {
-            throw new IllegalArgumentException("Date cannot be in the future.")
-        }
-
         // If no date is provided, we fetch the stock as it is currently (filtering out any items with no quantity).
         // This means we're allowed to simply query product availability since it contains up to date stock.
         if (at == null) {

--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -702,6 +702,10 @@ class ProductAvailabilityService {
      * @param at The moment in time to fetch stock for. If not provided, will fetch the current stock of each item.
      */
     List<AvailableItem> getAvailableItemsAtDate(Location facility, List<Product> products, Date at=null) {
+        if (at != null && at.after(new Date())) {
+            throw new IllegalArgumentException("Date cannot be in the future.")
+        }
+
         // If no date is provided, we fetch the stock as it is currently (filtering out any items with no quantity).
         // This means we're allowed to simply query product availability since it contains up to date stock.
         if (at == null) {

--- a/grails-app/services/org/pih/warehouse/inventory/RecordStockProductInventoryTransactionService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/RecordStockProductInventoryTransactionService.groovy
@@ -8,8 +8,6 @@ import grails.gorm.transactions.Transactional
 @Transactional
 class RecordStockProductInventoryTransactionService extends ProductInventoryTransactionService<RecordInventoryCommand> {
 
-    InventoryService inventoryService
-
     Transaction createAdjustmentTransaction(
             RecordInventoryCommand recordInventoryCommand,
             Date transactionDate

--- a/src/main/groovy/org/pih/warehouse/importer/ImportDataCommand.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/ImportDataCommand.groovy
@@ -30,7 +30,11 @@ class ImportDataCommand implements Validateable {
     def transaction
 
     static constraints = {
-        date(nullable: true)
+        date(nullable: true, validator: { val, obj ->
+            if (val != null && val.after(new Date())) {
+                return ['future']
+            }
+        })
         filename(nullable: true)
         importNow(nullable: true)
         importFile(nullable: true, validator: { val, obj ->


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7195?

**Description:** Multiple fixes:
1) fail an inventory import if a transaction already exists on the items with the same date as the adjustment transaction
2) fix check that errors if transaction date is in the future
3) add inventory import baseline transaction feature switch (I forgot to add it previously)
4) fix record stock error due to autowiring in inventoryService twice