### PR TITLE
OBPIH-7342 fix. Format dates properly on product association edit screen

### DIFF
--- a/grails-app/views/product/_productAssociations.gsp
+++ b/grails-app/views/product/_productAssociations.gsp
@@ -43,7 +43,7 @@
 
                         <td>${fieldValue(bean: productAssociation, field: "comments")}</td>
 
-                        <td><format:date obj="${productAssociation.dateCreated}" /></td>
+                        <td><g:formatDate date="${productAssociation.dateCreated}" /></td>
 
                         <td>
 


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7342

**Description:** Call `g:formatDate` instead of the deprecated `format:date` for product association dates, which have since been migrated to Instant fields. This should have been done in https://github.com/openboxes/openboxes/commit/f9e61d097842ce4b4311a09a875c6e81aee0562d, but it was missed.


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

Before fix:

<img width="1121" height="335" alt="image" src="https://github.com/user-attachments/assets/8a90fd86-9a3f-4c26-8441-9686f19c266b" />

After fix:

<img width="1371" height="272" alt="Screenshot from 2025-10-21 08-13-50" src="https://github.com/user-attachments/assets/4c0ab076-11bc-4d0f-8b92-4d10f6563fe1" />

