### PR TITLE
OBPIH-7506 allow blank lot numbers when updating product availability

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -917,6 +917,11 @@ class ProductAvailabilityService {
     }
 
     void updateProductAvailability(InventoryItem inventoryItem) {
+        // OBPIH-7506: Only use the default lot if the lot number is null because we have valid inventory items in our
+        //             system with blank string lot numbers (ie " "). Until we can fix our importers and migrate our
+        //             data to not allow blank lots, we have to continue to allow both null and " " lots to coexist.
+        String lotNumber = inventoryItem.lotNumber == null ? Constants.DEFAULT_LOT_NUMBER : inventoryItem.lotNumber
+
         def results = ProductAvailability.executeUpdate(
                 "update ProductAvailability a " +
                         "set a.lotNumber=:lotNumber " +
@@ -924,12 +929,11 @@ class ProductAvailabilityService {
                         "and a.lotNumber != :lotNumber",
                 [
                         inventoryItemId: inventoryItem.id,
-                        lotNumber      : inventoryItem.lotNumber?:Constants.DEFAULT_LOT_NUMBER
+                        lotNumber      : lotNumber
                 ]
         )
-        log.info "Updated ${results} product availability records for inventory item ${inventoryItem?.lotNumber?:Constants.DEFAULT_LOT_NUMBER}"
+        log.info "Updated ${results} product availability records for inventory item with lot number [${lotNumber}]"
     }
-
 
     void updateProductAvailability(Location location) {
         def isBinLocation = location?.isInternalLocation()


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7506

OBS tickets that this resolves:
- https://pihemr.atlassian.net/browse/OBS-1879
- https://pihemr.atlassian.net/browse/OBS-1908

**Description:** There's a detailed explanation of the issue in the OBS tickets but in brief, when an inventory snapshot refresh is triggered for an inventory item (which was happening during putaway creation), it also triggers a product availability refresh on that inventory item. The product availability refresh logic wasn't differentiating between null and blank lot numbers and so it'd try to update both to the same default lot number, causing duplicate key errors. This change simply allows product availability refresh records to contain rows for blank lots as well.

Note that we rarely experience this because this particular refresh logic is only triggered by inventory snapshot refreshes. I assume the "regular" product availability refresh logic already handles this case properly (otherwise we'd see this error everywhere)