### PR TITLE
:whale: Setting base url using Docker and removing .env

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -2,3 +2,4 @@ DATASOURCE_URL=jdbc:mysql://host.docker.internal:3306/openboxes?useSSL=false
 DATASOURCE_USERNAME=openboxes
 DATASOURCE_PASSWORD=openboxes
 JAVA_TOOL_OPTIONS=-Xms1024m -Xmx1024m -XX:+UseParallelGC -Djava.awt.headless=true
+OPENBOXES_SERVER_URL=https://youdomain.com/openboxes/

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,1 +1,2 @@
 /mysql
+.env

--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -8,6 +8,7 @@ services:
         DATASOURCE_USERNAME: ${DATASOURCE_USERNAME:-openboxes}
         DATASOURCE_PASSWORD: ${DATASOURCE_PASSWORD:-openboxes}
         DATASOURCE_URL: ${DATASOURCE_URL:-jdbc:mysql://db/openboxes?useSSL=false}
+        GRAILS_SERVERURL: ${OPENBOXES_SERVER_URL}
         JAVA_TOOL_OPTIONS: ${JAVA_TOOL_OPTIONS:--Xms1024m -Xmx1024m -XX:+UseParallelGC -Djava.awt.headless=true}
       healthcheck:
         test: "curl --fail --silent localhost:8080/openboxes/health | grep UP || exit 1"


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> Add custom domain support and .env.example

**Link to GitHub issue or Jira ticket:**

**Description:**

This pull request addresses an issue encountered when deploying the application to a production environment with a custom domain and a reverse proxy.

Previously, after making local adaptations, the application functioned as expected on localhost:80. However, upon deployment to production, the login functionality failed due to redirects to http://app:8080/.

After investigating, I discovered that an environment variable could be used to specify the application's domain. I tested this solution, and it successfully resolved the redirection issue. Therefore, I am proposing an update to the docker-compose.yml file to include this necessary environment variable.

Additionally, this pull request proposes replacing the .env file with a .env.example file. This change ensures that local environment configurations are not inadvertently committed to the repository, as .env will be added to .gitignore. This promotes better security practices and simplifies environment management for developers.

***Why these changes?***
- Custom Domain Support: Enables seamless deployment and proper login redirection when using a custom domain with a reverse proxy in production.
- Improved Environment Management: Prevents sensitive environment variables from being committed to the repository, enhancing security and streamlining development workflows.