### PR TITLE
OBPIH-7471 Keep Approver column visible after clicking clear button (fix)

### DIFF
--- a/src/js/components/stock-movement/outbound/StockMovementOutboundTable.jsx
+++ b/src/js/components/stock-movement/outbound/StockMovementOutboundTable.jsx
@@ -353,7 +353,7 @@ const StockMovementOutboundTable = ({
         />
       ),
     },
-  ], [requisitionStatuses, translate]);
+  ], [requisitionStatuses, translate, isRequestsOpen]);
 
   return (
     <>


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:**
https://pihemr.atlassian.net/browse/OBPIH-7471

**Description:**
The problem was that boolean isRequestsOpen was not included in the dependency array of the useMemo hook. When clicking the Clear button, isRequestsOpen temporarily becomes false and then back to true. Since useMemo didn’t depend on this value, the columns were not updated and the Approver column disappeared.

I fixed this by adding isRequestsOpen to the useMemo dependencies, so the columns update correctly and the Approver column stays visible after clicking Clear button.


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
