### PR TITLE
OBPIH-7116 if an import line has a comment but won't result in an adjustment, pu…

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/ProductInventoryTransactionService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductInventoryTransactionService.groovy
@@ -44,6 +44,7 @@ abstract class ProductInventoryTransactionService<T> {
      * @param transactionDate The datetime that the transaction should be marked with. If left blank will be
      *                        the current time.
      * @param comment An optional comment to associate with the transaction
+     * @param transactionEntriesComments A map of transaction entry comments keyed on inventory item and bin location
      * @param validateTransactionDates An optional param to disable validation of transactions at the same time
      *                                 (Used when for some reason we want to allow multiple transactions at the
      *                                 same time). By default it's true.
@@ -90,6 +91,7 @@ abstract class ProductInventoryTransactionService<T> {
      * @param transactionDate The datetime that the transaction should be marked with. If left blank will be
      *                        the current time.
      * @param comment An optional comment to associate with the transaction
+     * @param transactionEntriesComments A map of transaction entry comments keyed on inventory item and bin location
      * @param validateTransactionDates An optional param to disable validation of transactions at the same time
      *                                 (Used when for some reason we want to allow multiple transactions at the
      *                                 same time). By default it's true.


### PR DESCRIPTION
…t the comment in the baseline transaction entry

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7116

**Description:** We normally put inventory import comments in the adjustment transaction entries, but if we know that there won't be an adjustment transaction entry for an import row/item (because there's no quantity change), we add the comment to the baseline transaction entry instead so that the comment is not lost.

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

[Screencast from 2025-07-17 10:46:03 AM.webm](https://github.com/user-attachments/assets/29122d54-126a-4cc3-a2df-1ec7008d1a9b)
