### PR TITLE
Fix broken workflow docker-image.yml

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,11 +1,8 @@
 name: Docker
 on:
   push:
-    branches: [ feature/upgrade-to-grails-3.3.10 ]
-    # Publish semver tags as releases.
-    tags: [ 'v*' ]
-  pull_request:
-    branches: [ feature/upgrade-to-grails-3.3.10 ]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+**'
 
 env:
   REGISTRY: ghcr.io
@@ -20,27 +17,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v1 
+      - name: Set up JDK
+        uses: actions/setup-java@v4
         with:
-          path: ~/.gradle/caches  
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }} 
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - uses: actions/cache@v1
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-
-      - uses: actions/setup-java@v2
-        with:
-          distribution: 'adopt'
-          java-version: '8'
-
-      - name: Run Unit tests
-        run: ./gradlew test
+          java-version: 8
+          distribution: zulu
+          cache: 'gradle'
 
       - name: Build dependencies, project and prepare files for Docker build
         run: ./gradlew prepareDocker -Dgrails.env=prod --console=plain


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** N/A

**Description:** the docker-image.yml workflow is broken. This should hopefully fix it. The reason it broke was because the `actions/cache@v1` action was removed recently: https://github.com/orgs/community/discussions/148746. I switched the logic to behave like we have it elsewhere in our workflows (using the 'cache' attribute of the setup-java action).

I haven't run this yet to confirm if it works.