### PR TITLE
OBPIH-7444 fail creating adjustment when transaction already exists a…

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -3093,6 +3093,7 @@ transactionType.transactionCode.label=Transaction Code
 # Transfer Stock
 transferStock.chooseDestination.message=Choose destination
 adjustStock.invalid.quantity.message=Quantity must be greater than 0 and not equal to current quantity
+adjustStock.invalid.transactionDate.duplicate.message=A transaction already exists at the specified time
 # Data binding errors. Use "typeMismatch.$className.$propertyName to customize (eg typeMismatch.Book.author)
 typeMismatch.java.lang.Double=Property {0} must be a valid number
 typeMismatch.java.lang.Integer=Property {0} must be a valid number

--- a/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
@@ -243,7 +243,7 @@ class InventoryImportDataService implements ImportDataService {
 
         // We'd have weird behaviour if we allowed two transactions to exist at the same exact time (precision at the
         // database level is to the second) so fail if there's already a transaction on the items for the given date.
-        if (inventoryService.hasTransactionEntriesOnDate(facility, transactionDate, inventoryImportData.inventoryItems)) {
+        if (inventoryService.hasTransactionEntriesOnDate(facility, transactionDate, inventoryImportData.products as List<Product>)) {
             throw new IllegalArgumentException("A transaction already exists at time ${transactionDate}")
         }
 

--- a/grails-app/services/org/pih/warehouse/inventory/CycleCountTransactionService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/CycleCountTransactionService.groovy
@@ -18,6 +18,7 @@ class CycleCountTransactionService {
     ProductAvailabilityService productAvailabilityService
     CycleCountProductInventoryTransactionService cycleCountProductInventoryTransactionService
     TransactionIdentifierService transactionIdentifierService
+    InventoryService inventoryService
 
     /**
      * Given a completed cycle count, will create and persist the resulting product inventory transaction,
@@ -59,6 +60,11 @@ class CycleCountTransactionService {
 
     private Transaction createAdjustmentTransaction(
             CycleCount cycleCount, Date transactionDate, boolean itemQuantityOnHandIsUpToDate) {
+
+        // Reports and QoH calculations get messed up if two transactions for a product exist at the same exact time.
+        if (inventoryService.hasTransactionEntriesOnDate(cycleCount.facility, transactionDate, cycleCount.products)) {
+            throw new IllegalArgumentException("A transaction already exists at time ${transactionDate}")
+        }
 
         // We need to compare the quantity counted against the most up to date QoH in product availability.
         // However, if the cycle count items already have an up to date QoH (which will be the case if

--- a/grails-app/services/org/pih/warehouse/inventory/ProductInventoryTransactionService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductInventoryTransactionService.groovy
@@ -120,8 +120,8 @@ abstract class ProductInventoryTransactionService<T> {
         // We'd have weird behaviour if we allowed two transactions to exist at the same exact time (precision at the
         // database level is to the second) so fail if there's already a transaction on the items for the given date.
         Date actualTransactionDate = transactionDate ?: new Date()
-        List<InventoryItem> inventoryItems = availableItems.collect{ it.inventoryItem }
-        if (validateTransactionDates && inventoryService.hasTransactionEntriesOnDate(facility, actualTransactionDate, inventoryItems)) {
+        List<Product> products = availableItems.collect{ it.inventoryItem.product }.unique()
+        if (validateTransactionDates && inventoryService.hasTransactionEntriesOnDate(facility, actualTransactionDate, products)) {
             throw new IllegalArgumentException("A transaction already exists at time ${actualTransactionDate}")
         }
 

--- a/src/test/groovy/unit/org/pih/warehouse/inventory/CycleCountProductInventoryTransactionServiceSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/inventory/CycleCountProductInventoryTransactionServiceSpec.groovy
@@ -75,21 +75,20 @@ class CycleCountProductInventoryTransactionServiceSpec extends Specification imp
         and: 'mocked available items'
         List<AvailableItem> availableItems = [
                 new AvailableItem(
-                        inventoryItem: new InventoryItem(),
+                        inventoryItem: new InventoryItem(product: product),
                         binLocation: new Location(),
                         quantityOnHand: 50,
                 ),
                 new AvailableItem(
-                        inventoryItem: new InventoryItem(),
+                        inventoryItem: new InventoryItem(product: product),
                         binLocation: new Location(),
                         quantityOnHand: 25,
                 )
         ]
-        List<InventoryItem> inventoryItems = availableItems.collect{ it.inventoryItem }
         productAvailabilityServiceStub.getAvailableItemsAtDate(facility, [product], null) >> availableItems
 
         and: 'no other transactions exist at that time'
-        inventoryServiceStub.hasTransactionEntriesOnDate(facility, _ as Date, inventoryItems) >> false
+        inventoryServiceStub.hasTransactionEntriesOnDate(facility, _ as Date, [product]) >> false
 
         when: 'we create a baseline with no date provided'
         Transaction transaction = cycleCountProductInventoryTransactionService.createInventoryBaselineTransaction(
@@ -119,21 +118,20 @@ class CycleCountProductInventoryTransactionServiceSpec extends Specification imp
         and: 'mocked available items'
         List<AvailableItem> availableItems = [
                 new AvailableItem(
-                        inventoryItem: new InventoryItem(),
+                        inventoryItem: new InventoryItem(product: product),
                         binLocation: new Location(),
                         quantityOnHand: 50,
                 ),
                 new AvailableItem(
-                        inventoryItem: new InventoryItem(),
+                        inventoryItem: new InventoryItem(product: product),
                         binLocation: new Location(),
                         quantityOnHand: 25,
                 )
         ]
-        List<InventoryItem> inventoryItems = availableItems.collect{ it.inventoryItem }
         productAvailabilityServiceStub.getAvailableItemsAtDate(facility, [product], transactionDate) >> availableItems
 
         and: 'no other transactions exist at that time'
-        inventoryServiceStub.hasTransactionEntriesOnDate(facility, transactionDate, inventoryItems) >> false
+        inventoryServiceStub.hasTransactionEntriesOnDate(facility, transactionDate, [product]) >> false
 
         when: 'we create a baseline with date provided'
         Transaction transaction = cycleCountProductInventoryTransactionService.createInventoryBaselineTransaction(
@@ -177,16 +175,15 @@ class CycleCountProductInventoryTransactionServiceSpec extends Specification imp
         and: 'mocked available items'
         List<AvailableItem> availableItems = [
                 new AvailableItem(
-                        inventoryItem: new InventoryItem(),
+                        inventoryItem: new InventoryItem(product: product),
                         binLocation: new Location(),
                         quantityOnHand: 50,
                 ),
         ]
-        List<InventoryItem> inventoryItems = availableItems.collect{ it.inventoryItem }
         productAvailabilityServiceStub.getAvailableItemsAtDate(facility, [product], transactionDate) >> availableItems
 
         and: 'other transactions do exist at that time'
-        inventoryServiceStub.hasTransactionEntriesOnDate(facility, transactionDate, inventoryItems) >> true
+        inventoryServiceStub.hasTransactionEntriesOnDate(facility, transactionDate, [product]) >> true
 
         when:
         cycleCountProductInventoryTransactionService.createInventoryBaselineTransaction(

--- a/src/test/groovy/unit/org/pih/warehouse/inventory/CycleCountTransactionServiceSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/inventory/CycleCountTransactionServiceSpec.groovy
@@ -15,6 +15,7 @@ import org.pih.warehouse.inventory.CycleCountProductInventoryTransactionService
 import org.pih.warehouse.inventory.CycleCountTransactionService
 import org.pih.warehouse.inventory.Inventory
 import org.pih.warehouse.inventory.InventoryItem
+import org.pih.warehouse.inventory.InventoryService
 import org.pih.warehouse.inventory.ProductAvailabilityService
 import org.pih.warehouse.inventory.Transaction
 import org.pih.warehouse.inventory.TransactionEntry
@@ -39,6 +40,9 @@ class CycleCountTransactionServiceSpec extends Specification implements DataTest
 
     @Shared
     TransactionIdentifierService transactionIdentifierServiceStub
+
+    @Shared
+    InventoryService inventoryServiceStub
 
     @Shared
     TransactionType productInventoryTransactionType
@@ -68,6 +72,9 @@ class CycleCountTransactionServiceSpec extends Specification implements DataTest
         transactionIdentifierServiceStub = Stub(TransactionIdentifierService)
         cycleCountTransactionService.transactionIdentifierService = transactionIdentifierServiceStub
 
+        inventoryServiceStub = Stub(InventoryService)
+        cycleCountTransactionService.inventoryService = inventoryServiceStub
+
         // Set up the transaction types
         productInventoryTransactionType = new TransactionType()
         productInventoryTransactionType.id = Constants.PRODUCT_INVENTORY_TRANSACTION_TYPE_ID
@@ -83,6 +90,9 @@ class CycleCountTransactionServiceSpec extends Specification implements DataTest
         Location facility = new Location(inventory: new Inventory())
         Product product = new Product()
         Date date = new Date()
+
+        and: 'no other transactions exist at the time for the product'
+        inventoryServiceStub.hasTransactionEntriesOnDate(facility, _ as Date, [product]) >> false
 
         and: 'a cycle count with no discrepancies'
         CycleCount cycleCount = new CycleCount(
@@ -119,6 +129,9 @@ class CycleCountTransactionServiceSpec extends Specification implements DataTest
         Product product2 = new Product()
         product2.id = 2
         Date date = new Date()
+
+        and: 'no other transactions exist at the time for the products'
+        inventoryServiceStub.hasTransactionEntriesOnDate(facility, _ as Date, [product1, product2]) >> false
 
         and: 'a cycle count with two products and no discrepancies'
         CycleCount cycleCount = new CycleCount(
@@ -163,6 +176,9 @@ class CycleCountTransactionServiceSpec extends Specification implements DataTest
         Product product = new Product()
         InventoryItem inventoryItem = new InventoryItem()
         Date date = new Date()
+
+        and: 'no other transactions exist at the time for the product'
+        inventoryServiceStub.hasTransactionEntriesOnDate(facility, _ as Date, [product]) >> false
 
         and: 'a cycle count with discrepancies'
         String binNameNegativeAdjustment = "binNeg"
@@ -238,6 +254,45 @@ class CycleCountTransactionServiceSpec extends Specification implements DataTest
         assert positiveTransactionEntry.product == product
         assert negativeTransactionEntry.inventoryItem == inventoryItem
         assert positiveTransactionEntry.quantity == 3
+    }
+
+    void 'OBPIH-7444: createTransactions should fail when a transaction already exists for the product'() {
+        given: 'mocked inputs'
+        Location facility = new Location(inventory: new Inventory())
+        Product product = new Product()
+        InventoryItem inventoryItem = new InventoryItem()
+        Date date = new Date()
+
+        and: 'a transaction already exists at the time for the product'
+        inventoryServiceStub.hasTransactionEntriesOnDate(facility, _ as Date, [product]) >> true
+
+        and: 'a cycle count with discrepancies'
+        CycleCount cycleCount = new CycleCount(
+                facility: facility,
+                cycleCountItems: [
+                        new CycleCountItem(
+                                inventoryItem: inventoryItem,
+                                location: new Location(name: 'bin1'),
+                                product: product,
+                                countIndex: 0,
+                                status: CycleCountItemStatus.COUNTED,
+                                quantityOnHand: 30,
+                                quantityCounted: 33,  // Positive discrepancy (+3)
+                        ),
+                ]
+        )
+
+        and: 'a mocked transaction number'
+        transactionIdentifierServiceStub.generate(_ as Transaction) >> "123ABC"
+
+        and: 'a mocked product inventory transaction'
+        createExpectedProductInventoryTransaction(facility, product, cycleCount, date)
+
+        when:
+        cycleCountTransactionService.createTransactions(cycleCount, true)
+
+        then:
+        thrown(IllegalArgumentException)
     }
 
     private Transaction createExpectedProductInventoryTransaction(


### PR DESCRIPTION
…t time

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7444

**Description:** If we do a cycle count or record stock or inventory import and set quantity to zero for a product, then next CC or RS or II on that product won't have a baseline (because we don't create baselines if quantity == 0, this is something we're going to change in 0.9.6). Because of that, we can successfully create multiple adjustment transactions at the exact same time. To fix this, we need to also check that there are no transactions at the time of the adjustments.


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

Video showing the bug: https://jam.dev/c/6005951b-9362-454e-8e7b-bc64e31a24a6

Video shows that after this fix, if we do a record stock to set quantity to zero, then an inventory import at the same time should fail, even if it's on different items of the product.

[Screencast from 2025-08-08 11:33:34 AM.webm](https://github.com/user-attachments/assets/e9c1a961-8820-46db-bcfd-43716b85c65c)

