### PR TITLE
OBPIH-7195 fix4: handle inventory import duplicates and zero out stock for missing rows

### DIFF
--- a/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
@@ -142,10 +142,11 @@ class InventoryImportDataService implements ImportDataService {
 
         Date baselineTransactionDate = command.date
 
-        // Get the stock for all items in the import at the date that the baseline transaction will be created.
+        // An inventory import will set the quantity for an entire inventory of a facility, so we need to fetch
+        // ALL available items at the date that the baseline transaction will be created.
         Map<String, AvailableItem> availableItems = productAvailabilityService.getAvailableItemsAtDateAsMap(
                 command.location,
-                inventoryImportData.products,
+                null,
                 baselineTransactionDate)
 
         String comment = "Imported from ${command.filename} on ${new Date()}"
@@ -185,24 +186,53 @@ class InventoryImportDataService implements ImportDataService {
         Transaction transaction = new Transaction()
 
         for (entry in inventoryImportData.rows) {
-            String key = entry.key
-            InventoryImportDataRow row = entry.value
+            List<InventoryImportDataRow> rowsForKey = entry.value
 
             // If we have no product availability record for the item, we assume that means we have no quantity.
-            int quantityOnHand = availableItems.get(key)?.quantityOnHand ?: 0
+            int quantityOnHandToUse = availableItems.get(entry.key)?.quantityOnHand ?: 0
 
-            int adjustmentQuantity = row.quantity - quantityOnHand
-            if (adjustmentQuantity == 0) {
+            for (InventoryImportDataRow row in rowsForKey) {
+                int adjustmentQuantity = row.quantity - quantityOnHandToUse
+
+                // Update QoH so that we don't double count it while computing adjustmentQuantity when we have multiple
+                // rows with the same key (which results in rowsForKey having more than one entry). For example, if a
+                // [product + bin + lot] has a QoH of 5, the following rows should create the following adjustments:
+                // - row with the same [product + bin + lot] and quantity == 6  -> should cause a +1 adjustment
+                // - row with the same [product + bin + lot] and quantity == 10 -> should cause a +10 adjustment
+                quantityOnHandToUse = Math.max(quantityOnHandToUse - row.quantity, 0)
+
+                if (adjustmentQuantity == 0) {
+                    continue
+                }
+
+                TransactionEntry transactionEntry = new TransactionEntry(
+                        transaction: transaction,
+                        quantity: adjustmentQuantity,
+                        product: row.product,
+                        binLocation: row.binLocation,
+                        inventoryItem: row.inventoryItem,
+                        comments: row.comments,
+                )
+                transaction.addToTransactionEntries(transactionEntry)
+            }
+        }
+
+        // Any available items that exist in the system but were not in the import should be set to quantity 0.
+        Set<String> keysInImport = inventoryImportData.rows.keySet()
+        for (entry in availableItems) {
+            AvailableItem availableItem = entry.value
+
+            if (keysInImport.contains(entry.key)) {
                 continue
             }
 
             TransactionEntry transactionEntry = new TransactionEntry(
                     transaction: transaction,
-                    quantity: adjustmentQuantity,
-                    product: row.product,
-                    binLocation: row.binLocation,
-                    inventoryItem: row.inventoryItem,
-                    comments: row.comments,
+                    quantity: -availableItem.quantityOnHand,
+                    product: availableItem.inventoryItem.product,
+                    binLocation: availableItem.binLocation,
+                    inventoryItem: availableItem.inventoryItem,
+                    comments: 'Quantity set to zero due to item not being defined in the inventory import file.',
             )
             transaction.addToTransactionEntries(transactionEntry)
         }
@@ -285,27 +315,36 @@ class InventoryImportDataService implements ImportDataService {
      * Convenience POJO for holding the results of the inventory import.
      */
     private class InventoryImportData {
-        Map<String, InventoryImportDataRow> rows = [:]
-        Set<Product> products = []
+
+        /**
+         * Map the imported rows by [product code + bin location name + lot number]. We store the rows as a list
+         * because there can be duplicates. (This is a valid scenario. It's an easy way for users to merge products.)
+         */
+        Map<String, List<InventoryImportDataRow>> rows = [:]
 
         void put(Location binLocation, InventoryItem inventoryItem, def rowRaw) {
-            products.add(inventoryItem.product)
-
             String key = ProductAvailabilityService.constructAvailableItemKey(binLocation, inventoryItem)
-            rows.put(key, new InventoryImportDataRow(
+            rows.computeIfAbsent(key, { k -> [] }).add(new InventoryImportDataRow(
                     binLocation,
                     inventoryItem,
                     rowRaw.quantity.toInteger() as Integer,
                     rowRaw.comments as String))
         }
 
-        InventoryImportDataRow get(Location binLocation, InventoryItem inventoryItem) {
+        List<InventoryImportDataRow> get(Location binLocation, InventoryItem inventoryItem) {
             String key = ProductAvailabilityService.constructAvailableItemKey(binLocation, inventoryItem)
             return rows.get(key)
         }
 
         List<InventoryItem> getInventoryItems() {
-            return rows.values().inventoryItem
+            List<InventoryItem> items = []
+            for (List<InventoryImportDataRow> rowsWithSameKey : rows.values()) {
+                if (rowsWithSameKey) {
+                    // Rows with the same key have the same inventory item so only add it to the list once.
+                    items.add(rowsWithSameKey[0].inventoryItem)
+                }
+            }
+            return items
         }
     }
 

--- a/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
@@ -232,7 +232,7 @@ class InventoryImportDataService implements ImportDataService {
                     product: availableItem.inventoryItem.product,
                     binLocation: availableItem.binLocation,
                     inventoryItem: availableItem.inventoryItem,
-                    comments: 'Quantity set to zero due to item not being defined in the inventory import file.',
+                    comments: 'Item was not in inventory import file so quantity was assumed to be zero.',
             )
             transaction.addToTransactionEntries(transactionEntry)
         }

--- a/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
@@ -2696,7 +2696,7 @@ class InventoryService implements ApplicationContextAware {
      *         ordered by transaction date to make it easy to iterate through them chronologically.
      */
     List<TransactionEntry> getTransactionEntriesBeforeDate(Location facility, Collection<Product> products, Date date) {
-        if (!date || !products) {
+        if (!date) {
             return []
         }
 

--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -677,12 +677,12 @@ class ProductAvailabilityService {
     /**
      * Fetches the stock of a list of products at a facility at a given moment in time.
      *
-     * @param facility
-     * @param products
+     * @param facility The location to fetch stock for.
+     * @param products The products to fetch stock for. If null, will fetch all products
      * @param at The moment in time to fetch stock for. If not provided, will fetch the current stock of each item.
      * @return a map of AvailableItem keyed on [product code + bin location name + lot number]
      */
-    Map<String, AvailableItem> getAvailableItemsAtDateAsMap(Location facility, Collection<Product> products, Date at=null) {
+    Map<String, AvailableItem> getAvailableItemsAtDateAsMap(Location facility, Collection<Product> products=null, Date at=null) {
         List<AvailableItem> availableItems = getAvailableItemsAtDate(facility, products, at)
 
         Map<String, AvailableItem> availableItemsMap = [:]
@@ -698,10 +698,10 @@ class ProductAvailabilityService {
      * quantity on hand is zero.
      *
      * @param facility The location to fetch stock for.
-     * @param products The products to fetch stock for.
+     * @param products The products to fetch stock for. If null, will fetch all products
      * @param at The moment in time to fetch stock for. If not provided, will fetch the current stock of each item.
      */
-    List<AvailableItem> getAvailableItemsAtDate(Location facility, Collection<Product> products, Date at=null) {
+    List<AvailableItem> getAvailableItemsAtDate(Location facility, Collection<Product> products=null, Date at=null) {
         if (at != null && at.after(new Date())) {
             throw new IllegalArgumentException("Date cannot be in the future.")
         }
@@ -709,7 +709,7 @@ class ProductAvailabilityService {
         // If no date is provided, we fetch the stock as it is currently (filtering out any items with no quantity).
         // This means we're allowed to simply query product availability since it contains up to date stock.
         if (at == null) {
-            return getAvailableItems(facility, products.collect{ it.id }, false, true)
+            return getAvailableItems(facility, products?.collect{ it.id }, false, true)
         }
 
         // Otherwise we're trying to fetch stock at a specific moment in time, so we need to calculate it ourselves

--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -677,12 +677,12 @@ class ProductAvailabilityService {
     /**
      * Fetches the stock of a list of products at a facility at a given moment in time.
      *
-     * @param facility The location to fetch stock for.
-     * @param products The products to fetch stock for. If null, will fetch all products
+     * @param facility
+     * @param products
      * @param at The moment in time to fetch stock for. If not provided, will fetch the current stock of each item.
      * @return a map of AvailableItem keyed on [product code + bin location name + lot number]
      */
-    Map<String, AvailableItem> getAvailableItemsAtDateAsMap(Location facility, Collection<Product> products=null, Date at=null) {
+    Map<String, AvailableItem> getAvailableItemsAtDateAsMap(Location facility, Collection<Product> products, Date at=null) {
         List<AvailableItem> availableItems = getAvailableItemsAtDate(facility, products, at)
 
         Map<String, AvailableItem> availableItemsMap = [:]
@@ -698,10 +698,10 @@ class ProductAvailabilityService {
      * quantity on hand is zero.
      *
      * @param facility The location to fetch stock for.
-     * @param products The products to fetch stock for. If null, will fetch all products
+     * @param products The products to fetch stock for.
      * @param at The moment in time to fetch stock for. If not provided, will fetch the current stock of each item.
      */
-    List<AvailableItem> getAvailableItemsAtDate(Location facility, Collection<Product> products=null, Date at=null) {
+    List<AvailableItem> getAvailableItemsAtDate(Location facility, Collection<Product> products, Date at=null) {
         if (at != null && at.after(new Date())) {
             throw new IllegalArgumentException("Date cannot be in the future.")
         }
@@ -709,7 +709,7 @@ class ProductAvailabilityService {
         // If no date is provided, we fetch the stock as it is currently (filtering out any items with no quantity).
         // This means we're allowed to simply query product availability since it contains up to date stock.
         if (at == null) {
-            return getAvailableItems(facility, products?.collect{ it.id }, false, true)
+            return getAvailableItems(facility, products.collect{ it.id }, false, true)
         }
 
         // Otherwise we're trying to fetch stock at a specific moment in time, so we need to calculate it ourselves

--- a/grails-app/services/org/pih/warehouse/inventory/ProductInventoryTransactionService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductInventoryTransactionService.groovy
@@ -117,6 +117,7 @@ abstract class ProductInventoryTransactionService<T> {
         for (AvailableItem availableItem : availableItems) {
             TransactionEntry transactionEntry = new TransactionEntry(
                     quantity: availableItem.quantityOnHand,
+                    product: availableItem.inventoryItem.product,
                     binLocation: availableItem.binLocation,
                     inventoryItem: availableItem.inventoryItem,
                     transaction: transaction,


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7195

**Description:** Two fixes:
1) Allow for duplicate lines in the import. They should each result in separate transaction entries whos quantities sum up to each other.
2) Any items that have stock but were not included in the import will have their stock set to zero

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

Video explaining the change: https://jam.dev/c/27edbf8b-a984-481e-ba15-a3285114913d
