### PR TITLE
OBLS-289 hide rollback button when order has a status of pending

### DIFF
--- a/grails-app/views/putaway/_putawaySummary.gsp
+++ b/grails-app/views/putaway/_putawaySummary.gsp
@@ -86,15 +86,17 @@
                     <img src="${resource(dir: 'images/icons/silk', file: 'cart_edit.png')}" />&nbsp;
                     <warehouse:message code="default.edit.label" args="[warehouse.message(code:'putawayOrder.label')]"/>
                 </g:link>
-                <g:link controller="putaway" action="rollback" id="${orderInstance.id}" class="button">
-                    <img src="${resource(dir: 'images/icons/silk', file: 'arrow_undo.png')}" />&nbsp;
-                    <g:message code="default.rollback.label" args="[g.message(code: 'order.label')]" default="Rollback Putaway"/>
-                </g:link>
-                <g:if test="${grailsApplication.config.openboxes.putaway.rollbackAndDelete.enabled}">
-                    <g:link controller="putaway" action="rollbackAndDelete" id="${orderInstance.id}" class="button">
+                <g:if test="${orderInstance?.status != OrderStatus.PENDING}">
+                    <g:link controller="putaway" action="rollback" id="${orderInstance.id}" class="button">
                         <img src="${resource(dir: 'images/icons/silk', file: 'arrow_undo.png')}" />&nbsp;
-                        <g:message code="putaway.rollbackAndDelete.label" args="[g.message(code: 'order.label')]" default="Rollback and Delete"/>
+                        <g:message code="default.rollback.label" args="[g.message(code: 'order.label')]" default="Rollback Putaway"/>
                     </g:link>
+                    <g:if test="${grailsApplication.config.openboxes.putaway.rollbackAndDelete.enabled}">
+                        <g:link controller="putaway" action="rollbackAndDelete" id="${orderInstance.id}" class="button">
+                            <img src="${resource(dir: 'images/icons/silk', file: 'arrow_undo.png')}" />&nbsp;
+                            <g:message code="putaway.rollbackAndDelete.label" args="[g.message(code: 'order.label')]" default="Rollback and Delete"/>
+                        </g:link>
+                    </g:if>
                 </g:if>
             </div>
         </g:if>


### PR DESCRIPTION
**Link to GitHub issue or Jira ticket:** https://openboxes.atlassian.net/browse/OBLS-289

**Description:**
- Order with a status of `PENDING` has no `Rollback Putaway` and `Rollback and Delete` button available.
