### PR TITLE
OBPIH-7368 Improve performance of export/import of counting step with…

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/UrlMappings.groovy
+++ b/grails-app/controllers/org/pih/warehouse/UrlMappings.groovy
@@ -1007,6 +1007,11 @@ class UrlMappings {
             action = [POST: "createCycleCountItemBatch", PATCH: "updateCycleCountItemBatch"]
         }
 
+        "/api/facilities/$facility/cycle-counts/items/batch" {
+            controller = "cycleCountApi"
+            action = [POST: "createCycleCountItemBatch", PATCH: "updateCycleCountItemBatch"]
+        }
+
         "/api/facilities/$facility/cycle-counts/$cycleCountId/refresh" {
             controller = "cycleCountApi"
             action = [POST: "refreshCycleCount"]

--- a/src/js/api/services/CycleCountApi.js
+++ b/src/js/api/services/CycleCountApi.js
@@ -3,6 +3,7 @@ import queryString from 'query-string';
 import {
   CYCLE_COUNT, CYCLE_COUNT_ITEM,
   CYCLE_COUNT_ITEMS_BATCH,
+  CYCLE_COUNT_ITEMS_BATCH_ROOT,
   CYCLE_COUNT_ITEMS_IMPORT,
   CYCLE_COUNT_PENDING_REQUESTS,
   CYCLE_COUNT_RECOUNT_START,
@@ -52,8 +53,14 @@ export default {
       removeOutOfStockItemsImplicitly), {}, { params: { countIndex } }),
   createCycleCountItems: (payload, locationId, cycleCountId) =>
     apiClient.post(CYCLE_COUNT_ITEMS_BATCH(locationId, cycleCountId), payload),
+  // Root endpoint doesn't require the cycleCountId - we can send items from multiple cycle counts
+  createCycleCountItemsBatch: (payload, locationId) =>
+    apiClient.post(CYCLE_COUNT_ITEMS_BATCH_ROOT(locationId), payload),
   updateCycleCountItems: (payload, locationId, cycleCountId) =>
     apiClient.patch(CYCLE_COUNT_ITEMS_BATCH(locationId, cycleCountId), payload),
+  // Root endpoint doesn't require the cycleCountId - we can send items from multiple cycle counts
+  updateCycleCountItemsBatch: (payload, locationId) =>
+    apiClient.patch(CYCLE_COUNT_ITEMS_BATCH_ROOT(locationId), payload),
   importCycleCountItems: (file, locationId) => {
     const formData = new FormData();
     formData.append('importFile', file);

--- a/src/js/api/urls.js
+++ b/src/js/api/urls.js
@@ -192,6 +192,8 @@ export const CYCLE_COUNT_RECOUNT_START = (locationId, format) => `${CYCLE_COUNT(
 export const CYCLE_COUNT_ITEM = (locationId, itemId) => `${CYCLE_COUNT(locationId)}/items/${itemId}`;
 export const CYCLE_COUNT_ITEMS = (locationId, cycleCountId) => `${CYCLE_COUNT(locationId)}/${cycleCountId}/items`;
 export const CYCLE_COUNT_ITEMS_BATCH = (locationId, cycleCountId) => `${CYCLE_COUNT(locationId)}/${cycleCountId}/items/batch`;
+// Root endpoint doesn't require the cycleCountId - we can send items from multiple cycle counts
+export const CYCLE_COUNT_ITEMS_BATCH_ROOT = (locationId) => `${CYCLE_COUNT(locationId)}/items/batch`;
 export const CYCLE_COUNT_SUBMIT_COUNT = (locationId, cycleCountId) => `${CYCLE_COUNT(locationId)}/${cycleCountId}/count`;
 export const CYCLE_COUNT_SUBMIT_RECOUNT = (locationId, cycleCountId) => `${CYCLE_COUNT(locationId)}/${cycleCountId}/recount`;
 export const CYCLE_COUNT_REFRESH_ITEMS = (locationId, cycleCountId, removeOutOfStockItemsImplicitly) => `${CYCLE_COUNT(locationId)}/${cycleCountId}/refresh${removeOutOfStockItemsImplicitly ? '?removeOutOfStockItemsImplicitly=true' : ''}`;

--- a/src/js/hooks/cycleCount/useCountStep.jsx
+++ b/src/js/hooks/cycleCount/useCountStep.jsx
@@ -194,7 +194,6 @@ const useCountStep = () => {
     markAllItemsAsUpdated(cycleCountId);
     setCountedBy((prevState) => ({ ...prevState, [cycleCountId]: person }));
     setDefaultCountedBy((prevState) => ({ ...prevState, [cycleCountId]: person }));
-    setDefaultCountedBy((prevState) => ({ ...prevState, [cycleCountId]: person }));
     resetFocus();
   };
 
@@ -315,13 +314,13 @@ const useCountStep = () => {
 
   const getCountedDate = (cycleCountId) => dateCounted[cycleCountId];
 
-  const getPayload = (cycleCountItem, cycleCount, shouldSetDefaultAssignee) => ({
+  const getPayload = (cycleCountItem, shouldSetDefaultAssignee) => ({
     ...cycleCountItem,
     recount: false,
     assignee: shouldSetDefaultAssignee
-      ? getCountedBy(cycleCount.id)?.id ?? currentUser.id
-      : getCountedBy(cycleCount.id)?.id,
-    dateCounted: getCountedDate(cycleCount.id),
+      ? getCountedBy(cycleCountItem.cycleCountId)?.id ?? currentUser.id
+      : getCountedBy(cycleCountItem.cycleCountId)?.id,
+    dateCounted: getCountedDate(cycleCountItem.cycleCountId),
     inventoryItem: {
       ...cycleCountItem?.inventoryItem,
       product: cycleCountItem.product?.id,
@@ -330,40 +329,47 @@ const useCountStep = () => {
         outputDateFormat: DateFormat.MM_DD_YYYY,
       }),
     },
+    cycleCount: cycleCountItem.cycleCountId,
   });
 
   const save = async (shouldSetDefaultAssignee = false) => {
     try {
       show();
       resetValidationState();
+      const cycleCountItemsToUpdateBatch = [];
+      const cycleCountItemsToCreateBatch = [];
       for (const cycleCount of tableData.current) {
         const cycleCountItemsToUpdate = cycleCount.cycleCountItems
           .filter((item) => ((item.updated || !item.assignee) && !item.id.includes('newRow')))
-          .map(trimLotNumberSpaces);
-        const updatePayload = {
-          itemsToUpdate: cycleCountItemsToUpdate.map((item) =>
-            getPayload(item, cycleCount, shouldSetDefaultAssignee)),
-        };
-        if (updatePayload.itemsToUpdate.length > 0) {
-          await cycleCountApi
-            .updateCycleCountItems(updatePayload, currentLocation?.id, cycleCount.id);
+          .map((item) => ({ ...trimLotNumberSpaces(item), cycleCountId: cycleCount.id }));
+
+        if (cycleCountItemsToUpdate.length > 0) {
+          cycleCountItemsToUpdateBatch.push(cycleCountItemsToUpdate);
         }
         const cycleCountItemsToCreate = cycleCount.cycleCountItems
           .filter((item) => item.id.includes('newRow'))
-          .map(trimLotNumberSpaces);
-        const createPayload = {
-          itemsToCreate: cycleCountItemsToCreate.map((item) =>
-            getPayload(item, cycleCount, shouldSetDefaultAssignee)),
-        };
-        if (createPayload.itemsToCreate.length > 0) {
-          await cycleCountApi
-            .createCycleCountItems(createPayload, currentLocation?.id, cycleCount.id);
+          .map((item) => ({ ...trimLotNumberSpaces(item), cycleCountId: cycleCount.id }));
+
+        if (cycleCountItemsToCreate.length > 0) {
+          cycleCountItemsToCreateBatch.push(cycleCountItemsToCreate);
         }
 
         // Now that we've successfully saved all the items, mark them all as not updated so that
         // we don't try to update them again next time something is changed.
         markAllItemsAsNotUpdated(cycleCount.id);
       }
+      const updatePayload = {
+        itemsToUpdate: cycleCountItemsToUpdateBatch.flat().map((item) =>
+          getPayload(item, shouldSetDefaultAssignee)),
+      };
+      await cycleCountApi
+        .updateCycleCountItemsBatch(updatePayload, currentLocation?.id);
+      const createPayload = {
+        itemsToCreate: cycleCountItemsToCreateBatch.flat().map((item) =>
+          getPayload(item, shouldSetDefaultAssignee)),
+      };
+      await cycleCountApi
+        .createCycleCountItemsBatch(createPayload, currentLocation?.id);
     } finally {
       // After the save, refetch cycle counts so that a new row can't be saved multiple times
       await fetchCycleCounts();
@@ -649,6 +655,9 @@ const useCountStep = () => {
       );
       setImportErrors(response.data.errors);
       let cycleCounts = _.groupBy(response.data.data, 'cycleCountId');
+      const countedByUpdates = {};
+      const dateCountedUpdates = {};
+
       tableData.current = tableData.current.map((cycleCount) => {
         // After each iteration assign it to false again, so that the flag
         // can be reused for next cycle counts in the loop
@@ -667,12 +676,11 @@ const useCountStep = () => {
                 // so we can make this operation only once
                 // this is why we introduce the assigneeImported boolean flag
                 if (correspondingImportItem && !assigneeImported.current[cycleCount.id]) {
-                  assignCountedBy(cycleCount.id)(correspondingImportItem.assignee);
+                  countedByUpdates[cycleCount.id] = correspondingImportItem.assignee;
                   // Do not allow to clear the date counted dropdown
                   // if dateCounted was not set in the sheet
                   if (correspondingImportItem.dateCounted) {
-                    setDateCounted((prevState) =>
-                      ({ ...prevState, [cycleCount.id]: correspondingImportItem.dateCounted }));
+                    dateCountedUpdates[cycleCount.id] = correspondingImportItem.dateCounted;
                   }
                   // Mark the flag as true, so that it's not triggered for each item
                   assigneeImported.current = true;
@@ -695,9 +703,14 @@ const useCountStep = () => {
           ],
         };
       });
+      // Batch update state
+      setCountedBy((prevState) => ({ ...prevState, ...countedByUpdates }));
+      setDefaultCountedBy((prevState) => ({ ...prevState, ...countedByUpdates }));
+      setDateCounted((prevState) => ({ ...prevState, ...dateCountedUpdates }));
+
+      // Reset focus once
+      resetFocus();
     } finally {
-      // After import we want to trigger the validation on fields,
-      // so that a user knows what fields to correct from the UI
       triggerValidation();
       hide();
     }

--- a/src/main/groovy/org/pih/warehouse/inventory/CycleCountItemCommand.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/CycleCountItemCommand.groovy
@@ -54,7 +54,7 @@ class CycleCountItemCommand implements Validateable {
     def beforeValidate() {
         String cycleCountId = RequestContextHolder.getRequestAttributes().params?.cycleCountId
         String facilityId = RequestContextHolder.getRequestAttributes().params?.facility
-        cycleCount = CycleCount.get(cycleCountId)
+        cycleCount = cycleCount ?: CycleCount.get(cycleCountId)
         facility = Location.read(facilityId)
     }
 


### PR DESCRIPTION
… long batches

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:**

**Description:**
Data source: proceeding with 14 cycle counts at once (24 items overall).

For export, what could be improved is the batch endpoint - previously we were sending X batch requests, where X is amount of cycle count proceeded. Now, I make only one batch request, containing all cycle counts that we are proceeding.
This doesn't improve the performance much, still the export itself takes for about 16 seconds after changes (before it was 19 seconds), so what we really earn is X*~200ms where X is amount of cycle count proceeded.

Regarding the import, the crucial part was the assignee/dateCounted setStates + `resetCount()` being called in a loop - for each cycle count separately. I moved that out of the loop, to store the dates/assignees that I would like to update, and then, I do it in one setState statement, in the end.
As the result, the time of import for my data (14 CC, 24 items) went down from 190 seconds to 12 seconds.


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
