### PR TITLE
OBPIH-7295 add supplier code to stock movement details page if shipme…

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -3207,6 +3207,7 @@ stockMovement.edit.label=Edit Stock Movement
 stockMovement.rollbackLastReceipt.label=Rollback Last Receipt
 stockMovement.uploadDocuments.label=Upload documents
 stockMovement.origin.label=Origin
+stockMovement.originCode.label=Supplier Code
 stockMovement.destination.label=Destination
 stockMovement.stocklist.label=Stocklist
 stockMovement.requestedBy.label=Requested By

--- a/grails-app/views/stockMovement/show.gsp
+++ b/grails-app/views/stockMovement/show.gsp
@@ -248,6 +248,16 @@
                                 ${stockMovement?.displayStatus?.label}
                             </td>
                         </tr>
+                        <g:if test="${stockMovement?.shipment?.isFromPurchaseOrder}">
+                            <tr class="prop">
+                                <td class="name">
+                                    <g:message code="stockMovement.originCode.label"/>
+                                </td>
+                                <td class="value">
+                                    ${stockMovement?.origin?.organization?.code}
+                                </td>
+                            </tr>
+                        </g:if>
                         <tr class="prop">
                             <td class="name">
                                 <warehouse:message code="stockMovement.origin.label"/>


### PR DESCRIPTION
…nt is for a PO

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7295

**Description:** Like https://github.com/openboxes/openboxes/pull/5376. Add the supplier code (of the origin org) to the stock movement details page if the shipment is from a purchase order


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

<img width="728" height="718" alt="Screenshot from 2025-07-15 14-48-11" src="https://github.com/user-attachments/assets/97a282a4-c4a8-46b7-9691-b3bc743c5188" />

