### PR TITLE
OBPIH-7504cfixes to product inventory migration warnings

### DIFF
--- a/grails-app/services/org/pih/warehouse/data/MigrationService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/MigrationService.groovy
@@ -1090,18 +1090,14 @@ class MigrationService {
             FROM transaction_entry te1
                      JOIN inventory_item ii1 ON te1.inventory_item_id = ii1.id
                      JOIN transaction t1 ON te1.transaction_id = t1.id
-                     JOIN transaction_entry te2 ON te1.inventory_item_id != te2.inventory_item_id
+                     JOIN transaction_entry te2 ON te1.transaction_id != te2.transaction_id
                      JOIN inventory_item ii2 ON te2.inventory_item_id = ii2.id
                      JOIN transaction t2 ON te2.transaction_id = t2.id
             WHERE
               ii1.product_id = ii2.product_id
               AND t1.transaction_date = t2.transaction_date
               AND t1.id < t2.id
-              AND (
-                (t1.transaction_type_id = :transactionTypeId and t2.transaction_type_id != :transactionTypeId) 
-                OR 
-                (t1.transaction_type_id != :transactionTypeId and t2.transaction_type_id = :transactionTypeId)
-              )
+              AND (t1.transaction_type_id = :transactionTypeId OR t2.transaction_type_id = :transactionTypeId)
               AND t1.inventory_id = :inventoryId
               AND t2.inventory_id = :inventoryId
         """, [inventoryId: location.inventory.id, transactionTypeId: transactionType.id])


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7504

**Description:** See comments in the ticket. Two issues:

1) There are issues with two product inventory transactions existing at the same time so I changed it to also warn in that case
2) We weren't seeing warnings for two transactions at the same time on the same lot. I think this was just a bug
