### PR TITLE
OB-3258: fix loader while applying data table styles

### DIFF
--- a/grails-app/views/location/edit.gsp
+++ b/grails-app/views/location/edit.gsp
@@ -696,16 +696,21 @@
           cookie: {
             expires: 1
           },
+          beforeLoad: function(event, ui) {
+            $('.loading').show();
+          },
+          load: function(event, ui) {
+            $('.loading').hide();
+            $('.dataTable').dataTable({
+                "bJQueryUI": true,
+                "bDestroy": true,
+                "sPaginationType": "full_numbers"
+            });
+          },
           ajaxOptions: {
             error: function (xhr, status, index, anchor) {
               $(anchor.hash).html();
             },
-            beforeSend: function () {
-              $('.loading').show();
-            },
-            complete: function () {
-              $(".loading").hide();
-            }
           }
         }
     );

--- a/grails-app/views/location/showBinLocations.gsp
+++ b/grails-app/views/location/showBinLocations.gsp
@@ -76,12 +76,3 @@
         </g:unless>
     </div>
 </div>
-<script>
-    $(document).ready(function() {
-        $('.dataTable').dataTable({
-            "bJQueryUI": true,
-            "bDestroy": true,
-            "sPaginationType": "full_numbers"
-        });
-    });
-</script>


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://openboxes.atlassian.net/browse/OB-3258

**Description:**
- Ensure the spinner shows while the tab content is fetching, and that DataTables only initialize after the new HTML is loaded.

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
![Peek 2025-07-01 14-49](https://github.com/user-attachments/assets/619219bf-28e7-49cf-9d98-3280c2d8595b)

