### PR TITLE
OBPIH-7322 change products inventoried to use items inventoried indic…

### DIFF
--- a/grails-app/utils/org/pih/warehouse/DateUtil.groovy
+++ b/grails-app/utils/org/pih/warehouse/DateUtil.groovy
@@ -54,6 +54,12 @@ class DateUtil {
     static final DateTimeFormatter DISPLAY_DATE_FORMATTER = DateTimeFormatter.ofPattern("dd/MMM/yyyy")
     static final DateTimeFormatter DISPLAY_DATE_TIME_OFFSET_FORMATTER = DateTimeFormatter.ofPattern("dd/MMM/yyyy HH:mm XXX")
     static final DateTimeFormatter DISPLAY_TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss")
+
+    /**
+     * A Date representing the epoch instant, which is January 1, 1970, 00:00:00 GMT.
+     */
+    static final Date EPOCH_DATE = new Date(0)
+
     /**
      * Converts a LocalDate to a date-only string for display. This method should only be used by GSPs and file
      * exporters. Otherwise we should return the date object as is and let the frontend decide the display format.


### PR DESCRIPTION
…ator logic

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7322

**Description:** Change the logic for the "products inventoried" indicator to use the same logic as the "items inventoried" dashboard indicator (as was suggested by Manon). Kacper already refactored the dashboard indicator to account for the baseline + adjustment refactor so this seems safe to do. We want to display the same data in both indicators.

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

<img width="1200" height="407" alt="Screenshot from 2025-07-22 11-09-32" src="https://github.com/user-attachments/assets/4405fe92-13fd-478b-86e6-47e283e54fb9" />
