### PR TITLE
OBPIH-7342 support java.time types in datepicker taglibs

### DIFF
--- a/grails-app/domain/org/pih/warehouse/product/ProductAssociation.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/ProductAssociation.groovy
@@ -9,6 +9,8 @@
  **/
 package org.pih.warehouse.product
 
+import java.time.Instant
+
 /**
  * Represents an association between two products.
  */
@@ -31,8 +33,8 @@ class ProductAssociation {
 
     ProductAssociation mutualAssociation
 
-    Date dateCreated
-    Date lastUpdated
+    Instant dateCreated
+    Instant lastUpdated
 
     static belongsTo = [product: Product]
 

--- a/grails-app/services/org/pih/warehouse/core/DashboardService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/DashboardService.groovy
@@ -12,6 +12,8 @@ package org.pih.warehouse.core
 import grails.gorm.transactions.Transactional
 import grails.plugins.csv.CSVWriter
 import org.hibernate.sql.JoinType
+
+import org.pih.warehouse.DateUtil
 import org.pih.warehouse.inventory.InventoryItem
 import org.pih.warehouse.inventory.InventoryLevel
 import org.pih.warehouse.inventory.InventoryStatus
@@ -163,11 +165,11 @@ class DashboardService {
             }
 
             if (command.startDate) {
-                ge("expirationDate", command.startDate + 1)
+                ge("expirationDate", DateUtil.asDate(command.startDate.plusDays(1)))
             }
 
             if (command.endDate) {
-                le("expirationDate", command.endDate)
+                le("expirationDate", DateUtil.asDate(command.endDate))
             }
 
             order("expirationDate", "desc")
@@ -206,11 +208,11 @@ class DashboardService {
             }
 
             if (command.startDate) {
-                ge("expirationDate", command.startDate + 1)
+                ge("expirationDate", DateUtil.asDate(command.startDate.plusDays(1)))
             }
 
             if (command.endDate) {
-                le("expirationDate", command.endDate)
+                le("expirationDate", DateUtil.asDate(command.endDate))
             }
 
             order("expirationDate", "asc")

--- a/grails-app/taglib/org/pih/warehouse/FormatTagLib.groovy
+++ b/grails-app/taglib/org/pih/warehouse/FormatTagLib.groovy
@@ -20,9 +20,12 @@ class FormatTagLib {
     static namespace = "format"
 
     /**
+     * @deprecated use g:formatDate from DateTagLib
+     *
      * Formats a Date
      * @attr obj REQUIRED the date to format
      */
+    @Deprecated
     def date = { attrs, body ->
         if (attrs.obj != null) {
             DateFormat df = new SimpleDateFormat((attrs.format) ?: Constants.DEFAULT_DATE_FORMAT)
@@ -31,9 +34,12 @@ class FormatTagLib {
     }
 
     /**
+     * @deprecated use g:formatDate from DateTagLib
+     *
      * Formats a DateTime
      * @attr obj REQUIRED the date to format
      */
+    @Deprecated
     def datetime = { attrs, body ->
         if (attrs.obj != null) {
             DateFormat df = new SimpleDateFormat(Constants.DEFAULT_DATE_TIME_FORMAT)
@@ -49,6 +55,7 @@ class FormatTagLib {
      * Formats an Expiration Date
      * @attr obj REQUIRED the date to format
      */
+    @Deprecated
     def expirationDate = { attrs, body ->
         if (attrs.obj) {
             DateFormat df = new SimpleDateFormat(Constants.DEFAULT_MONTH_YEAR_DATE_FORMAT)

--- a/grails-app/views/inventory/listExpiredStock.gsp
+++ b/grails-app/views/inventory/listExpiredStock.gsp
@@ -101,11 +101,8 @@
 											   default="Expires after"
 									/>
 								</label>
-								<g:jqueryDatePicker id="startDate"
-													name="startDate"
+								<g:jqueryDatePicker name="startDate"
 													cssClass="filter"
-													format="MM/dd/yyyy"
-													autocomplete="off"
 													value="${command?.startDate}"
 								/>
 							</div>
@@ -115,11 +112,8 @@
 											   default="Expires before"
 									/>
 								</label>
-								<g:jqueryDatePicker id="endDate"
-													name="endDate"
+								<g:jqueryDatePicker name="endDate"
 													cssClass="filter"
-													format="MM/dd/yyyy"
-													autocomplete="off"
 													value="${command.endDate}"
 								/>
 							</div>

--- a/grails-app/views/productAssociation/create.gsp
+++ b/grails-app/views/productAssociation/create.gsp
@@ -95,7 +95,7 @@
 									<label for="dateCreated"><warehouse:message code="productAssociation.dateCreated.label" default="Date Created" /></label>
 								</td>
 								<td valign="top" class="value ${hasErrors(bean: productAssociationInstance, field: 'dateCreated', 'errors')}">
-									<g:datePicker name="dateCreated" precision="minute" value="${productAssociationInstance?.dateCreated}"  />
+									<g:datePicker name="dateCreated" value="${productAssociationInstance?.dateCreated}"  />
 								</td>
 							</tr>
 						

--- a/grails-app/views/productAssociation/edit.gsp
+++ b/grails-app/views/productAssociation/edit.gsp
@@ -99,7 +99,7 @@
 								  <label for="dateCreated"><warehouse:message code="productAssociation.dateCreated.label" default="Date Created" /></label>
 								</td>
 								<td valign="top" class="value ${hasErrors(bean: productAssociationInstance, field: 'dateCreated', 'errors')}">
-									<g:datePicker name="dateCreated" precision="minute" value="${productAssociationInstance?.dateCreated}"  />
+									<g:datePicker name="dateCreated" value="${productAssociationInstance?.dateCreated}"  />
 								</td>
 							</tr>
 						

--- a/grails-app/views/productAssociation/list.gsp
+++ b/grails-app/views/productAssociation/list.gsp
@@ -119,7 +119,7 @@
 
                                         <td>${fieldValue(bean: productAssociationInstance, field: "comments")}</td>
 
-                                        <td><format:date obj="${productAssociationInstance.dateCreated}" /></td>
+                                        <td><g:formatDate date="${productAssociationInstance.dateCreated}" /></td>
 
                                     </tr>
                                 </g:each>

--- a/grails-app/views/report/showTransactionReport.gsp
+++ b/grails-app/views/report/showTransactionReport.gsp
@@ -51,12 +51,10 @@
 									<warehouse:message code="report.startDate.label"/>
 								</label>
 
-								<g:jqueryDatePicker id="startDate"
-													name="startDate"
+								<g:jqueryDatePicker name="startDate"
 													cssClass="filter"
-													value="${command?.startDate }"
-													format="MM/dd/yyyy"
-													autocomplete="off"/>
+													value="${command?.startDate}"
+                                />
 
 							</div>
 							<div class="filter-list-item">
@@ -65,12 +63,10 @@
 									<warehouse:message code="report.endDate.label"/>
 								</label>
 
-								<g:jqueryDatePicker id="endDate"
-													name="endDate"
+								<g:jqueryDatePicker name="endDate"
 													cssClass="filter"
-													value="${command?.endDate }"
-													format="MM/dd/yyyy"
-													autocomplete="off"/>
+													value="${command?.endDate}"
+                                />
 							</div>
 							<div class="filter-list-item">
 								<label>

--- a/src/main/groovy/org/pih/warehouse/report/InventoryReportCommand.groovy
+++ b/src/main/groovy/org/pih/warehouse/report/InventoryReportCommand.groovy
@@ -10,6 +10,8 @@
 package org.pih.warehouse.report
 
 import grails.validation.Validateable
+import java.time.LocalDate
+
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.product.Category
 import org.pih.warehouse.product.Product
@@ -18,8 +20,8 @@ class InventoryReportCommand implements Validateable {
 
     Product product
     Location location
-    Date startDate
-    Date endDate
+    LocalDate startDate
+    LocalDate endDate
     Category category
     Category rootCategory
     String status


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7342

**Description:** As a part of switching away from java.util.Date and towards java.time.LocalDate and java.time.Instant, we needed to modify the datepicker taglibs that we use on our GSPs to be able to accomodate the new java.time classes.

We have two date pickers in the old GSPs:

`jqueryDatePicker` which uses a date selector widget similar to what we do on the React side:

<img width="467" height="484" alt="image" src="https://github.com/user-attachments/assets/a0f4b5f8-5eed-4dc6-ae82-a5ab07473e3a" />

and `datePicker` which is just some simple dropdown selectors:

<img width="813" height="411" alt="image" src="https://github.com/user-attachments/assets/ed470277-51bd-4339-87a0-5a1618f95f8c" />


With this change, we can now call both of them without error:
- `<g:jqueryDatePicker value="${someLocalDateField}" />`
- `<g:datePicker value="${someJavaTimeField}" />`