### PR TITLE
Switch to using pull_request trigger when running tests in github action

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -37,8 +37,11 @@ jobs:
 
       # Tests are run for each database in the above matrix, but we only want to publish a code coverage report once.
       # "strategy.job-index" gives us the index of the current job in the matrix. Any index is fine. We use the first.
+      # Additionally, because we're using pull_request instead of pull_request_target (for security purposes) when
+      # running tests on PRs (see test-pull-request.yml), forks won't have access to GitHub secrets, so this step will
+      # fail if we try to run it. As such, we have to skip publishing Codecov reports when running tests from forks.
       - name: Upload results to Codecov
-        if: ${{ strategy.job-index == 0 }}
+        if: ${{ strategy.job-index == 0 && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -2,9 +2,9 @@ name: Test Pull Request
 
 # Runs all tests whenever a pull request is created or updated.
 on:
-  # Use pull_request_target instead of pull_request because we want this to run on PRs from forks. Simply allowing
-  # actions to run can be insecure, hence why we require approval before running actions in a PR from a fork.
-  pull_request_target:
+  # Use pull_request instead of pull_request_target for security purposes and so that tests run on the source branch
+  # (ie the PR branch), not the target branch.
+  pull_request:
     types: [opened, synchronize]
 
 jobs:


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** N/A

**Description:** using `pull_request_target` when running tests in github actions results in running against the target code. As such, any test fixes in a PR won't get picked up when running the action until after being merged. We needed to use `pull_request_target` so that PRs from forks could run tests since we're publishing to codecov, which needs token access (which `pull_request` doesn't grant) but we can simply disable codecov reporting when running from forks.