### PR TITLE
5392 remove unused product snapshot controller

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
@@ -45,7 +45,6 @@ class ProductController {
     MailService mailService
     def productService
     def documentService
-    def inventoryService
     def barcodeService
     def productMergeService
     UploadService uploadService
@@ -1013,18 +1012,6 @@ class ProductController {
         log.info "productCatalogs: " + productCatalogs
 
         render template: "productCatalogs", model: [productInstance: product]
-    }
-
-    def createProductSnapshot() {
-
-        Product product = Product.get(params.id)
-        Location location = Location.get(session.warehouse.id)
-
-        inventoryService.createStockSnapshot(location, product)
-
-        flash.message = "Successfully created stock snapshot for product ${product.productCode} ${product?.name}"
-
-        redirect(controller: "inventoryItem", action: "showStockCard", id: params.id)
     }
 
     private def updateTags(productInstance, params) {


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://github.com/openboxes/openboxes/issues/5392

**Description:** We removed the "product snapshot" feature (not to be confused with the inventory snapshot feature) from the stock card in https://github.com/openboxes/openboxes/pull/5269 (behind the scenes this feature did a record stock containing the current stock for the product, so essentially it did what we have now for baselines but using the product inventory transaction type). This PR is just removing the extra code that I forgot to also remove as a part of that original PR.

Note that you can still achieve this "snapshot" functionality by simply doing a record stock and clicking save without making any changes.
