### PR TITLE
OB-3258: fix data table init, remove redundant column

### DIFF
--- a/grails-app/views/location/showBinLocations.gsp
+++ b/grails-app/views/location/showBinLocations.gsp
@@ -24,7 +24,6 @@
                     <th><g:message code="location.binLocation.label" default="Bin Location"/></th>
                     <th><g:message code="location.zone.label"/></th>
                     <th><g:message code="location.locationType.label"/></th>
-                    <th><g:message code="location.zone.label"/></th>
                     <th><g:message code="default.actions.label"></g:message></th>
                 </tr>
                 </thead>


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://openboxes.atlassian.net/browse/OB-3258

**Description:**
- Remove the extra `<th>` so the table header and body line up perfectly.

---
### :camera: Screenshots & Recordings (optional)
![Peek 2025-07-10 14-33](https://github.com/user-attachments/assets/5c81c158-da98-4465-bed7-5d03d2497072)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
