### PR TITLE
OBPIH-7475 date formatters for GSPs and data exporters

### DIFF
--- a/grails-app/domain/org/pih/warehouse/product/Product.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/Product.groovy
@@ -11,6 +11,7 @@ package org.pih.warehouse.product
 
 import grails.databinding.BindUsing
 import grails.util.Holders
+import java.time.Instant
 import org.apache.commons.collections.FactoryUtils
 import org.apache.commons.collections.list.LazyList
 import org.apache.commons.lang.NotImplementedException
@@ -229,8 +230,8 @@ class Product implements Comparable, Serializable {
     GlAccount glAccount
 
     // Auditing
-    Date dateCreated
-    Date lastUpdated
+    Instant dateCreated
+    Instant lastUpdated
     User createdBy
     User updatedBy
 

--- a/grails-app/services/org/pih/warehouse/product/ProductService.groovy
+++ b/grails-app/services/org/pih/warehouse/product/ProductService.groovy
@@ -17,6 +17,8 @@ import org.apache.commons.lang.StringUtils
 import org.hibernate.criterion.CriteriaSpecification
 import org.hibernate.criterion.Restrictions
 import org.hibernate.sql.JoinType
+import org.springframework.beans.factory.annotation.Autowired
+
 import org.pih.warehouse.core.ApiException
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.GlAccount
@@ -27,7 +29,9 @@ import org.pih.warehouse.core.Tag
 import org.pih.warehouse.core.UnitOfMeasure
 import org.pih.warehouse.LocalizationUtil
 import util.ReportUtil
-import java.text.SimpleDateFormat
+
+import org.pih.warehouse.core.date.DateFormatterManager
+
 /**
  * @author jmiranda*
  */
@@ -41,6 +45,7 @@ class ProductService {
     def userService
     def dataService
     ProductGroupService productGroupService
+    @Autowired DateFormatterManager dateFormatter
 
     def getNdcResults(operation, q) {
         def hipaaspaceApiKey = grailsApplication.config.hipaaspace.api.key
@@ -853,7 +858,6 @@ class ProductService {
      */
     String exportProducts(List<Product> products, boolean includeAttributes) {
 
-        def formatDate = new SimpleDateFormat("dd/MMM/yyyy hh:mm:ss")
         def attributes = Attribute.findAllByExportableAndActive(true, true)
         def formatTagLib = grailsApplication.mainContext.getBean('org.pih.warehouse.FormatTagLib')
         boolean hasRoleFinance = userService.hasRoleFinance()
@@ -887,8 +891,8 @@ class ProductService {
                 VendorName          : product.vendorName ?: '',
                 UPC                 : product.upc ?: '',
                 NDC                 : product.ndc ?: '',
-                Created             : product.dateCreated ? "${formatDate.format(product.dateCreated)}" : "",
-                Updated             : product.lastUpdated ? "${formatDate.format(product.lastUpdated)}" : "",
+                Created             : dateFormatter.formatForExport(product.dateCreated),
+                Updated             : dateFormatter.formatForExport(product.lastUpdated),
             ]
 
             if (includeAttributes) {

--- a/grails-app/utils/org/pih/warehouse/DateUtil.groovy
+++ b/grails-app/utils/org/pih/warehouse/DateUtil.groovy
@@ -44,31 +44,23 @@ import org.pih.warehouse.databinding.DataBindingConstants
  */
 class DateUtil {
 
+    private static final String EMPTY_DISPLAY_DATE = ''
+
     /*
-     * Formatters for displaying dates. These should only be used by GSPs and file exporters. Everything else should
-     * return the date object itself to the frontend (which will get formatted to an ISO formatted string).
+     * Formatters for displaying dates. These should only be used by GSPs and file exporters. When returning dates via
+     * API, we should always use ISO format, which is the default toString() behaviour of the java.time classes.
      *
      * We should strive to only ever use a single format per date type. For example, we should only have one format
      * for displaying day + month + year. This allows us to be consistent in how we display date fields in the app.
      */
-    static final DateTimeFormatter DISPLAY_DATE_FORMATTER = DateTimeFormatter.ofPattern("dd/MMM/yyyy")
-    static final DateTimeFormatter DISPLAY_DATE_TIME_OFFSET_FORMATTER = DateTimeFormatter.ofPattern("dd/MMM/yyyy HH:mm XXX")
-    static final DateTimeFormatter DISPLAY_TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss")
+    static final DateTimeFormatter DEFAULT_DISPLAY_DATE_FORMATTER = DateTimeFormatter.ofPattern("dd/MMM/yyyy")
+    static final DateTimeFormatter DEFAULT_DISPLAY_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("dd/MMM/yyyy HH:mm:ss XXX")
+    static final DateTimeFormatter DEFAULT_DISPLAY_TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss")
 
     /**
      * A Date representing the epoch instant, which is January 1, 1970, 00:00:00 GMT.
      */
     static final Date EPOCH_DATE = new Date(0)
-
-    /**
-     * Converts a LocalDate to a date-only string for display. This method should only be used by GSPs and file
-     * exporters. Otherwise we should return the date object as is and let the frontend decide the display format.
-     *
-     * @return a formatted date String. Ex: "01/Jan/2025"
-     */
-    static String asDateForDisplay(LocalDate date) {
-        return DISPLAY_DATE_FORMATTER.format(date)
-    }
 
     /**
      * Converts a Date to a date-only string for display. This method should only be used by GSPs and file exporters.
@@ -79,36 +71,7 @@ class DateUtil {
      * @return a formatted date String. Ex: "01/Jan/2025"
      */
     static String asDateForDisplay(Date date, ZoneId zone=null) {
-        return asDateForDisplay(asLocalDate(date, zone))
-    }
-
-    /**
-     * Converts an Instant to a date + time + offset string for display. This method should only be used by GSPs and
-     * file exporters. Otherwise we should return the date object as is and let the frontend decide the display format.
-     *
-     * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example. Defaults to the system timezone.
-     * @return a formatted datetime String. Ex: "01/Jan/2025 00:00 +05:00"
-     */
-    static String asDateTimeForDisplay(Instant instant, ZoneId zone=null) {
-        ZoneId zoneToUse = zone ?: getSystemZoneOffset()
-        return asDateTimeForDisplay(instant.atZone(zoneToUse))
-    }
-
-    /**
-     * Converts a ZonedDateTime to a date + time + offset string for display. This method should only be used by GSPs
-     * and file exporters. Otherwise we should return the date object as is and let the frontend decide the display
-     * format.
-     *
-     * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example. Defaults to the existing timezone
-     *        of the ZonedDateTime.
-     * @return a formatted datetime String. Ex: "01/Jan/2025 00:00 +05:00"
-     */
-    static String asDateTimeForDisplay(ZonedDateTime zonedDateTime, ZoneId zone=null) {
-        // If we're not given a zone to display, we retain the zone as defined in the ZonedDateTime. We could have
-        // converted it to the system timezone, but it felt safer to preserve the ZDT's state. In most cases we'll be
-        // specifying the timezone, and when we don't, the ZDT will be in server time anyways, so it shouldn't matter.
-        ZonedDateTime zonedDateTimeToUse = zone ? zonedDateTime.withZoneSameInstant(zone) : zonedDateTime
-        return DISPLAY_DATE_TIME_OFFSET_FORMATTER.format(zonedDateTimeToUse)
+        return date ? DEFAULT_DISPLAY_DATE_FORMATTER.format(asLocalDate(date, zone)) : EMPTY_DISPLAY_DATE
     }
 
     /**
@@ -117,10 +80,22 @@ class DateUtil {
      * Useful when working with old code that uses the old Date format.
      *
      * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example. Defaults to the system timezone.
-     * @return a formatted datetime String. Ex: "01/Jan/2025 00:00 +05:00"
+     * @return a formatted datetime String. Ex: "01/Jan/2025 00:00:00 +05:00"
      */
     static String asDateTimeForDisplay(Date date, ZoneId zone=null) {
-        return asDateTimeForDisplay(asInstant(date), zone)
+        return date ? DEFAULT_DISPLAY_DATE_TIME_FORMATTER.format(asZonedDateTime(date, zone)) : EMPTY_DISPLAY_DATE
+    }
+
+    /**
+     * Converts a Date to a time-only string for display. This method should only be used by GSPs and file
+     * exporters. Otherwise we should return the date object as is and let the frontend decide the display format.
+     * Useful when working with old code that uses the old Date format.
+     *
+     * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example. Defaults to the system timezone.
+     * @return a formatted time String. Ex: "12:34:56"
+     */
+    static String asTimeForDisplay(Date date, ZoneId zone=null) {
+        return date ? DEFAULT_DISPLAY_TIME_FORMATTER.format(asLocalTime(date, zone)) : EMPTY_DISPLAY_DATE
     }
 
     /**
@@ -144,7 +119,7 @@ class DateUtil {
      * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example. Defaults to the system timezone.
      */
     static ZonedDateTime asZonedDateTime(Instant instant, ZoneId zone=null) {
-        ZoneId zoneToUse = zone ?: getSystemZoneOffset()
+        ZoneId zoneToUse = zone ?: getSystemZoneId()
         return instant ? instant.atZone(zoneToUse) : null
     }
 
@@ -166,8 +141,24 @@ class DateUtil {
      * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example. Defaults to the system timezone.
      */
     static LocalDate asLocalDate(Date date, ZoneId zone=null) {
+        // We need to be really careful here. We want the LocalDate object to be at midnight on the given Date in the
+        // given timezone as it is currently. That's why we need to fetch the current offset and not simply the zone.
+        // If we fetch the zone, the call to atStartOfDay will outsmart us and try to display it in the offset that
+        // was relevant at the time, which might be different than the current offset due to daylight savings time.
+        // This will result in the day being shifted by one. Using the offset directly avoids this scenario.
         ZoneId zoneToUse = zone ?: getSystemZoneOffset()
         return date ? asInstant(date).atZone(zoneToUse).toLocalDate() : null
+    }
+
+    /**
+     * Null-safe conversion of a (deprecated) java.util.Date to a LocalTime.
+     * Useful when working with old code that uses the old format.
+     *
+     * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example. Defaults to the system timezone.
+     */
+    static LocalTime asLocalTime(Date date, ZoneId zone=null) {
+        ZoneId zoneToUse = zone ?: getSystemZoneId()
+        return date ? asInstant(date).atZone(zoneToUse).toLocalTime() : null
     }
 
     /**
@@ -228,6 +219,11 @@ class DateUtil {
      * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example. Defaults to the system timezone.
      */
     static Date asDate(LocalDate localDate, ZoneId zone=null) {
+        // We need to be really careful here. We want the Date object to be at midnight on the given day in the
+        // given timezone as it is currently. That's why we need to fetch the current offset and not simply the zone.
+        // If we fetch the zone, the call to atStartOfDay will outsmart us and try to display it in the offset that
+        // was relevant at the time, which might be different than the current offset due to daylight savings time.
+        // This will result in the day being shifted by one. Using the offset directly avoids this scenario.
         ZoneId zoneToUse = zone ?: getSystemZoneOffset()
         return localDate ? asDate(localDate.atStartOfDay(zoneToUse)) : null
     }
@@ -240,21 +236,14 @@ class DateUtil {
         // Extracts the offset rules for the timezone (ie what the offset is for a zone for a given time of year),
         // then uses those rules to determine the offset (ex: '-05:00') for the given instant. This check is required
         // because a zone can be in one of many offsets depending on the time of year due to daylight savings.
-        return ZoneId.systemDefault().getRules().getOffset(instant ?: Instant.now())
+        return getSystemZoneId().getRules().getOffset(instant ?: Instant.now())
     }
 
     /**
-     * Converts a Date to a time-only string for display.
+     * Get the current ZoneId of the system.
      */
-    static String asTimeForDisplay(Date date) {
-        if (!date) {
-            return null
-        }
-        LocalTime time = date.toInstant()
-                .atZone(ZoneId.systemDefault())
-                .toLocalTime()
-
-        return DISPLAY_TIME_FORMATTER.format(time)
+    static ZoneId getSystemZoneId() {
+        return ZoneId.systemDefault()
     }
 
     static Date clearTime(Date date) {

--- a/grails-app/views/inventoryItem/_productDetails.gsp
+++ b/grails-app/views/inventoryItem/_productDetails.gsp
@@ -1,4 +1,4 @@
-<%@ page import="org.pih.warehouse.inventory.InventoryStatus" %>
+<%@ page import="org.pih.warehouse.DateUtil; org.pih.warehouse.inventory.InventoryStatus" %>
 <style>
 .nailthumb-container {
     width: 100%;
@@ -350,8 +350,7 @@
                 </td>
                 <td class="value">
                     <span class="fade">
-                        ${g.formatDate(date: productInstance?.dateCreated, format: 'd-MMM-yyyy')}
-                        ${g.formatDate(date: productInstance?.dateCreated, format: 'hh:mma')}
+                        ${g.formatDate(date: productInstance?.dateCreated)}
                     </span>
 
                 </td>
@@ -365,8 +364,7 @@
                 </td>
                 <td class="value">
                     <span class="fade">
-                        ${g.formatDate(date: productInstance?.lastUpdated, format: 'd-MMM-yyyy')}
-                        ${g.formatDate(date: productInstance?.lastUpdated, format: 'hh:mma')}
+                        ${g.formatDate(date: productInstance?.lastUpdated)}
                     </span>
                 </td>
             </tr>

--- a/src/main/groovy/org/pih/warehouse/core/date/DateDisplayFormat.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/date/DateDisplayFormat.groovy
@@ -1,0 +1,25 @@
+package org.pih.warehouse.core.date
+
+/**
+ * The different ways that we display dates
+ */
+enum DateDisplayFormat {
+
+    /**
+     * As used by our APIs.
+     *
+     * This enum value is likely to be unused since our APIs simply call toString() on dates but we add it here
+     * for the sake of clarity.
+     */
+    JSON,
+
+    /**
+     * The old frontend pages that still use GSPs.
+     */
+    GSP,
+
+    /**
+     * As used by file exporters.
+     */
+    CSV,
+}

--- a/src/main/groovy/org/pih/warehouse/core/date/DateFormatter.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/date/DateFormatter.groovy
@@ -1,0 +1,12 @@
+package org.pih.warehouse.core.date
+
+/**
+ * A formatter that converts date objects to strings.
+ */
+interface DateFormatter<T> {
+
+    /**
+     * Stringifies a given date object.
+     */
+    String format(T date)
+}

--- a/src/main/groovy/org/pih/warehouse/core/date/DateFormatterManager.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/date/DateFormatterManager.groovy
@@ -1,0 +1,116 @@
+package org.pih.warehouse.core.date
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import org.grails.web.servlet.mvc.GrailsWebRequest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+import org.pih.warehouse.core.session.SessionManager
+
+/**
+ * Formats date objects for display. For use only by data exporters and GSPs. APIs should always return dates in
+ * ISO format using UTC.
+ */
+@Component
+class DateFormatterManager {
+
+    @Autowired
+    SessionManager sessionManager
+
+    /**
+     * Convenience method for converting the given date object to a String for use by file exporters.
+     */
+    String formatForExport(Object date) {
+        return format(date, DateFormatterContext.builder()
+                .withDisplayFormat(DateDisplayFormat.CSV)
+                .build())
+    }
+
+    /**
+     * Converts the given date object to a String in the locale and timezone of the requesting user.
+     */
+    String format(Object date, DateFormatterContext context=null) {
+
+        Locale locale = context?.localeOverride ?: getLocale()
+        ZoneId timezone = context?.timezoneOverride ?: getTimezone()
+        DateDisplayFormat displayFormat = context?.displayFormat ?: DateDisplayFormat.GSP
+
+        DateFormatter<?> formatter
+        switch (date) {
+            case Instant:
+                formatter = new TemporalAccessorDateTimeFormatter<Instant>(
+                        locale, context?.patternOverride, displayFormat, timezone)
+                break
+            case ZonedDateTime:
+                formatter = new TemporalAccessorDateTimeFormatter<ZonedDateTime>(
+                        locale, context?.patternOverride, displayFormat, timezone)
+                break
+            case LocalDate:
+                formatter = new TemporalAccessorDateFormatter<LocalDate>(
+                        locale, context?.patternOverride, displayFormat)
+                break
+            default:
+                throw new UnsupportedOperationException("Cannot format date of type [${date.class}]")
+        }
+
+        return formatter.format(date)
+    }
+
+    private Locale getLocale() {
+        // Extracts the locale from the request. We need a fallback for when we're not in the context of an HTTP
+        // request, such as when running unit tests or console commands.
+        return GrailsWebRequest.lookup()?.getLocale() ?: Locale.getDefault()
+    }
+
+    private ZoneId getTimezone(){
+        // We trust session manager to provide a default timezone if there is no valid session.
+        return sessionManager.timezone.toZoneId()
+    }
+
+    /**
+     * Context objects containing the configuration fields for formatting dates.
+     * For a majority of cases the default settings can be used and so this object will not be required.
+     */
+    static class DateFormatterContext {
+        Locale localeOverride
+        String patternOverride
+        ZoneId timezoneOverride
+        DateDisplayFormat displayFormat
+
+        static DateFormatterContextBuilder builder() {
+            return new DateFormatterContextBuilder()
+        }
+    }
+
+    private static class DateFormatterContextBuilder {
+
+        DateFormatterContext context = new DateFormatterContext()
+
+        DateFormatterContext build() {
+            return context
+        }
+
+        DateFormatterContextBuilder withLocaleOverride(Locale localeOverride) {
+            context.localeOverride = localeOverride
+            return this
+        }
+
+        DateFormatterContextBuilder withPatternOverride(String patternOverride) {
+            context.patternOverride = patternOverride
+            return this
+        }
+
+        DateFormatterContextBuilder withTimezoneOverride(ZoneId timezoneOverride) {
+            context.timezoneOverride = timezoneOverride
+            return this
+        }
+
+        DateFormatterContextBuilder withDisplayFormat(DateDisplayFormat displayFormat) {
+            context.displayFormat = displayFormat
+            return this
+        }
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/date/TemporalAccessorDateFormatter.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/date/TemporalAccessorDateFormatter.groovy
@@ -1,0 +1,38 @@
+package org.pih.warehouse.core.date
+
+import java.time.format.DateTimeFormatter
+import java.time.temporal.TemporalAccessor
+
+import org.pih.warehouse.DateUtil
+
+/**
+ * A formatter that converts TemporalAccessor objects that have a date component to Strings.
+ */
+class TemporalAccessorDateFormatter<T extends TemporalAccessor> extends TemporalAccessorFormatter<T> {
+
+    TemporalAccessorDateFormatter(Locale locale, String pattern, DateDisplayFormat displayFormat) {
+        super(locale, pattern, displayFormat)
+    }
+
+    DateTimeFormatter getJsonFormatter() {
+        // For consistency, our APIs should always return ISO formatted dates.
+        return DateTimeFormatter.ISO_DATE
+    }
+
+    DateTimeFormatter getGspFormatter() {
+        // TODO: We should support a localized default pattern for GSPs. Certain languages such as Arabic
+        //       and Chinese display dates in unique formats, and so we should change the format depending on
+        //       the locale that is provided. We can achieve this by having the pattern be a translated field in
+        //       message.properties (and in fact we already do this via the default.date.format field) instead of a
+        //       constant value (though we can still use the constant as a fallback if the message isn't defined).
+        return DateUtil.DEFAULT_DISPLAY_DATE_FORMATTER
+    }
+
+    DateTimeFormatter getCsvFormatter() {
+        // We format our CSV exports using ISO pattern (regardless of locale) because we want to ensure that if
+        // the same CSV is later imported, it won't fail on date format errors. We could export to a locale-specific
+        // pattern but we'd need to verify that each of those patterns can be handled by our data binders. For now,
+        // we stick with ISO pattern because it's the only universal date format and is guaranteed to work.
+        return DateTimeFormatter.ISO_DATE
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/date/TemporalAccessorDateTimeFormatter.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/date/TemporalAccessorDateTimeFormatter.groovy
@@ -1,0 +1,51 @@
+package org.pih.warehouse.core.date
+
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.temporal.TemporalAccessor
+
+import org.pih.warehouse.DateUtil
+
+/**
+ * A formatter that converts TemporalAccessor objects that have a date + time component to Strings.
+ */
+class TemporalAccessorDateTimeFormatter<T extends TemporalAccessor> extends TemporalAccessorFormatter<T> {
+
+    /**
+     * The timezone that we should convert the datetime to be in.
+     */
+    ZoneId timezone
+
+    TemporalAccessorDateTimeFormatter(Locale locale, String pattern, DateDisplayFormat displayFormat, ZoneId timezone) {
+        super(locale, pattern, displayFormat)
+        this.timezone = timezone
+    }
+
+    DateTimeFormatter getJsonFormatter() {
+        // For consistency, our APIs should always return ISO formatted dates.
+        return DateTimeFormatter.ISO_OFFSET_DATE_TIME
+    }
+
+    DateTimeFormatter getGspFormatter() {
+        // TODO: We should support a localized default pattern for GSPs. Certain languages such as Arabic
+        //       and Chinese display dates in unique formats, and so we should change the format depending on
+        //       the locale that is provided. We can achieve this by having the pattern be a translated field in
+        //       message.properties (and in fact we already do this via the default.date.format field) instead of a
+        //       constant value (though we can still use the constant as a fallback if the message isn't defined).
+        return DateUtil.DEFAULT_DISPLAY_DATE_TIME_FORMATTER
+    }
+
+    DateTimeFormatter getCsvFormatter() {
+        // We format our CSV exports using ISO pattern (regardless of locale) because we want to ensure that if
+        // the same CSV is later imported, it won't fail on date format errors. We could export to a locale-specific
+        // pattern but we'd need to verify that each of those patterns can be handled by our data binders. For now,
+        // we stick with ISO pattern because it's the only universal date format and is guaranteed to work.
+        return DateTimeFormatter.ISO_OFFSET_DATE_TIME
+    }
+
+    @Override
+    protected DateTimeFormatter addContextToFormatter(DateTimeFormatter formatter) {
+        return super.addContextToFormatter(formatter)
+                .withZone(timezone)
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/date/TemporalAccessorFormatter.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/date/TemporalAccessorFormatter.groovy
@@ -1,0 +1,90 @@
+package org.pih.warehouse.core.date
+
+import java.time.format.DateTimeFormatter
+import java.time.temporal.TemporalAccessor
+import org.apache.commons.lang.StringUtils
+
+/**
+ * A formatter that converts date objects to strings.
+ */
+abstract class TemporalAccessorFormatter<T extends TemporalAccessor> implements DateFormatter<T> {
+
+    private static final String EMPTY_DISPLAY_DATE = ''
+
+    /**
+     * The locale that we need to translate the date to. Needed for day (Monday) and month (January) fields.
+     */
+    Locale locale
+
+    /**
+     * An optional override of the pattern to format the date to.
+     */
+    String pattern
+
+    /**
+     *
+     */
+    DateDisplayFormat displayFormat
+
+    TemporalAccessorFormatter(Locale locale, String pattern, DateDisplayFormat displayFormat) {
+        this.locale = locale
+        this.pattern = pattern
+        this.displayFormat = displayFormat
+    }
+
+    /**
+     * Returns the default DateTimeFormatter to use when formatting for JSON APIs.
+     */
+    abstract DateTimeFormatter getJsonFormatter()
+
+    /**
+     * Returns the default DateTimeFormatter to use when formatting for frontend GSPs.
+     */
+    abstract DateTimeFormatter getGspFormatter()
+
+    /**
+     * Returns the default DateTimeFormatter to use when formatting for CSV exports.
+     */
+    abstract DateTimeFormatter getCsvFormatter()
+
+    /**
+     * Returns the DateTimeFormatter that will be used to format the date to a String.
+     */
+    DateTimeFormatter getFormatter() {
+        // If we're overriding the pattern, construct a new formatter from that pattern and return it.
+        if (StringUtils.isNotBlank(pattern)) {
+            return addContextToFormatter(DateTimeFormatter.ofPattern(pattern))
+        }
+
+        DateTimeFormatter formatter
+        switch (displayFormat) {
+            case DateDisplayFormat.JSON:
+                formatter = getJsonFormatter()
+                break
+            case DateDisplayFormat.GSP:
+                formatter = getGspFormatter()
+                break
+            case DateDisplayFormat.CSV:
+                formatter = getCsvFormatter()
+                break
+        }
+        return addContextToFormatter(formatter)
+    }
+
+    /**
+     * Adds user-specific context to the given DateTimeFormatter
+     * Can be overwritten by child implementations to add additional context.
+     */
+    protected DateTimeFormatter addContextToFormatter(DateTimeFormatter formatter) {
+        return formatter
+                .withLocale(locale)
+    }
+
+    String format(T date) {
+        if (!date) {
+            return EMPTY_DISPLAY_DATE
+        }
+
+        return getFormatter().format(date)
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/session/SessionAttribute.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/session/SessionAttribute.groovy
@@ -1,0 +1,22 @@
+package org.pih.warehouse.core.session
+
+import org.pih.warehouse.core.Location
+
+/**
+ * Enumerates the custom attributes that we put into the HttpSession.
+ */
+enum SessionAttribute {
+
+    TIMEZONE('timezone', TimeZone),
+    WAREHOUSE('warehouse', Location),
+    IMPERSONATED_USER_ID('impersonatedUserId', String),
+    ACTIVE_USER_ID('activeUserId', String)
+
+    String attributeName
+    Class type
+
+    SessionAttribute(String attributeName, Class type) {
+        this.attributeName = attributeName
+        this.type = type
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/session/SessionManager.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/session/SessionManager.groovy
@@ -1,0 +1,44 @@
+package org.pih.warehouse.core.session
+
+import javax.servlet.http.HttpSession
+import org.springframework.stereotype.Component
+import org.springframework.web.context.request.RequestAttributes
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+
+import org.pih.warehouse.DateUtil
+
+/**
+ * Handles operations on a user's HTTP session.
+ *
+ * Grails exposes the "session" field to controllers and tag libs, so those classes can safely use that field.
+ * This class is for accessing the session from anywhere else in the application.
+ */
+@Component
+class SessionManager {
+
+    /**
+     * @return TimeZone The timezone of the user associated with the current request.
+     */
+    TimeZone getTimezone() {
+        TimeZone timezone = getAttribute(SessionAttribute.TIMEZONE, SessionAttribute.TIMEZONE.type)
+
+        // Default to the system timezone if the requesting user doesn't have one specified.
+        return timezone ?: TimeZone.getTimeZone(DateUtil.getSystemZoneId().getId())
+    }
+
+    private <T> T getAttribute(SessionAttribute attribute, Class<T> type) {
+        RequestAttributes requestAttributes = RequestContextHolder.currentRequestAttributes()
+        if (!requestAttributes instanceof ServletRequestAttributes) {
+            throw new UnsupportedOperationException("Cannot get request attributes of type: ${requestAttributes?.getClass()}")
+        }
+        HttpSession session = (requestAttributes as ServletRequestAttributes).session
+        if (!session) {
+            // Return without error if there's no active session, which can happen if we're not in the context
+            // of an HTTP request. Ex: unit tests or running console commands
+            return null
+        }
+
+        return type.cast(session.getAttribute(attribute.attributeName))
+    }
+}

--- a/src/test/groovy/unit/org/pih/warehouse/core/date/DateFormatterManagerSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/core/date/DateFormatterManagerSpec.groovy
@@ -1,0 +1,138 @@
+package unit.org.pih.warehouse.core.date
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import org.apache.commons.lang.StringUtils
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import org.pih.warehouse.core.date.DateDisplayFormat
+import org.pih.warehouse.core.date.DateFormatterManager
+import org.pih.warehouse.core.session.SessionManager
+
+import static org.pih.warehouse.core.date.DateFormatterManager.DateFormatterContext
+
+/**
+ * Tests the DateFormatterManager.
+ * We don't test the specific formatters themselves. We let those be tested separately.
+ */
+@Unroll
+class DateFormatterManagerSpec extends Specification {
+
+    @Shared
+    DateFormatterManager dateFormatterManager
+
+    @Shared
+    SessionManager sessionManagerStub
+
+    void setup() {
+        dateFormatterManager = new DateFormatterManager()
+
+        sessionManagerStub = Stub(SessionManager)
+        dateFormatterManager.sessionManager = sessionManagerStub
+    }
+
+    void 'format does not error when given an Instant and no override'() {
+        given:
+        sessionManagerStub.timezone >> TimeZone.getTimeZone('UTC')
+
+        and:
+        Instant instant = Instant.now()
+
+        when:
+        String result = dateFormatterManager.format(instant)
+
+        then:
+        assert StringUtils.isNotBlank(result)
+        assert result.endsWith('Z')
+    }
+
+    void 'format does not error when given an Instant and overrides'() {
+        given:
+        DateFormatterContext context = DateFormatterContext.builder()
+                .withLocaleOverride(Locale.ENGLISH)
+                .withPatternOverride('XXX')
+                .withTimezoneOverride(ZoneId.of('+01:00'))
+                .withDisplayFormat(DateDisplayFormat.GSP)
+                .build()
+
+        and:
+        Instant instant = Instant.now()
+
+        when:
+        String result = dateFormatterManager.format(instant, context)
+
+        then:
+        assert result == '+01:00'
+    }
+
+    void 'format does not error when given a ZonedDateTime and no override'() {
+        given:
+        sessionManagerStub.timezone >> TimeZone.getTimeZone('UTC')
+
+        and:
+        ZonedDateTime zdt = ZonedDateTime.now()
+
+        when:
+        String result = dateFormatterManager.format(zdt)
+
+        then:
+        assert StringUtils.isNotBlank(result)
+        assert result.endsWith('Z')
+    }
+
+    void 'format does not error when given a ZonedDateTime and overrides'() {
+        given:
+        DateFormatterContext context = DateFormatterContext.builder()
+                .withLocaleOverride(Locale.ENGLISH)
+                .withPatternOverride('XXX')
+                .withTimezoneOverride(ZoneId.of('+01:00'))
+                .withDisplayFormat(DateDisplayFormat.GSP)
+                .build()
+
+        and:
+        ZonedDateTime zdt = ZonedDateTime.now()
+
+        when:
+        String result = dateFormatterManager.format(zdt, context)
+
+        then:
+        assert result == '+01:00'
+    }
+
+    void 'format does not error when given a LocalDate and no override'() {
+        given:
+        sessionManagerStub.timezone >> TimeZone.getTimeZone('UTC')
+
+        and:
+        LocalDate localDate = LocalDate.of(2000, 1, 1)
+
+        when:
+        String result = dateFormatterManager.format(localDate)
+
+        then:
+        assert result == '01/Jan/2000'
+    }
+
+    void 'format does not error when given a LocalDate and overrides'() {
+        given:
+        DateFormatterContext context = DateFormatterContext.builder()
+                .withLocaleOverride(Locale.ENGLISH)
+                .withPatternOverride('yyyy-MM-dd')
+                .withTimezoneOverride(ZoneId.of('+01:00'))  // Does nothing for LocalDate
+                .withDisplayFormat(DateDisplayFormat.GSP)
+                .build()
+
+        and:
+        LocalDate localDate = LocalDate.of(2000, 1, 1)
+
+        when:
+        String result = dateFormatterManager.format(localDate, context)
+
+        then:
+        assert result == '2000-01-01'
+    }
+}

--- a/src/test/groovy/unit/org/pih/warehouse/utils/DateUtilSpec.groovy
+++ b/src/test/groovy/unit/org/pih/warehouse/utils/DateUtilSpec.groovy
@@ -250,63 +250,12 @@ class DateUtilSpec extends Specification {
         "2000-01-01T00:00+06:00" | '+05:00'          || "1999-12-31"          | "+06 to +05 (backwards conversion)"
     }
 
-    void 'asDateForDisplay should successfully convert a LocalDate to a String'() {
+    void 'asDateTimeForDisplay should successfully convert a null Date to a String'() {
         given:
-        LocalDate localDate = LocalDate.of(2000, 1, 1)
+        Date date = null
 
         expect:
-        assert DateUtil.asDateForDisplay(localDate) == '01/Jan/2000'
-    }
-
-    void 'asDateTimeForDisplay should successfully convert an Instant to a String'() {
-        given: 'an Instant in the current timezone offset of the system (will internally get converted to UTC)'
-        ZoneOffset offset = DateUtil.getSystemZoneOffset()
-        Instant instant = ZonedDateTime.parse("2000-01-01T00:00:00" + offset).toInstant()
-
-        expect: 'the date time is coverted back to the system timezone for display'
-        assert DateUtil.asDateTimeForDisplay(instant) == "01/Jan/2000 00:00 " + offset
-    }
-
-    void 'asDateTimeForDisplay should successfully convert an Instant with a tz to a String for case: #scenario'() {
-        given:
-        Instant instant = Instant.parse(givenDate)
-        ZoneId zone = ZoneId.of(timezoneToDisplay)
-
-        expect:
-        assert DateUtil.asDateTimeForDisplay(instant, zone) == expectedConvertedDate
-
-        where:
-        givenDate              | timezoneToDisplay || expectedConvertedDate      | scenario
-        "2000-01-01T00:00:00Z" | 'Z'               || "01/Jan/2000 00:00 Z"      | "UTC timezone"
-        "2000-01-01T00:00:00Z" | '+05:00'          || "01/Jan/2000 05:00 +05:00" | "timezone ahead of UTC"
-        "2000-01-01T00:00:00Z" | '-05:00'          || "31/Dec/1999 19:00 -05:00" | "timezone behind UTC"
-    }
-
-    void 'asDateTimeForDisplay should successfully convert a ZonedDateTime to a String'() {
-        given: 'a ZonedDateTime in the current timezone offset of the system'
-        ZoneOffset offset = DateUtil.getSystemZoneOffset()
-        ZonedDateTime zonedDateTime = ZonedDateTime.parse("2000-01-01T00:00:00" + offset)
-
-        expect:
-        assert DateUtil.asDateTimeForDisplay(zonedDateTime) == "01/Jan/2000 00:00 " + offset
-    }
-
-    void 'asDateTimeForDisplay should successfully convert a ZonedDateTime with a tz to a String for case: #scenario'() {
-        given:
-        ZonedDateTime zonedDateTime = ZonedDateTime.parse(givenDate)
-        ZoneId zone = ZoneId.of(timezoneToDisplay)
-
-        expect:
-        assert DateUtil.asDateTimeForDisplay(zonedDateTime, zone) == expectedConvertedDate
-
-        where:
-        givenDate                | timezoneToDisplay || expectedConvertedDate      | scenario
-        "2000-01-01T00:00Z"      | 'Z'               || "01/Jan/2000 00:00 Z"      | "UTC to UTC (no conversion)"
-        "2000-01-01T00:00+05:00" | 'Z'               || "31/Dec/1999 19:00 Z"      | "+05 to UTC (backwards conversion)"
-        "2000-01-01T00:00-05:00" | 'Z'               || "01/Jan/2000 05:00 Z"      | "-05 to UTC (forwards conversion)"
-        "2000-01-01T00:00Z"      | '+05:00'          || "01/Jan/2000 05:00 +05:00" | "UTC to +05 (forwards conversion)"
-        "2000-01-01T00:00+05:00" | '+05:00'          || "01/Jan/2000 00:00 +05:00" | "+05 to +05 (no conversion)"
-        "2000-01-01T00:00+06:00" | '+05:00'          || "31/Dec/1999 23:00 +05:00" | "+06 to +05 (backwards conversion)"
+        assert DateUtil.asDateTimeForDisplay(date) == ''
     }
 
     void 'asDateTimeForDisplay should successfully convert a Date to a String'() {
@@ -315,7 +264,7 @@ class DateUtilSpec extends Specification {
         Date date = newDate("2000-01-01T00:00" + offset)
 
         expect:
-        assert DateUtil.asDateTimeForDisplay(date) == "01/Jan/2000 00:00 " + offset
+        assert DateUtil.asDateTimeForDisplay(date) == "01/Jan/2000 00:00:00 " + offset
     }
 
     void 'asDateTimeForDisplay should successfully convert a Date with a tz to a String for case: #scenario'() {
@@ -327,10 +276,18 @@ class DateUtilSpec extends Specification {
         assert DateUtil.asDateTimeForDisplay(date, zone) == expectedConvertedDate
 
         where:
-        givenDate           | timezoneToDisplay || expectedConvertedDate      | scenario
-        "2000-01-01T00:00Z" | 'Z'               || "01/Jan/2000 00:00 Z"      | "UTC timezone"
-        "2000-01-01T00:00Z" | '+05:00'          || "01/Jan/2000 05:00 +05:00" | "timezone ahead of UTC"
-        "2000-01-01T00:00Z" | '-05:00'          || "31/Dec/1999 19:00 -05:00" | "timezone behind UTC"
+        givenDate           | timezoneToDisplay || expectedConvertedDate         | scenario
+        "2000-01-01T00:00Z" | 'Z'               || "01/Jan/2000 00:00:00 Z"      | "UTC timezone"
+        "2000-01-01T00:00Z" | '+05:00'          || "01/Jan/2000 05:00:00 +05:00" | "timezone ahead of UTC"
+        "2000-01-01T00:00Z" | '-05:00'          || "31/Dec/1999 19:00:00 -05:00" | "timezone behind UTC"
+    }
+
+    void 'asDateForDisplay should successfully convert a null Date to a String'() {
+        given:
+        Date date = null
+
+        expect:
+        assert DateUtil.asDateForDisplay(date) == ''
     }
 
     void 'asDateForDisplay should successfully convert a Date to a String'() {


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:**
- https://pihemr.atlassian.net/browse/OBPIH-7474
- https://pihemr.atlassian.net/browse/OBPIH-7475

**Description:** I decided to do both OBPIH-7474 and OBPIH-7475 together since there ended up being significant overlap.

This change adds the ability for us to format dates for display on GSPs and CSV exporters.

To format a date for GSPs:
```
<span class="something">
    ${g.formatDate(date: productInstance?.dateCreated)}
</span>
```

To format a date for exporters:
```
def csvRow = [
    ...
    Created:  dateFormatter.formatForExport(product.dateCreated),
    Updated: dateFormatter.formatForExport(product.lastUpdated),
]
```

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

Date in GSP in UTC+6 timezone:
<img width="458" height="85" alt="image" src="https://github.com/user-attachments/assets/9c240dd2-3a5f-4d0a-ac21-8369700b663a" />

Same date in UTC-7 timezone:
<img width="458" height="85" alt="image" src="https://github.com/user-attachments/assets/8119aba3-64f8-4ce2-b11c-da6abbad1f1f" />

Same date in Spanish locale:
<img width="458" height="85" alt="image" src="https://github.com/user-attachments/assets/d7e90b21-a472-474c-b84e-0bd79f71f287" />

Same date in Chinese locale (it "works" but it's not grammatically correct for Chinese):
<img width="458" height="85" alt="image" src="https://github.com/user-attachments/assets/c685db88-870d-459e-b818-ef0d6e8b41d0" />

Date in CSV export in ISO format (my server is PST so daylight savings time weirdness is happening):
<img width="346" height="191" alt="image" src="https://github.com/user-attachments/assets/94913019-e9d5-4e46-80db-39a89aa3afbd" />
