### PR TITLE
OBLS-133 display zone name and location type in the proper column

### DIFF
--- a/grails-app/views/location/showBinLocations.gsp
+++ b/grails-app/views/location/showBinLocations.gsp
@@ -44,10 +44,10 @@
                             </a>
                         </td>
                         <td>
-                            ${binLocation?.locationType?.name}
+                            ${binLocation?.zone?.name}
                         </td>
                         <td>
-                            ${binLocation?.zone?.name}
+                            ${binLocation?.locationType?.name}
                         </td>
 
                         <td>


### PR DESCRIPTION
**Link to GitHub issue or Jira ticket:** https://openboxes.atlassian.net/browse/OBLS-133

**Description:**
Dsplay zone name and location type in the proper column.

---
### :camera: Screenshots & Recordings (optional)
<img width="1081" height="386" alt="image" src="https://github.com/user-attachments/assets/d783e57f-25d5-4398-9613-ed177ba51efa" />

