### PR TITLE
OBPIH-7574 always fetch root cause in cycle count

### DIFF
--- a/src/js/hooks/cycleCount/useResolveStepTable.jsx
+++ b/src/js/hooks/cycleCount/useResolveStepTable.jsx
@@ -75,9 +75,7 @@ const useResolveStepTable = ({
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (!reasonCodes?.length) {
-      dispatch(fetchReasonCodes('CYCLE_COUNT', FETCH_CYCLE_COUNT_REASON_CODES));
-    }
+    dispatch(fetchReasonCodes('CYCLE_COUNT', FETCH_CYCLE_COUNT_REASON_CODES));
   }, []);
 
   // Get appropriate input component based on table column


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7574

**Description:** We’ve updated the root cause options for cycle count but because we cache them in state, we can’t see the updated list unless we clear the browser cache. This change forces that value to always be fetched.
