### PR TITLE
OBPIH-7437 handle all items skipped during inventory import

### DIFF
--- a/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
@@ -140,6 +140,13 @@ class InventoryImportDataService implements ImportDataService {
     void importData(ImportDataCommand command) {
         InventoryImportData inventoryImportData = parseData(command)
 
+        // (OBPIH-7437) If there's nothing in the import, or everything is getting skipped, return early.
+        //  Without this, ALL products at the facility will have their quantities zeroed out! (When the TODO
+        //  in InventoryService.getTransactionEntriesBeforeDate is resolved, this will no longer be true.)
+        if (!inventoryImportData.products) {
+            return
+        }
+
         Date baselineTransactionDate = command.date
 
         // Get the stock for all items in the import at the date that the baseline transaction will be created.

--- a/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
@@ -2707,6 +2707,10 @@ class InventoryService implements ApplicationContextAware {
 
         def criteria = TransactionEntry.createCriteria()
         return criteria.list {
+            // TODO: Consider refactoring this logic to distinguish between products==null and products.?isEmpty().
+            //       The former should give the current behaviour (fetch ALL products) and the latter should return an
+            //       empty list. Existing flows will need to be refactored to default to either passing null or []
+            //       depending on their desired behaviour. See OBPIH-7437.
             if (products) {
                 inventoryItem {
                     'in'("product", products)


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7437

**Description:** If an import has no products/items or all the items are skipped due to no quantity being defined, ALL products for the facility were getting zeroed out. This was due to how a query in InventoryService was working (if the given list of products is falsey, fetch ALL transactions).

A more proper fix would be to change the query to distinguish between an empty list of products and a null list of products, but that refactor would have potential knock on effects across users of that query so I opted for the safest option for now since we're so close to release.


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

Video describing issue: https://jam.dev/c/732d4448-6805-4bbc-9c8f-ef2314d2965c
