### PR TITLE
Added long overdue security policy to main github repository (fixes #2707)

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+This security policy applies to all public repositories under the [OpenBoxes](https://github.com/openboxes) organization on 
+GitHub.
+
+## Supported Versions
+We provide security updates for the [latest official release](https://github.com/openboxes/openboxes/releases/latest) of OpenBoxes.
+
+## Reporting a Vulnerability
+
+If you discover a vulnerability in any public project under the [OpenBoxes](https://github.com/openboxes) organization, 
+please report it responsibly to [support@openboxes.com](mailto:support@openboxes.com).
+
+## Response SLA
+As an open-source project with limited resources, we will do our best to respond to and resolve security issues 
+in a timely manner.
+
+We will attempt to acknowledge reports within 5–10 business days and provide a resolution within 90 days, 
+depending on the severity and complexity. We will also make every effort to publicly disclose all security 
+vulnerabilities as soon as a security update (hotfix) is available.
+
+**Please do not disclose the issue publicly until we’ve had a chance to investigate and provide a fix.**
+
+


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:**
https://github.com/openboxes/openboxes/issues/2707

**Description:**
Create a basic security policy (security.md) to help security researchers report vulnerabilities. I would like a future version to be based on the [security.txt](https://securitytxt.org/) standard. For now, I've just added the bare minimum. 

---
### :camera: Screenshots & Recordings (optional)

<img width="1733" height="1096" alt="image" src="https://github.com/user-attachments/assets/fa10df12-9f8a-4762-b1a3-859ca0cbff76" />
