### PR TITLE
OBPIH-7430 don't error on record stock if no adjustments are made

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
@@ -1452,7 +1452,7 @@ class InventoryService implements ApplicationContextAware {
                     }
                 }
 
-                // c) Create a new transaction entry (even if quantity didn't change)
+                // c) Create a new transaction entry (but only if the quantity changed)
                 TransactionEntry transactionEntry = recordStockProductInventoryTransactionService.createAdjustmentTransactionEntry(
                         row,
                         inventoryItem,
@@ -1469,10 +1469,9 @@ class InventoryService implements ApplicationContextAware {
                 return
             }
 
-            // 5. Check if there are any changes recorded
+            // 5. Check if there are any changes in quantity recorded. If there aren't, we're done.
             if (!adjustmentTransaction.transactionEntries) {
-                cmd.errors.reject("transaction.noChanges", "There are no quantity changes in the current transaction")
-                return
+                return cmd
             }
 
             // Quantity available to promise will be manually calculated,


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7430

**Description:** Doing a record stock where the quantity for all items is unchanged (ie there are no adjustments) is valid and so should not throw an error.


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

A video recording of the issue: https://jam.dev/c/2309b701-383f-4c6b-b01b-59eced2b41c3