### PR TITLE
OBPIH-7512 replace string key with AvailableItemKey when working with product av…

### DIFF
--- a/grails-app/services/org/pih/warehouse/data/LoadDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/LoadDataService.groovy
@@ -13,7 +13,6 @@ import grails.gorm.transactions.Transactional
 import grails.plugins.csv.CSVMapReader
 import grails.validation.ValidationException
 import org.pih.warehouse.DateUtil
-import org.pih.warehouse.api.AvailableItem
 import org.pih.warehouse.core.*
 import org.pih.warehouse.importer.ImportDataCommand
 import org.pih.warehouse.importer.LocationImportDataService
@@ -29,6 +28,7 @@ import org.pih.warehouse.inventory.Transaction
 import org.pih.warehouse.inventory.TransactionEntry
 import org.pih.warehouse.inventory.TransactionIdentifierService
 import org.pih.warehouse.inventory.TransactionType
+import org.pih.warehouse.inventory.product.availability.AvailableItemMap
 import org.pih.warehouse.product.Product
 import org.pih.warehouse.product.ProductCatalog
 import org.pih.warehouse.product.ProductService
@@ -37,8 +37,6 @@ import org.pih.warehouse.requisition.Requisition
 import org.pih.warehouse.requisition.RequisitionItem
 import org.pih.warehouse.requisition.RequisitionItemSortByCode
 
-import java.text.DateFormat
-import java.text.SimpleDateFormat
 import java.time.Instant
 
 @Transactional
