### PR TITLE
OBPIH-7143 fail starting count when in pending outbound

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -1137,6 +1137,7 @@ cycleCountRequestCommand.product.duplicateExists=Cycle count request already exi
 cycleCountRequestCommand.product.hasQuantityAllocated=Cannot request a count for a product ({3}) that is in a pending stock movement
 cycleCountRequestBatchCommand.requests.duplicateExists=Cycle count request already exists for this/these products ({3})
 cycleCountStartCommand.cycleCountRequest.invalidCycleCountStatus=Count cannot be started when cycle count status is ({3})
+cycleCountStartCommand.cycleCountRequest.hasQuantityAllocated=Cannot start a count for a product ({3}) that is in a pending stock movement
 cycleCountStartRecountCommand.cycleCountRequest.noCycleCountFound=Cannot start recount for cycle count that does not exist
 cycleCountStartRecountCommand.cycleCountRequest.invalidCycleCountStatus=Recount cannot be started when cycle count status is ({3})
 cycleCountStartRecountCommand.countIndex.invalid=Count index ({3}) is invalid for recount

--- a/src/main/groovy/org/pih/warehouse/inventory/CycleCountStartCommand.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/CycleCountStartCommand.groovy
@@ -2,6 +2,9 @@ package org.pih.warehouse.inventory
 
 import grails.validation.Validateable
 
+import org.pih.warehouse.product.Product
+import org.pih.warehouse.product.ProductAvailability
+
 class CycleCountStartCommand implements Validateable {
 
     CycleCountRequest cycleCountRequest
@@ -9,6 +12,18 @@ class CycleCountStartCommand implements Validateable {
     static constraints = {
         cycleCountRequest(validator: { CycleCountRequest cycleCountRequest ->
             CycleCount cycleCount = cycleCountRequest.cycleCount
+
+            // If a product is in a pending outbound, we don't allow you to proceed with the count unless it has
+            // already been started (ie the status is past 'REQUESTED'). There is too much uncertainty when some of
+            // the stock allocated, so to avoid confusion we require the outbound to be resolved first.
+            if (!cycleCount || cycleCount.status == CycleCountStatus.REQUESTED) {
+                Product product = cycleCountRequest.product
+                int quantityAllocatedForProduct = ProductAvailability.findAllByLocationAndProduct(
+                        cycleCountRequest.facility, product)?.sum{ it.quantityAllocated ?: 0 } as Integer ?: 0
+                if (quantityAllocatedForProduct > 0) {
+                    return ['hasQuantityAllocated', product.productCode]
+                }
+            }
             if (!cycleCount) {
                 // When first starting a count, the cycle count object won't exist yet, so this is valid.
                 return true


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7143

**Description:** Kasia had a good point that when the product is in a pending outbound, we should also block users from **starting** a count (the other PR was for erroring when **requesting** a count). However we should only block the count from being started while it's in the "to count" state. Once there is progress in the count, it should be able to finish.

Initial PR: https://github.com/openboxes/openboxes/pull/5276