### PR TITLE
OBPIH-7230 still create baseline transaction if QoH is zero

### DIFF
--- a/grails-app/services/org/pih/warehouse/data/LoadDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/LoadDataService.groovy
@@ -262,6 +262,7 @@ class LoadDataService {
         Map<String, Product> productMap = Product.findAllByProductCodeInList(productCodes).collectEntries {
             [it.productCode, it]
         }
+        List<Product> products = productMap.values().toList()
 
         // Calculate dates for inventory baseline and adjustment transactions
         Date adjustmentTransactionDate = DateUtil.asDate(Instant.now())
@@ -270,7 +271,7 @@ class LoadDataService {
         // 1. Calculate the current available items from product availability - one snapshot transaction for all products
         AvailableItemMap availableItems = productAvailabilityService.getAvailableItemsAtDateAsMap(
                 targetWarehouse,
-                productMap.values().toList(),
+                products,
                 inventoryBaselineTransactionDate
         )
 
@@ -288,6 +289,7 @@ class LoadDataService {
             inventoryImportProductInventoryTransactionService.createInventoryBaselineTransactionForGivenStock(
                     targetWarehouse,
                     null,
+                    products,
                     availableItems.values(),
                     inventoryBaselineTransactionDate
             )

--- a/grails-app/services/org/pih/warehouse/data/MigrationService.groovy
+++ b/grails-app/services/org/pih/warehouse/data/MigrationService.groovy
@@ -599,6 +599,7 @@ class MigrationService {
             Transaction baselineTransaction = productInventoryTransactionMigrationService.createInventoryBaselineTransactionForGivenStock(
                     location,
                     null,
+                    currentTransactionProducts,
                     availableItems.values(),
                     it.transactionDate,
                     newComment,

--- a/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
@@ -168,6 +168,7 @@ class InventoryImportDataService implements ImportDataService {
         inventoryImportProductInventoryTransactionService.createInventoryBaselineTransactionForGivenStock(
                 command.location,
                 command,
+                inventoryImportData.products,
                 availableItems.values(),
                 baselineTransactionDate,
                 comment,

--- a/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
@@ -1442,6 +1442,7 @@ class InventoryService implements ApplicationContextAware {
                 recordStockProductInventoryTransactionService.createInventoryBaselineTransactionForGivenStock(
                         currentLocation,
                         null,
+                        [cmd.product],
                         availableItems.values() as List<AvailableItem>,
                         cmd.transactionDate
                 )
@@ -1721,6 +1722,14 @@ class InventoryService implements ApplicationContextAware {
      */
     InventoryItem findOrCreateInventoryItem(InventoryItem inventoryItem) {
         return findOrCreateInventoryItem(inventoryItem.product, inventoryItem.lotNumber, inventoryItem.expirationDate)
+    }
+
+    /**
+     * Fetches the inventory item associated with the default lot of the given product,
+     * creating it if it does not exist.
+     */
+    InventoryItem findOrCreateDefaultInventoryItem(Product product) {
+        return findOrCreateInventoryItem(product, null, null)
     }
 
     /**

--- a/grails-app/services/org/pih/warehouse/inventory/ProductInventoryTransactionService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductInventoryTransactionService.groovy
@@ -68,8 +68,15 @@ abstract class ProductInventoryTransactionService<T> {
                 facility, products, transactionDate)
 
         createInventoryBaselineTransactionForGivenStock(
-                facility, sourceObject, availableItems, transactionDate, comment, transactionEntriesComments,
-                validateTransactionDates, disableRefresh
+                facility,
+                sourceObject,
+                products,
+                availableItems,
+                transactionDate,
+                comment,
+                transactionEntriesComments,
+                validateTransactionDates,
+                disableRefresh,
         )
     }
 
@@ -88,7 +95,8 @@ abstract class ProductInventoryTransactionService<T> {
      *
      * @param facility The Location to take the baseline snapshot at
      * @param sourceObject The source object that caused the Transaction. Ex: CycleCount, Order, Requisition...
-     * @partam availableItems The stock to take a baseline snapshot against.
+     * @param products The products to take a baseline snapshot for
+     * @param availableItems The stock to take a baseline snapshot against.
      * @param transactionDate The datetime that the transaction should be marked with. If left blank will be
      *                        the current time.
      * @param comment An optional comment to associate with the transaction
@@ -103,40 +111,102 @@ abstract class ProductInventoryTransactionService<T> {
     Transaction createInventoryBaselineTransactionForGivenStock(
             Location facility,
             T sourceObject,
+            Collection<Product> products,
             Collection<AvailableItem> availableItems,
             Date transactionDate=null,
             String comment=null,
             Map<AvailableItemKey, String> transactionEntriesComments = [:],
-            validateTransactionDates = true,
-            disableRefresh = false
+            boolean validateTransactionDates = true,
+            boolean disableRefresh = false
     ) {
 
-        // If there are no available items, there would be no transaction entries, so skip creating the transaction.
-        if (!availableItems || !baselineTransactionsEnabled()) {
+        if (!baselineTransactionsEnabled()) {
             return null
         }
-
-        TransactionType transactionType = TransactionType.read(Constants.INVENTORY_BASELINE_TRANSACTION_TYPE_ID)
 
         // We'd have weird behaviour if we allowed two transactions to exist at the same exact time (precision at the
         // database level is to the second) so fail if there's already a transaction on the items for the given date.
         Date actualTransactionDate = transactionDate ?: new Date()
-        List<Product> products = availableItems.collect{ it.inventoryItem.product }.unique()
-        if (validateTransactionDates && inventoryService.hasTransactionEntriesOnDate(facility, actualTransactionDate, products)) {
+        if (validateTransactionDates && inventoryService.hasTransactionEntriesOnDate(
+                facility, actualTransactionDate, products as List<Product>)) {
             throw new IllegalArgumentException("A transaction already exists at time ${actualTransactionDate}")
         }
 
-        Transaction transaction = new Transaction(
-                inventory: facility.inventory,
-                transactionDate: actualTransactionDate,
-                transactionType: transactionType,
-                comment: comment,
-                disableRefresh: disableRefresh
-        )
+        // If there are no available items, there is no stock for the products. We still want to create a baseline
+        // though so create one representing zero stock for the products in the default lot and bin.
+        Transaction transaction
+        if (!availableItems) {
+            transaction = initEmptyBaselineTransaction(
+                    facility,
+                    sourceObject,
+                    products,
+                    actualTransactionDate,
+                    comment,
+                    transactionEntriesComments,
+                    disableRefresh,
+            )
+        }
+        // Otherwise we do have some stock for the products so create the baseline as normal.
+        else {
+            transaction = initNonEmptyBaselineTransaction(
+                    facility,
+                    sourceObject,
+                    availableItems,
+                    actualTransactionDate,
+                    comment,
+                    transactionEntriesComments,
+                    disableRefresh,
+            )
+        }
 
-        transaction.transactionNumber = transactionIdentifierService.generate(transaction)
+        if (!transaction.save()) {
+            throw new ValidationException("Invalid transaction", transaction.errors)
+        }
+        return transaction
+    }
 
-        setSourceObject(transaction, sourceObject)
+    /**
+     * Initializes (but does not persist) an "empty" baseline transaction containing one entry for each of the given
+     * products that sets zero stock/quantity in the default bin and lot.
+     */
+    private Transaction initEmptyBaselineTransaction(Location facility,
+                                                     T sourceObject,
+                                                     Collection<Product> products,
+                                                     Date transactionDate,
+                                                     String comment,
+                                                     Map<AvailableItemKey, String> transactionEntriesComments,
+                                                     boolean disableRefresh) {
+
+        Transaction transaction = initTransaction(facility, sourceObject, transactionDate, comment, disableRefresh)
+
+        for (Product product in products) {
+            InventoryItem defaultInventoryItem = inventoryService.findOrCreateDefaultInventoryItem(product)
+            TransactionEntry transactionEntry = new TransactionEntry(
+                    quantity: 0,
+                    product: product,
+                    binLocation: null,
+                    inventoryItem: defaultInventoryItem,
+                    transaction: transaction,
+                    comments: transactionEntriesComments?.get(new AvailableItemKey(null, defaultInventoryItem)),
+            )
+            transaction.addToTransactionEntries(transactionEntry)
+        }
+
+        return transaction
+    }
+
+    /**
+     * Initializes (but does not persist) a baseline transaction containing one entry for each available item.
+     */
+    private Transaction initNonEmptyBaselineTransaction(Location facility,
+                                                        T sourceObject,
+                                                        Collection<AvailableItem> availableItems,
+                                                        Date transactionDate,
+                                                        String comment,
+                                                        Map<AvailableItemKey, String> transactionEntriesComments,
+                                                        boolean disableRefresh) {
+
+        Transaction transaction = initTransaction(facility, sourceObject, transactionDate, comment, disableRefresh)
 
         for (AvailableItem availableItem : availableItems) {
             TransactionEntry transactionEntry = new TransactionEntry(
@@ -150,9 +220,30 @@ abstract class ProductInventoryTransactionService<T> {
             transaction.addToTransactionEntries(transactionEntry)
         }
 
-        if (!transaction.save()) {
-            throw new ValidationException("Invalid transaction", transaction.errors)
-        }
+        return transaction
+    }
+
+    /**
+     * Initializes (but does not persist) a Transaction instance for the baseline.
+     */
+    private Transaction initTransaction(Location facility,
+                                        T sourceObject,
+                                        Date transactionDate,
+                                        String comment,
+                                        boolean disableRefresh) {
+
+        TransactionType transactionType = TransactionType.read(Constants.INVENTORY_BASELINE_TRANSACTION_TYPE_ID)
+
+        Transaction transaction = new Transaction(
+                inventory: facility.inventory,
+                transactionDate: transactionDate,
+                transactionType: transactionType,
+                comment: comment,
+                disableRefresh: disableRefresh,
+        )
+        transaction.transactionNumber = transactionIdentifierService.generate(transaction)
+        setSourceObject(transaction, sourceObject)
+
         return transaction
     }
 }


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7230

**Description:** We rely on the existance of transactions for last counted date, so even when we do a count on a product with no quantity and we count no quantity again, we still want that count action to be tracked and update last counted date.

This change will insert a baseline with quantity zero in the default lot and bin in the above scenario.


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

First I set the stock to zero with a record stock, then I did a second record stock, also setting stock to zero. You can see that we still create the second baseline in that scenario, even though there's no stock at the time
<img width="1427" height="423" alt="Screenshot from 2025-09-26 14-49-42" src="https://github.com/user-attachments/assets/ae036007-4385-4e6f-a394-563699f0c94e" />