@@ -226,16 +224,15 @@ class LoadDataService {
             Map<String, String> csvReaderRow,
             Product product,
             Location binLocation,
-            Map<String, AvailableItem> availableItems
+            AvailableItemMap availableItems
     ) {
         InventoryItem inventoryItem = inventoryService.findAndUpdateOrCreateInventoryItem(
                 product,
                 csvReaderRow["Lot number"],
                 DateUtil.asDate(csvReaderRow["Expiration date"], Constants.EXPIRATION_DATE_FORMATTER)
         )
-        String key = ProductAvailabilityService.constructAvailableItemKey(binLocation, inventoryItem)
         int newQuantity = csvReaderRow["Physical QOH"] as int
-        int quantityOnHand = availableItems.get(key)?.quantityOnHand ?: 0
+        int quantityOnHand = availableItems.get(binLocation, inventoryItem)?.quantityOnHand ?: 0
         int adjustmentQuantity = newQuantity - quantityOnHand
 
         if (adjustmentQuantity == 0) {
@@ -271,7 +268,7 @@ class LoadDataService {
         Date inventoryBaselineTransactionDate = DateUtil.asDate(DateUtil.asInstant(adjustmentTransactionDate).minusSeconds(1))
 
         // 1. Calculate the current available items from product availability - one snapshot transaction for all products
-        Map<String, AvailableItem> availableItems = productAvailabilityService.getAvailableItemsAtDateAsMap(
+        AvailableItemMap availableItems = productAvailabilityService.getAvailableItemsAtDateAsMap(
                 targetWarehouse,
                 productMap.values().toList(),
                 inventoryBaselineTransactionDate

--- a/grails-app/services/org/pih/warehouse/data/MigrationService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/MigrationService.groovy
@@ -926,7 +926,7 @@ class MigrationService {
                     AvailableItemKey itemKey = new AvailableItemKey(binLocation, inventoryItem)
                     String comments = entries.comments.findAll { it }.join(', ')
                     [(itemKey): [
-                        binLocation: inventoryItem,
+                        binLocation: binLocation,
                         inventoryItem: inventoryItem,
                         quantity: entries.sum { it.quantity },
                         comments: comments.length() > 255 ? comments.substring(0, 255) : comments

--- a/grails-app/services/org/pih/warehouse/data/MigrationService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/MigrationService.groovy
@@ -31,12 +31,15 @@ import org.pih.warehouse.core.PartyType
 import org.pih.warehouse.core.RatingTypeCode
 import org.pih.warehouse.core.RoleType
 import org.pih.warehouse.core.User
+import org.pih.warehouse.inventory.InventoryItem
 import org.pih.warehouse.inventory.ProductAvailabilityService
 import org.pih.warehouse.inventory.ProductInventoryTransactionMigrationService
 import org.pih.warehouse.inventory.Transaction
 import org.pih.warehouse.inventory.TransactionCode
 import org.pih.warehouse.inventory.TransactionEntry
 import org.pih.warehouse.inventory.TransactionType
+import org.pih.warehouse.inventory.product.availability.AvailableItemKey
+import org.pih.warehouse.inventory.product.availability.AvailableItemMap
 import org.pih.warehouse.product.Product
 import org.pih.warehouse.product.ProductSupplier
 import org.pih.warehouse.receiving.Receipt
@@ -493,7 +496,7 @@ class MigrationService {
                 if (cleanupAdjustmentEnabled && shouldBeZeroedOut) {
                     log.info("Check if there is need for 'zeroing out' adjustments for products that had no stock before migration")
 
-                    Map<String, AvailableItem> availableItems = productAvailabilityService.getAvailableItemsAtDateAsMap(
+                    AvailableItemMap availableItems = productAvailabilityService.getAvailableItemsAtDateAsMap(
                             location,
                             shouldBeZeroedOut
                     )
@@ -555,7 +558,7 @@ class MigrationService {
         }
 
         Date previousTransactionDate = null
-        transactions.each { Transaction it ->
+        for (Transaction it in transactions) {
             // For single product transactions, we can keep only the newest transaction with the same transaction date
             if (singleProduct && previousTransactionDate && it.transactionDate == previousTransactionDate) {
                 log.debug "Transaction ${it.transactionNumber} has a transaction date equal to the previously processed " +
@@ -580,7 +583,7 @@ class MigrationService {
             List<Product> currentTransactionProducts = entries?.collect { TransactionEntry te -> te.inventoryItem.product }?.unique()
 
             // Create inventory baseline for old transaction that is being migrated (if enabled)
-            Map<String, AvailableItem> availableItems = productAvailabilityService.getAvailableItemsAtDateAsMap(
+            AvailableItemMap availableItems = productAvailabilityService.getAvailableItemsAtDateAsMap(
                     location, currentTransactionProducts, it.transactionDate)
 
             String newComment = "Migrated from single Product Inventory transaction to Baseline + Adjustment pair. " +
@@ -909,24 +912,28 @@ class MigrationService {
      */
     private Transaction createAdjustmentTransaction(Location facility,
                                                     List<TransactionEntry> transactionEntries,
-                                                    Map<String, AvailableItem> availableItems,
+                                                    AvailableItemMap availableItems,
                                                     Date transactionDate,
                                                     String comment) {
         // Don't bother populating the transaction's fields until we know we'll need one.
         Transaction transaction = new Transaction()
 
-        Map<String, Map> groupedEntries = transactionEntries?.groupBy { [it.inventoryItem, it.binLocation] }?.collectEntries { key, entries ->
-            String itemKey = productAvailabilityService.constructAvailableItemKey(key[1], key[0])
-            String comments = entries.comments.findAll { it }.join(', ')
-            [(itemKey): [
-                binLocation: key[1],
-                inventoryItem: key[0],
-                quantity: entries.sum { it.quantity },
-                comments: comments.length() > 255 ? comments.substring(0, 255) : comments
-            ]]
-        }
+        Map<AvailableItemKey, Map> groupedEntries = transactionEntries
+                ?.groupBy { [it.inventoryItem, it.binLocation] }
+                ?.collectEntries { key, entries ->
+                    InventoryItem inventoryItem = key[0] as InventoryItem
+                    Location binLocation = key[1] as Location
+                    AvailableItemKey itemKey = new AvailableItemKey(binLocation, inventoryItem)
+                    String comments = entries.comments.findAll { it }.join(', ')
+                    [(itemKey): [
+                        binLocation: inventoryItem,
+                        inventoryItem: inventoryItem,
+                        quantity: entries.sum { it.quantity },
+                        comments: comments.length() > 255 ? comments.substring(0, 255) : comments
+                    ]]
+        } as Map<AvailableItemKey, Map>
 
-        groupedEntries?.each { String key, Map value ->
+        groupedEntries?.each { AvailableItemKey key, Map value ->
             // Assuming there is no duplicated product-lot-bin combination in the transaction entries
             // If there are, it need to be done similarly like in the Inventory Import
             int quantityOnHand = availableItems.get(key)?.quantityOnHand ?: 0
@@ -948,12 +955,12 @@ class MigrationService {
 
         // For all products in the transaction, any other bins/lots of those products that exist in the system (ie have
         // a product availability entry) but were not in the migrated transaction should have their quantity set to zero.
-        Set<String> keysInTransaction = groupedEntries.keySet()
-        availableItems.each { entry ->
+        Set<AvailableItemKey> keysInTransaction = groupedEntries.keySet()
+        for (entry in availableItems.entrySet()) {
             AvailableItem availableItem = entry.value
 
             if (keysInTransaction.contains(entry.key)) {
-                return
+                continue
             }
 
             TransactionEntry transactionEntry = new TransactionEntry(
@@ -993,13 +1000,13 @@ class MigrationService {
      * the migration process and somehow it's not empty (it might happen due to the backdated transecations)
      */
     private Transaction createCleanupAdjustment(Location facility,
-                                                Map<String, AvailableItem> availableItems,
+                                                AvailableItemMap availableItems,
                                                 String comment) {
         // Don't bother populating the transaction's fields until we know we'll need one.
         Transaction transaction = new Transaction()
 
         if (availableItems) {
-            availableItems.each { String key, AvailableItem it ->
+            availableItems.values().each {
                 int quantityOnHand = it?.quantityOnHand ?: 0
                 // If there is already a item with qoh zero, we can skip it
                 if (quantityOnHand == 0) {

--- a/grails-app/services/org/pih/warehouse/data/MigrationService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/MigrationService.groovy
@@ -565,7 +565,7 @@ class MigrationService {
                         "transaction. Skipping migrating this one as it won't have effect on the stock."
                 it.disableRefresh = true
                 it.delete(flush: true, failOnError: true)
-                return
+                continue
             }
             previousTransactionDate = it.transactionDate
 
@@ -576,7 +576,7 @@ class MigrationService {
             if (!entries) {
                 it.disableRefresh = true
                 it.delete(flush: true, failOnError: true)
-                return
+                continue
             }
 
             // Find all products in entries (and create inventory baseline for these)

--- a/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
@@ -26,6 +26,8 @@ import org.pih.warehouse.inventory.ProductAvailabilityService
 import org.pih.warehouse.inventory.Transaction
 import org.pih.warehouse.inventory.TransactionEntry
 import org.pih.warehouse.inventory.TransactionType
+import org.pih.warehouse.inventory.product.availability.AvailableItemKey
+import org.pih.warehouse.inventory.product.availability.AvailableItemMap
 import org.pih.warehouse.product.Product
 
 import java.text.ParseException
@@ -150,7 +152,7 @@ class InventoryImportDataService implements ImportDataService {
         Date baselineTransactionDate = command.date
 
         // Get the stock for all items in the import at the date that the baseline transaction will be created.
-        Map<String, AvailableItem> availableItems = productAvailabilityService.getAvailableItemsAtDateAsMap(
+        AvailableItemMap availableItems = productAvailabilityService.getAvailableItemsAtDateAsMap(
                 command.location,
                 inventoryImportData.products,
                 baselineTransactionDate)
@@ -160,7 +162,7 @@ class InventoryImportDataService implements ImportDataService {
         // We normally put comments in the adjustment transaction entries, but if we know that there won't be
         // an adjustment transaction entry for an item (because there's no quantity change), we add the comment
         // to the baseline transaction entry instead so that the comment is not lost.
-        Map<Map<String, Object>, String> commentsForBaselineTransactionEntries =
+        Map<AvailableItemKey, String> commentsForBaselineTransactionEntries =
                 getCommentsForBaselineTransactionEntries(inventoryImportData.rows, availableItems)
 
         inventoryImportProductInventoryTransactionService.createInventoryBaselineTransactionForGivenStock(
@@ -185,14 +187,15 @@ class InventoryImportDataService implements ImportDataService {
     }
 
     /**
-     * Builds a map keyed on inventory item + bin location of all the comments from InventoryImportDataRow objects
+     * Builds a map keyed on AvailableItemKey of all the comments from InventoryImportDataRow objects
      * that have a comment but won't have an adjustment transaction item (because the quantity input is equal to
      * the current quantity on hand for the item).
      */
-    private Map<Map<String, Object>, String> getCommentsForBaselineTransactionEntries(
-            Map<String, List<InventoryImportDataRow>> rowsMap, Map<String, AvailableItem> availableItems) {
+    private Map<AvailableItemKey, String> getCommentsForBaselineTransactionEntries(
+            Map<AvailableItemKey, List<InventoryImportDataRow>> rowsMap,
+            AvailableItemMap availableItems) {
 
-        Map<Map<String, Object>, String> baselineTransactionEntryComments = [:]
+        Map<AvailableItemKey, String> baselineTransactionEntryComments = [:]
         for (rowsEntry in rowsMap.entrySet()) {
             List<InventoryImportDataRow> rowsForKey = rowsEntry.value
 
@@ -205,7 +208,7 @@ class InventoryImportDataService implements ImportDataService {
             int adjustmentQuantity = getAdjustmentQuantity(rowsForKey, availableItem)
             if (adjustmentQuantity == 0) {
                 baselineTransactionEntryComments.put(
-                        [inventoryItem: availableItem.inventoryItem, binLocation: availableItem.binLocation],
+                        new AvailableItemKey(availableItem),
                         comment)
             }
         }
@@ -388,16 +391,16 @@ class InventoryImportDataService implements ImportDataService {
     private class InventoryImportData {
 
         /**
-         * Map the imported rows by [product code + bin location name + lot number]. We store the rows as a list
+         * Map the imported rows by unique key. We store the rows as a list
          * because there can be duplicates. (This is a valid scenario. It's an easy way for users to merge products.)
          */
-        Map<String, List<InventoryImportDataRow>> rows = [:]
+        Map<AvailableItemKey, List<InventoryImportDataRow>> rows = [:]
         Set<Product> products = []
 
         void put(Location binLocation, InventoryItem inventoryItem, def rowRaw) {
             products.add(inventoryItem.product)
 
-            String key = ProductAvailabilityService.constructAvailableItemKey(binLocation, inventoryItem)
+            AvailableItemKey key = new AvailableItemKey(binLocation, inventoryItem)
             rows.computeIfAbsent(key, { k -> [] }).add(new InventoryImportDataRow(
                     binLocation,
                     inventoryItem,
@@ -406,7 +409,7 @@ class InventoryImportDataService implements ImportDataService {
         }
 
         List<InventoryImportDataRow> get(Location binLocation, InventoryItem inventoryItem) {
-            String key = ProductAvailabilityService.constructAvailableItemKey(binLocation, inventoryItem)
+            String key = new AvailableItemKey(binLocation, inventoryItem)
             return rows.get(key)
         }
 

--- a/grails-app/services/org/pih/warehouse/inventory/CycleCountTransactionService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/CycleCountTransactionService.groovy
@@ -6,6 +6,7 @@ import java.time.Instant
 
 import org.pih.warehouse.DateUtil
 import org.pih.warehouse.core.Constants
+import org.pih.warehouse.inventory.product.availability.AvailableItemKey
 import org.pih.warehouse.product.Product
 
 /**
@@ -132,14 +133,12 @@ class CycleCountTransactionService {
 
     private List<Transaction> createProductInventoryTransactions(CycleCount cycleCount, Date transactionDate) {
         List<Transaction> transactions = []
-        // We have to create a map keyed by inventoryItem and binLocation, because we further access it via AvailableItem properties
-        // and the inventoryItem + binLocation pair indicates the uniqueness in comparison with the CycleCountItem
-        Map<Map<String, Object>, String> commentsPerCycleCountItem = new HashMap<>()
+        Map<AvailableItemKey, String> commentsPerCycleCountItem = new HashMap<>()
         cycleCount.cycleCountItems.each {
             // We want to add a comment to product inventory transaction if we know,
             // that no adjustment transaction would be created afterwards, that would contain the comment
             if (it.comment && !it.quantityVariance) {
-                commentsPerCycleCountItem.put([inventoryItem: it.inventoryItem, binLocation: it.location], buildRecountComment(it))
+                commentsPerCycleCountItem.put(new AvailableItemKey(it.location, it.inventoryItem), buildRecountComment(it))
             }
         }
         // A cycle count can count multiple products. Each product needs their own product inventory transaction.

--- a/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
@@ -10,10 +10,9 @@
 package org.pih.warehouse.inventory
 
 import grails.gorm.transactions.Transactional
-import grails.util.Holders
 import grails.validation.ValidationException
 import org.hibernate.criterion.CriteriaSpecification
-import org.pih.warehouse.DateUtil
+
 import org.pih.warehouse.PaginatedList
 import org.pih.warehouse.api.AvailableItem
 import org.pih.warehouse.core.ConfigService
@@ -23,6 +22,7 @@ import org.pih.warehouse.core.Tag
 import org.pih.warehouse.core.User
 import org.pih.warehouse.importer.ImportDataCommand
 import org.pih.warehouse.importer.ImporterUtil
+import org.pih.warehouse.inventory.product.availability.AvailableItemMap
 import org.pih.warehouse.product.Category
 import org.pih.warehouse.product.Product
 import org.pih.warehouse.product.ProductAvailability
@@ -37,7 +37,6 @@ import org.springframework.validation.Errors
 import java.sql.Timestamp
 import java.text.NumberFormat
 import java.text.SimpleDateFormat
-import java.time.Instant
 
 @Transactional
 class InventoryService implements ApplicationContextAware {
@@ -1425,7 +1424,7 @@ class InventoryService implements ApplicationContextAware {
 
         try {
             // 1. Calculate the current available items for the given product
-            Map<String, AvailableItem> availableItems = productAvailabilityService.getAvailableItemsAtDateAsMap(
+            AvailableItemMap availableItems = productAvailabilityService.getAvailableItemsAtDateAsMap(
                     currentLocation,
                     [cmd.product],
                     new Date(cmd.transactionDate.time + 2000)

--- a/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
@@ -22,6 +22,7 @@ import org.pih.warehouse.core.Tag
 import org.pih.warehouse.core.User
 import org.pih.warehouse.importer.ImportDataCommand
 import org.pih.warehouse.importer.ImporterUtil
+import org.pih.warehouse.inventory.product.availability.AvailableItemKey
 import org.pih.warehouse.inventory.product.availability.AvailableItemMap
 import org.pih.warehouse.product.Category
 import org.pih.warehouse.product.Product
@@ -1372,10 +1373,10 @@ class InventoryService implements ApplicationContextAware {
     List<RecordInventoryRowCommand> groupDuplicatedRecordInventoryRows(RecordInventoryCommand cmd) {
         return cmd.recordInventoryRows
                 .groupBy { row ->
-                    ProductAvailabilityService.constructAvailableItemKey(
-                            row?.binLocation?.name,
-                            row?.lotNumber,
-                            cmd?.product?.productCode
+                    new AvailableItemKey(
+                            cmd?.product?.id,
+                            row?.lotNumber as String,
+                            row?.binLocation?.name as String
                     )
                 }
                 .collect { key, rows ->

--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -30,6 +30,7 @@ import org.pih.warehouse.api.AvailableItem
 import org.pih.warehouse.core.ApplicationExceptionEvent
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.Location
+import org.pih.warehouse.inventory.product.availability.AvailableItemMap
 import org.pih.warehouse.jobs.RefreshProductAvailabilityJob
 import org.pih.warehouse.order.OrderStatus
 import org.pih.warehouse.product.Category
@@ -666,14 +667,6 @@ class ProductAvailabilityService {
         return data
     }
 
-    /**
-     * Initializes a String comprising of [product code + bin location name + lot number], to be used to uniquely
-     * identify a product availability entry.
-     */
-    static String constructAvailableItemKey(Location binLocation, InventoryItem inventoryItem) {
-        return "${inventoryItem.product.productCode}-${binLocation?.name}-${inventoryItem?.lotNumber}"
-    }
-
     static String constructAvailableItemKey(String binLocationName, String lotNumber, String productCode) {
         return "${productCode}-${binLocationName}-${lotNumber}"
     }
@@ -684,16 +677,17 @@ class ProductAvailabilityService {
      * @param facility
      * @param products
      * @param at The moment in time to fetch stock for. If not provided, will fetch the current stock of each item.
-     * @return a map of AvailableItem keyed on [product code + bin location name + lot number]
+     * @return a map of AvailableItem keyed on ProductAvailabilityKey
      */
-    Map<String, AvailableItem> getAvailableItemsAtDateAsMap(Location facility, Collection<Product> products, Date at=null) {
+    AvailableItemMap getAvailableItemsAtDateAsMap(
+            Location facility,
+            Collection<Product> products,
+            Date at=null) {
+
         List<AvailableItem> availableItems = getAvailableItemsAtDate(facility, products, at)
 
-        Map<String, AvailableItem> availableItemsMap = [:]
-        for (AvailableItem availableItem : availableItems) {
-            String key = constructAvailableItemKey(availableItem.binLocation, availableItem.inventoryItem)
-            availableItemsMap.put(key, availableItem)
-        }
+        AvailableItemMap availableItemsMap = new AvailableItemMap()
+        availableItemsMap.putAll(availableItems)
         return availableItemsMap
     }
 

--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -667,10 +667,6 @@ class ProductAvailabilityService {
         return data
     }
 
-    static String constructAvailableItemKey(String binLocationName, String lotNumber, String productCode) {
-        return "${productCode}-${binLocationName}-${lotNumber}"
-    }
-
     /**
      * Fetches the stock of a list of products at a facility at a given moment in time.
      *

--- a/grails-app/services/org/pih/warehouse/inventory/ProductInventoryTransactionService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductInventoryTransactionService.groovy
@@ -6,6 +6,7 @@ import grails.validation.ValidationException
 import org.pih.warehouse.api.AvailableItem
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.Location
+import org.pih.warehouse.inventory.product.availability.AvailableItemKey
 import org.pih.warehouse.product.Product
 
 /**
@@ -44,7 +45,7 @@ abstract class ProductInventoryTransactionService<T> {
      * @param transactionDate The datetime that the transaction should be marked with. If left blank will be
      *                        the current time.
      * @param comment An optional comment to associate with the transaction
-     * @param transactionEntriesComments A map of transaction entry comments keyed on inventory item and bin location
+     * @param transactionEntriesComments A map of transaction entry comments keyed on AvailableItemKey
      * @param validateTransactionDates An optional param to disable validation of transactions at the same time
      *                                 (Used when for some reason we want to allow multiple transactions at the
      *                                 same time). By default it's true.
@@ -58,7 +59,7 @@ abstract class ProductInventoryTransactionService<T> {
             Collection<Product> products,
             Date transactionDate=null,
             String comment=null,
-            Map<Map<String, Object>, String> transactionEntriesComments = [:],
+            Map<AvailableItemKey, String> transactionEntriesComments = [:],
             Boolean validateTransactionDates = true,
             Boolean disableRefresh = false
     ) {
@@ -91,7 +92,7 @@ abstract class ProductInventoryTransactionService<T> {
      * @param transactionDate The datetime that the transaction should be marked with. If left blank will be
      *                        the current time.
      * @param comment An optional comment to associate with the transaction
-     * @param transactionEntriesComments A map of transaction entry comments keyed on inventory item and bin location
+     * @param transactionEntriesComments A map of transaction entry comments keyed on AvailableItemKey
      * @param validateTransactionDates An optional param to disable validation of transactions at the same time
      *                                 (Used when for some reason we want to allow multiple transactions at the
      *                                 same time). By default it's true.
@@ -105,7 +106,7 @@ abstract class ProductInventoryTransactionService<T> {
             Collection<AvailableItem> availableItems,
             Date transactionDate=null,
             String comment=null,
-            Map<Map<String, Object>, String> transactionEntriesComments = [:],
+            Map<AvailableItemKey, String> transactionEntriesComments = [:],
             validateTransactionDates = true,
             disableRefresh = false
     ) {
@@ -144,7 +145,7 @@ abstract class ProductInventoryTransactionService<T> {
                     binLocation: availableItem.binLocation,
                     inventoryItem: availableItem.inventoryItem,
                     transaction: transaction,
-                    comments: transactionEntriesComments?.get([inventoryItem: availableItem.inventoryItem, binLocation: availableItem.binLocation]),
+                    comments: transactionEntriesComments?.get(new AvailableItemKey(availableItem)),
             )
             transaction.addToTransactionEntries(transactionEntry)
         }

--- a/src/main/groovy/org/pih/warehouse/inventory/product/availability/AvailableItemKey.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/product/availability/AvailableItemKey.groovy
@@ -8,34 +8,43 @@ import org.pih.warehouse.inventory.InventoryItem
 import org.pih.warehouse.product.Product
 
 /**
- * A key on [bin location + inventory item] for uniquely identifying an available item record
+ * A key on [productId + bin location name + lot number] for uniquely identifying an available item record.
+ *
+ * We opt to key on these fields (instead of on [bin location id + inventory item id]) to support the case
+ * where we're in the process of creating the bin or lot and so don't have an id field for them yet.
  */
-@EqualsAndHashCode(excludes=["inventoryItem", "binLocation"])
+@EqualsAndHashCode
 class AvailableItemKey {
 
-    Location binLocation
-    InventoryItem inventoryItem
-    String key
+    String productId
+    String productLot
+    String binLocationName
 
     AvailableItemKey(AvailableItem availableItem) {
         this(availableItem?.binLocation, availableItem?.inventoryItem)
     }
 
     AvailableItemKey(Location binLocation, InventoryItem inventoryItem) {
-        this.binLocation = binLocation
-        this.inventoryItem = inventoryItem
-        key = asKey(binLocation, inventoryItem)
+        this(inventoryItem?.productId as String, inventoryItem?.lotNumber, binLocation?.name)
     }
 
-    String asKey(Location binLocation, InventoryItem inventoryItem) {
-        return "${binLocation?.id}-${inventoryItem?.id}"
+    AvailableItemKey(String productId, String productLot, String binLocationName) {
+        this.productId = productId
+        this.productLot = productLot
+        this.binLocationName = binLocationName
     }
 
     boolean equals(Location binLocation, InventoryItem inventoryItem) {
-        return key == asKey(binLocation, inventoryItem)
+        return equals(inventoryItem?.productId as String, inventoryItem?.lotNumber, binLocation?.name)
+    }
+
+    boolean equals(String productId, String productLot, String binLocationName) {
+        return this.productId == productId &&
+                this.productLot == productLot &&
+                this.binLocationName == binLocationName
     }
 
     boolean isForProduct(Product product) {
-        return inventoryItem?.productId == product.id
+        return productId == product.id
     }
 }

--- a/src/main/groovy/org/pih/warehouse/inventory/product/availability/AvailableItemKey.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/product/availability/AvailableItemKey.groovy
@@ -1,0 +1,41 @@
+package org.pih.warehouse.inventory.product.availability
+
+import groovy.transform.EqualsAndHashCode
+
+import org.pih.warehouse.api.AvailableItem
+import org.pih.warehouse.core.Location
+import org.pih.warehouse.inventory.InventoryItem
+import org.pih.warehouse.product.Product
+
+/**
+ * A key on [bin location + inventory item] for uniquely identifying an available item record
+ */
+@EqualsAndHashCode(excludes=["inventoryItem", "binLocation"])
+class AvailableItemKey {
+
+    Location binLocation
+    InventoryItem inventoryItem
+    String key
+
+    AvailableItemKey(AvailableItem availableItem) {
+        this(availableItem?.binLocation, availableItem?.inventoryItem)
+    }
+
+    AvailableItemKey(Location binLocation, InventoryItem inventoryItem) {
+        this.binLocation = binLocation
+        this.inventoryItem = inventoryItem
+        key = asKey(binLocation, inventoryItem)
+    }
+
+    String asKey(Location binLocation, InventoryItem inventoryItem) {
+        return "${binLocation?.id}-${inventoryItem?.id}"
+    }
+
+    boolean equals(Location binLocation, InventoryItem inventoryItem) {
+        return key == asKey(binLocation, inventoryItem)
+    }
+
+    boolean isForProduct(Product product) {
+        return inventoryItem?.productId == product.id
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/inventory/product/availability/AvailableItemMap.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/product/availability/AvailableItemMap.groovy
@@ -1,0 +1,58 @@
+package org.pih.warehouse.inventory.product.availability
+
+import org.pih.warehouse.api.AvailableItem
+import org.pih.warehouse.core.Location
+import org.pih.warehouse.inventory.InventoryItem
+import org.pih.warehouse.product.Product
+
+/**
+ * A simple convenience wrapper on a map of available items that is keyed using AvailableItemKey.
+ *
+ * We use this map structure quite often when working with available items so we provide this class
+ * as a way to avoid some boilerplate code.
+ */
+class AvailableItemMap {
+    Map<AvailableItemKey, AvailableItem> map = [:]
+
+    AvailableItem get(AvailableItemKey key) {
+        return map.get(key)
+    }
+
+    AvailableItem get(Location binLocation, InventoryItem inventoryItem) {
+        return get(new AvailableItemKey(binLocation, inventoryItem))
+    }
+
+    List<AvailableItem> getAllByProduct(Product product) {
+        return map.collect { key, value -> key.isForProduct(product) } as List<AvailableItem>
+    }
+
+    boolean contains(AvailableItem availableItem) {
+        return map.containsKey(new AvailableItemKey(availableItem))
+    }
+
+    AvailableItem put(AvailableItem availableItem) {
+        return map.put(new AvailableItemKey(availableItem), availableItem)
+    }
+
+    void putAll(List<AvailableItem> availableItems) {
+        for (AvailableItem availableItem in availableItems) {
+            put(availableItem)
+        }
+    }
+
+    int size() {
+        return map.size()
+    }
+
+    Collection<AvailableItem> values() {
+        return map.values()
+    }
+
+    Set<AvailableItemKey> keys() {
+        return map.keySet()
+    }
+
+    Set<Map.Entry<AvailableItemKey, AvailableItem>> entrySet() {
+        return map.entrySet()
+    }
+}


### PR DESCRIPTION
…ailability

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7512

**Description:**

When calculating QoH, we construct a map of available items that is keyed on a string value that is constructed from product code, bin location name, and lot number:
```
static String constructAvailableItemKey(Location binLocation, InventoryItem inventoryItem) {
    return "${inventoryItem.product.productCode}-${binLocation?.name}-${inventoryItem?.lotNumber}"
}
```
https://github.com/openboxes/openboxes/blob/release/0.9.5-hotfix2/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy

This is problematic however because it results in both the null lot and a lot with string "null" resolving to the same key:
```
String lotNumber = 'null'
println "${lotNumber}"          -> "null"
println "${lotNumber}" == null  -> false

lotNumber = null
println "${lotNumber}"          -> "null"
println "${lotNumber}" == null  -> false
```

I changed this logic to use an actual object as the key: `AvailableItemKey`. AvailableItemKey still uses bin location name and lot, but it keeps them as separate String fields, which should resolve the issue of null vs 'null'. Using a proper key class also means we don't need to pass around magic strings and unlabelled keys. I also introduced the `AvailableItemMap` as a convenience wrapper on the map so that it'd be easier to work with.