### PR TITLE
OBPIH-7195 fix3: inventory import, fix existing transaction check

### DIFF
--- a/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
@@ -145,7 +145,7 @@ class InventoryImportDataService implements ImportDataService {
         // Get the stock for all items in the import at the date that the baseline transaction will be created.
         Map<String, AvailableItem> availableItems = productAvailabilityService.getAvailableItemsAtDateAsMap(
                 command.location,
-                inventoryImportData.products.toList(),
+                inventoryImportData.products,
                 baselineTransactionDate)
 
         String comment = "Imported from ${command.filename} on ${new Date()}"
@@ -157,9 +157,9 @@ class InventoryImportDataService implements ImportDataService {
         Date adjustmentTransactionDate = DateUtil.asDate(DateUtil.asInstant(baselineTransactionDate).plusSeconds(1))
 
         // We let the adjustment transaction be built from the same available items that we built the baseline
-        // transaction with. Despite the fact that the adjustment transaction is dated one second after the baseline
-        // transaction, and so could have a different stock history, we will error if there are any other transactions
-        // that exist at that time, so we can guarantee that the available items will be the same for both the baseline
+        // transaction with. The adjustment transaction is dated one second after the baseline transaction so it
+        // could have a different stock history, but we error if there are any other transactions that exist at
+        // that time, so we can guarantee that the available items will be the same for both the baseline
         // and adjustment. This avoids needing to fetch available items twice (which is slow).
         createAdjustmentTransaction(
                 command.location, inventoryImportData, availableItems, adjustmentTransactionDate, comment)

--- a/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
@@ -141,6 +141,8 @@ class InventoryImportDataService implements ImportDataService {
         InventoryImportData inventoryImportData = parseData(command)
 
         Date baselineTransactionDate = command.date
+
+        // Get the stock for all items in the import at the date that the baseline transaction will be created.
         Map<String, AvailableItem> availableItems = productAvailabilityService.getAvailableItemsAtDateAsMap(
                 command.location,
                 inventoryImportData.products.toList(),
@@ -154,6 +156,11 @@ class InventoryImportDataService implements ImportDataService {
         // Date objects are mutable, so we use Instant to clone the date in the command and avoid directly modifying it.
         Date adjustmentTransactionDate = DateUtil.asDate(DateUtil.asInstant(baselineTransactionDate).plusSeconds(1))
 
+        // We let the adjustment transaction be built from the same available items that we built the baseline
+        // transaction with. Despite the fact that the adjustment transaction is dated one second after the baseline
+        // transaction, and so could have a different stock history, we will error if there are any other transactions
+        // that exist at that time, so we can guarantee that the available items will be the same for both the baseline
+        // and adjustment. This avoids needing to fetch available items twice (which is slow).
         createAdjustmentTransaction(
                 command.location, inventoryImportData, availableItems, adjustmentTransactionDate, comment)
     }
@@ -170,8 +177,7 @@ class InventoryImportDataService implements ImportDataService {
 
         // We'd have weird behaviour if we allowed two transactions to exist at the same exact time (precision at the
         // database level is to the second) so fail if there's already a transaction on the items for the given date.
-        List<InventoryItem> inventoryItems = availableItems.values().collect{ it.inventoryItem }
-        if (inventoryService.hasTransactionEntriesOnDate(facility, transactionDate, inventoryItems)) {
+        if (inventoryService.hasTransactionEntriesOnDate(facility, transactionDate, inventoryImportData.inventoryItems)) {
             throw new IllegalArgumentException("A transaction already exists at time ${transactionDate}")
         }
 
@@ -296,6 +302,10 @@ class InventoryImportDataService implements ImportDataService {
         InventoryImportDataRow get(Location binLocation, InventoryItem inventoryItem) {
             String key = ProductAvailabilityService.constructAvailableItemKey(binLocation, inventoryItem)
             return rows.get(key)
+        }
+
+        List<InventoryItem> getInventoryItems() {
+            return rows.values().inventoryItem
         }
     }
 

--- a/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
@@ -2695,7 +2695,7 @@ class InventoryService implements ApplicationContextAware {
      * @return All transaction entries for the given products at a facility older than the given date. Entries are
      *         ordered by transaction date to make it easy to iterate through them chronologically.
      */
-    List<TransactionEntry> getTransactionEntriesBeforeDate(Location facility, List<Product> products, Date date) {
+    List<TransactionEntry> getTransactionEntriesBeforeDate(Location facility, Collection<Product> products, Date date) {
         if (!date || !products) {
             return []
         }

--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -682,7 +682,7 @@ class ProductAvailabilityService {
      * @param at The moment in time to fetch stock for. If not provided, will fetch the current stock of each item.
      * @return a map of AvailableItem keyed on [product code + bin location name + lot number]
      */
-    Map<String, AvailableItem> getAvailableItemsAtDateAsMap(Location facility, List<Product> products, Date at=null) {
+    Map<String, AvailableItem> getAvailableItemsAtDateAsMap(Location facility, Collection<Product> products, Date at=null) {
         List<AvailableItem> availableItems = getAvailableItemsAtDate(facility, products, at)
 
         Map<String, AvailableItem> availableItemsMap = [:]
@@ -701,7 +701,7 @@ class ProductAvailabilityService {
      * @param products The products to fetch stock for.
      * @param at The moment in time to fetch stock for. If not provided, will fetch the current stock of each item.
      */
-    List<AvailableItem> getAvailableItemsAtDate(Location facility, List<Product> products, Date at=null) {
+    List<AvailableItem> getAvailableItemsAtDate(Location facility, Collection<Product> products, Date at=null) {
         if (at != null && at.after(new Date())) {
             throw new IllegalArgumentException("Date cannot be in the future.")
         }

--- a/grails-app/services/org/pih/warehouse/inventory/ProductInventoryTransactionService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductInventoryTransactionService.groovy
@@ -49,7 +49,7 @@ abstract class ProductInventoryTransactionService<T> {
     Transaction createInventoryBaselineTransaction(
             Location facility,
             T sourceObject,
-            List<Product> products,
+            Collection<Product> products,
             Date transactionDate=null,
             String comment=null) {
 


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7195

**Description:** This is just embarassing now :upside_down_face: The original code that checked for duplicate transactions was using the items in product availability, but those available items were from the time of the baseline transaction. If there were items in the import that didn't have any availability at the time of the baseline (ie quantity == 0) they didn't have any product availability records, and so wouldn't get checked. Now I make sure to check ALL items that were given in the input data.

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

![Screenshot from 2025-06-02 10-39-44](https://github.com/user-attachments/assets/c8a1c4f8-c82a-4afc-84ef-4a508661dc72)
