### PR TITLE
OBPIH-7295 add supplier code to shipment details page if shipment is for a PO

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -2889,6 +2889,7 @@ shipping.notificationEmailsWillNotBeSentOut.message=Notification emails will not
 shipping.notifications.label=Notifications
 shipping.notifications.message=The following people will receive an email notification that this shipment has shipped. If you do not want a particular person to receive a notification, uncheck the checkbox next to his/her name.
 shipping.or.label=--OR--
+shipping.originCode.label=Supplier Code
 shipping.origin.label=Origin
 shipping.overview.label=Overview
 shipping.package.label=Package

--- a/grails-app/views/shipment/showDetails.gsp
+++ b/grails-app/views/shipment/showDetails.gsp
@@ -50,6 +50,16 @@
 									<format:metadata obj="${shipmentInstance?.currentStatus}"/>
 								</td>
 							</tr>
+                            <g:if test="${shipmentInstance?.isFromPurchaseOrder}">
+                                <tr class="prop">
+                                    <td valign="top" class="name">
+                                        <label><warehouse:message code="shipping.originCode.label" /></label>
+                                    </td>
+                                    <td valign="top" id="shipmentStatus" class="value">
+                                        <format:metadata obj="${shipmentInstance?.origin?.organization?.code}"/>
+                                    </td>
+                                </tr>
+                            </g:if>
 							<tr class="prop">
 								<td valign="top" class="name">
 									<g:if test="${shipmentInstance?.status.code in [org.pih.warehouse.shipping.ShipmentStatusCode.SHIPPED, org.pih.warehouse.shipping.ShipmentStatusCode.RECEIVED]}">

--- a/grails-app/views/shipment/showDetails.gsp
+++ b/grails-app/views/shipment/showDetails.gsp
@@ -53,7 +53,7 @@
                             <g:if test="${shipmentInstance?.isFromPurchaseOrder}">
                                 <tr class="prop">
                                     <td valign="top" class="name">
-                                        <label><warehouse:message code="shipping.originCode.label" /></label>
+                                        <label><g:message code="shipping.originCode.label" /></label>
                                     </td>
                                     <td valign="top" id="shipmentStatus" class="value">
                                         <format:metadata obj="${shipmentInstance?.origin?.organization?.code}"/>


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7295

**Description:** Add the supplier code (of the origin org) to the shipment details page if the shipment is from a purchase order

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

<img width="823" height="444" alt="image" src="https://github.com/user-attachments/assets/6e74a699-3670-467e-80fb-a642923a4919" />
