### PR TITLE
OBPIH-7569 java.util.Date fields should default to server timezone when using g:datePicker

### DIFF
--- a/grails-app/views/batch/_uploadFileForm.gsp
+++ b/grails-app/views/batch/_uploadFileForm.gsp
@@ -17,7 +17,12 @@
                     <label><warehouse:message code="default.date.label"/></label>
                 </td>
                 <td class="value">
-                    <g:datePicker name="date" value="none" precision="minute" relativeYears="[-20..0]" noSelection="['':'']"/>
+                    <g:datePicker name="date"
+                                  value="none"
+                                  fieldType="${Date}"
+                                  precision="minute"
+                                  relativeYears="[-20..0]"
+                                  noSelection="['':'']"/>
                 </td>
             </tr>
             <tr class="prop">

--- a/grails-app/views/batch/importData.gsp
+++ b/grails-app/views/batch/importData.gsp
@@ -71,7 +71,10 @@
                                         <label><warehouse:message code="default.date.label"/></label>
                                     </td>
                                     <td class="value">
-                                        <g:datePicker name="date" value="${commandInstance?.date}" precision="minute"/>
+                                        <g:datePicker name="date"
+                                                      value="${commandInstance?.date}"
+                                                      fieldType="${Date}"
+                                                      precision="minute"/>
                                     </td>
                                 </tr>
                             </g:if>

--- a/grails-app/views/createShipmentWorkflow/createShipment/sendShipment.gsp
+++ b/grails-app/views/createShipmentWorkflow/createShipment/sendShipment.gsp
@@ -123,7 +123,10 @@
 									</td>
 									<td class="value ${hasErrors(bean: shipmentInstance, field: 'actualShippingDate', 'errors')}">
                                         <g:datePicker name="actualShippingDate"
-                                                      value="${shipmentInstance?.actualShippingDate?:new Date()}" precision="minute" noSelection="['':'']"/>
+                                                      value="${shipmentInstance?.actualShippingDate?:new Date()}"
+                                                      fieldType="${Date}"
+                                                      precision="minute"
+                                                      noSelection="['':'']"/>
 
 									</td>
 								</tr>

--- a/grails-app/views/inventory/_incomingTransfer.gsp
+++ b/grails-app/views/inventory/_incomingTransfer.gsp
@@ -19,7 +19,11 @@
 					<label><warehouse:message code="transaction.date.label"/></label>
 				</td>
 				<td class="value">
-                    <g:datePicker name="transactionInstance.transactionDate" value="${command?.transactionInstance?.transactionDate}" precision="minute" noSelection="['':'']"/>
+                    <g:datePicker name="transactionInstance.transactionDate"
+                                  value="${command?.transactionInstance?.transactionDate}"
+                                  fieldType="${Date}"
+                                  precision="minute"
+                                  noSelection="['':'']"/>
 				</td>
 			</tr>
 			<tr class="prop">
@@ -125,8 +129,12 @@
 													<g:textField class="text" name="transactionEntries[${i }].lotNumber"
 														value="${transactionEntry?.lotNumber }"/>
 
-													<g:datePicker name="transactionEntries[${i }].expirationDate" precision="day" noSelection="['':'']"
-														value="${transactionEntry?.expirationDate }" years="${(1900 + (new Date().year))..(1900+ (new Date() + (20 * 365)).year)}"/>
+													<g:datePicker name="transactionEntries[${i }].expirationDate"
+                                                                  precision="day"
+                                                                  noSelection="['':'']"
+                                                                  value="${transactionEntry?.expirationDate }"
+                                                                  fieldType="${Date}"
+                                                                  years="${(1900 + (new Date().year))..(1900+ (new Date() + (20 * 365)).year)}"/>
 
 													<img class="undo middle" src="${resource(dir:'images/icons/silk',file:'decline.png')}" title="${warehouse.message(code: 'cancel.label') }" alt="${warehouse.message(code: 'cancel.label') }"/>
 												</span>
@@ -218,8 +226,12 @@
 													<g:textField class="text" name="transactionEntries[${i }].lotNumber"
 														value="${command?.transactionEntries[i]?.lotNumber }"/>
 
-													<g:datePicker name="transactionEntries[${i }].expirationDate" precision="day" noSelection="['':'']"
-														value="${command?.transactionEntries[i]?.expirationDate }" years="${(1900 + (new Date().year))..(1900+ (new Date() + (20 * 365)).year)}"/>
+													<g:datePicker name="transactionEntries[${i }].expirationDate"
+                                                                  precision="day"
+                                                                  noSelection="['':'']"
+                                                                  value="${command?.transactionEntries[i]?.expirationDate }"
+                                                                  fieldType="${Date}"
+                                                                  years="${(1900 + (new Date().year))..(1900+ (new Date() + (20 * 365)).year)}"/>
 
 													<img class="undo middle" src="${resource(dir:'images/icons/silk',file:'decline.png')}" alt="${warehouse.message(code: 'cancel.label') }"/>
 												</span>

--- a/grails-app/views/inventory/_inventoryAdjustment.gsp
+++ b/grails-app/views/inventory/_inventoryAdjustment.gsp
@@ -26,7 +26,11 @@
                     <label><warehouse:message code="transaction.date.label"/></label>
                 </td>
                 <td class="value">
-                    <g:datePicker name="transactionInstance.transactionDate" value="${command?.transactionInstance?.transactionDate}" precision="minute" noSelection="['':'']"/>
+                    <g:datePicker name="transactionInstance.transactionDate"
+                                  value="${command?.transactionInstance?.transactionDate}"
+                                  fieldType="${Date}"
+                                  precision="minute"
+                                  noSelection="['':'']"/>
                 </td>
             </tr>
             <tr class="prop">

--- a/grails-app/views/inventory/_inventoryConsumed.gsp
+++ b/grails-app/views/inventory/_inventoryConsumed.gsp
@@ -19,7 +19,11 @@
 					<label><warehouse:message code="default.date.label"/></label>
 				</td>
 				<td class="value">
-                    <g:datePicker name="transactionInstance.transactionDate" value="${command?.transactionInstance?.transactionDate}" precision="minute" noSelection="['':'']"/>
+                    <g:datePicker name="transactionInstance.transactionDate"
+                                  value="${command?.transactionInstance?.transactionDate}"
+                                  fieldType="${Date}"
+                                  precision="minute"
+                                  noSelection="['':'']"/>
 
                 </td>
 			</tr>

--- a/grails-app/views/inventory/_inventoryDamaged.gsp
+++ b/grails-app/views/inventory/_inventoryDamaged.gsp
@@ -11,7 +11,11 @@
 					<label><warehouse:message code="transaction.date.label"/></label>
 				</td>
 				<td class="value">
-                    <g:datePicker name="transactionInstance.transactionDate" value="${command?.transactionInstance?.transactionDate}" precision="minute" noSelection="['':'']"/>
+                    <g:datePicker name="transactionInstance.transactionDate"
+                                  value="${command?.transactionInstance?.transactionDate}"
+                                  fieldType="${Date}"
+                                  precision="minute"
+                                  noSelection="['':'']"/>
 
                 </td>
 			</tr>

--- a/grails-app/views/inventory/_inventoryExpired.gsp
+++ b/grails-app/views/inventory/_inventoryExpired.gsp
@@ -10,7 +10,11 @@
                     <label><warehouse:message code="transaction.date.label"/></label>
                 </td>
 				<td class="value">
-                    <g:datePicker name="transactionInstance.transactionDate" value="${command?.transactionInstance?.transactionDate}" precision="minute" noSelection="['':'']"/>
+                    <g:datePicker name="transactionInstance.transactionDate"
+                                  value="${command?.transactionInstance?.transactionDate}"
+                                  fieldType="${Date}"
+                                  precision="minute"
+                                  noSelection="['':'']"/>
                 </td>
 			</tr>
 			<tr class="prop">

--- a/grails-app/views/inventory/_outgoingTransfer.gsp
+++ b/grails-app/views/inventory/_outgoingTransfer.gsp
@@ -21,7 +21,11 @@
 					<label><warehouse:message code="transaction.date.label"/></label>
 				</td>
 				<td class="value">
-                    <g:datePicker name="transactionInstance.transactionDate" value="${command?.transactionInstance?.transactionDate}" precision="minute" noSelection="['':'']"/>
+                    <g:datePicker name="transactionInstance.transactionDate"
+                                  value="${command?.transactionInstance?.transactionDate}"
+                                  fieldType="${Date}"
+                                  precision="minute"
+                                  noSelection="['':'']"/>
 				</td>
 			</tr>
 			<tr class="prop">

--- a/grails-app/views/inventory/editTransaction.gsp
+++ b/grails-app/views/inventory/editTransaction.gsp
@@ -84,8 +84,10 @@
 														<label><warehouse:message code="transaction.date.label"/></label>
 													</td>
 													<td class="value">
-														<g:datePicker id="transactionDate" name="transactionDate"
+														<g:datePicker id="transactionDate"
+                                                                      name="transactionDate"
 																	  value="${transactionInstance?.transactionDate}"
+                                                                      fieldType="${Date}"
 																		precision="minute"/>
 													</td>
 												</tr>

--- a/grails-app/views/inventoryItem/_showLotNumbers.gsp
+++ b/grails-app/views/inventoryItem/_showLotNumbers.gsp
@@ -100,8 +100,12 @@
 							<td>
 								<g:set var="yearStart" value="${new Date().format('yyyy')as int}"/>
 								<g:set var="yearEnd" value="${2050}"/>
-								<g:datePicker name="expirationDate" precision="day" noSelection="['null':'']" value=""
-									years="${yearStart..yearEnd }"/>
+								<g:datePicker name="expirationDate"
+                                              precision="day"
+                                              noSelection="['null':'']"
+                                              value=""
+                                              fieldType="${Date}"
+                                              years="${yearStart..yearEnd }"/>
 								<button class="button icon add">
 									<warehouse:message code="default.button.save.label"/>
 								</button>

--- a/grails-app/views/inventoryItem/_showRecordInventory.gsp
+++ b/grails-app/views/inventoryItem/_showRecordInventory.gsp
@@ -39,7 +39,11 @@
 							<label><warehouse:message code="transaction.transactionDate.label"/></label>
 						</td>
 						<td class="value">
-							<g:datePicker name="transactionDate" value="${commandInstance?.transactionDate}" precision="minute" noSelection="['':'']"/>
+							<g:datePicker name="transactionDate"
+                                          value="${commandInstance?.transactionDate}"
+                                          fieldType="${Date}"
+                                          precision="minute"
+                                          noSelection="['':'']"/>
 						</td>
 					</tr>
 					<tr class="prop">
@@ -126,8 +130,12 @@
 										<g:if test ="${!recordInventoryRow?.oldQuantity}">
 											<g:set var="currentYear" value="${new Date()[Calendar.YEAR]}"/>
 											<g:set var="minimumYear" value="${ConfigHelper.minimumExpirationDate[Calendar.YEAR]}"/>
-											<g:datePicker name="recordInventoryRows[${status}].expirationDate" years="${minimumYear..currentYear + 20}"
-														  noSelection="['': '']" precision="day" value="${recordInventoryRow?.expirationDate}"/>
+											<g:datePicker name="recordInventoryRows[${status}].expirationDate"
+                                                          years="${minimumYear..currentYear + 20}"
+                                                          noSelection="['': '']"
+                                                          precision="day"
+                                                          value="${recordInventoryRow?.expirationDate}"
+                                                          fieldType="${Date}"/>
 										</g:if>
 										<g:else>
 											<g:hiddenField name="recordInventoryRows[${status}].expirationDate"
@@ -465,6 +473,7 @@
 		<g:set var="minimumYear" value="${ConfigHelper.minimumExpirationDate[Calendar.YEAR]}"/>
         <g:datePicker name="recordInventoryRows[{{= getIndex()}}].expirationDate"
                       default="none"
+                      fieldType="${Date}"
 					  noSelection="['': '']"
 					  years="${minimumYear..currentYear + 20}"
                       precision="day"/>

--- a/grails-app/views/localization/create.gsp
+++ b/grails-app/views/localization/create.gsp
@@ -59,7 +59,10 @@
 											<label for="dateCreated"><warehouse:message code="localization.dateCreated.label" default="Date Created" /></label>
 										</td>
 										<td valign="top" class="value ${hasErrors(bean: localizationInstance, field: 'dateCreated', 'errors')}">
-											<g:datePicker name="dateCreated" precision="minute" value="${localizationInstance?.dateCreated}"  />
+											<g:datePicker name="dateCreated"
+                                                          precision="minute"
+                                                          value="${localizationInstance?.dateCreated}"
+                                                          fieldType="${Date}"/>
 										</td>
 									</tr>
 
@@ -68,7 +71,10 @@
 											<label for="lastUpdated"><warehouse:message code="localization.lastUpdated.label" default="Last Updated" /></label>
 										</td>
 										<td valign="top" class="value ${hasErrors(bean: localizationInstance, field: 'lastUpdated', 'errors')}">
-											<g:datePicker name="lastUpdated" precision="minute" value="${localizationInstance?.lastUpdated}"  />
+											<g:datePicker name="lastUpdated"
+                                                          precision="minute"
+                                                          value="${localizationInstance?.lastUpdated}"
+                                                          fieldType="${Date}"/>
 										</td>
 									</tr>
 

--- a/grails-app/views/localization/edit.gsp
+++ b/grails-app/views/localization/edit.gsp
@@ -61,7 +61,10 @@
 										  <label for="dateCreated"><warehouse:message code="localization.dateCreated.label" default="Date Created" /></label>
 										</td>
 										<td valign="top" class="value ${hasErrors(bean: localizationInstance, field: 'dateCreated', 'errors')}">
-											<g:datePicker name="dateCreated" precision="minute" value="${localizationInstance?.dateCreated}"  />
+											<g:datePicker name="dateCreated"
+                                                          precision="minute"
+                                                          value="${localizationInstance?.dateCreated}"
+                                                          fieldType="${Date}"/>
 										</td>
 									</tr>
 
@@ -70,7 +73,10 @@
 										  <label for="lastUpdated"><warehouse:message code="localization.lastUpdated.label" default="Last Updated" /></label>
 										</td>
 										<td valign="top" class="value ${hasErrors(bean: localizationInstance, field: 'lastUpdated', 'errors')}">
-											<g:datePicker name="lastUpdated" precision="minute" value="${localizationInstance?.lastUpdated}"  />
+											<g:datePicker name="lastUpdated"
+                                                          precision="minute"
+                                                          value="${localizationInstance?.lastUpdated}"
+                                                          fieldType="${Date}"/>
 										</td>
 									</tr>
 

--- a/grails-app/views/productCatalog/create.gsp
+++ b/grails-app/views/productCatalog/create.gsp
@@ -71,7 +71,10 @@
 									<label for="dateCreated"><warehouse:message code="productCatalog.dateCreated.label" default="Date Created" /></label>
 								</td>
 								<td valign="top" class="value ${hasErrors(bean: productCatalogInstance, field: 'dateCreated', 'errors')}">
-									<g:datePicker name="dateCreated" precision="minute" value="${productCatalogInstance?.dateCreated}"  />
+									<g:datePicker name="dateCreated"
+                                                  precision="minute"
+                                                  value="${productCatalogInstance?.dateCreated}"
+                                                  fieldType="${Date}"/>
 								</td>
 							</tr>
 						
@@ -80,7 +83,10 @@
 									<label for="lastUpdated"><warehouse:message code="productCatalog.lastUpdated.label" default="Last Updated" /></label>
 								</td>
 								<td valign="top" class="value ${hasErrors(bean: productCatalogInstance, field: 'lastUpdated', 'errors')}">
-									<g:datePicker name="lastUpdated" precision="minute" value="${productCatalogInstance?.lastUpdated}"  />
+									<g:datePicker name="lastUpdated"
+                                                  precision="minute"
+                                                  value="${productCatalogInstance?.lastUpdated}"
+                                                  fieldType="${Date}"/>
 								</td>
 							</tr>
 						

--- a/grails-app/views/receiveOrderWorkflow/receiveOrder/processOrderItems.gsp
+++ b/grails-app/views/receiveOrderWorkflow/receiveOrder/processOrderItems.gsp
@@ -121,8 +121,14 @@
 																	<g:textField name="orderItems[${i }].lotNumber" value="${orderItem?.lotNumber }" size="20" class="text updateable"/>
 																</td>
 																<td nowrap="true">
-																	<g:datePicker name="orderItems[${i }].expirationDate" precision="day" default="none" class="chzn-select" noSelection="['':'']"
-																		years="${(1900 + (new Date().year))..(1900+ (new Date() + (50 * 365)).year)}" value="${orderItem?.expirationDate }" />
+																	<g:datePicker name="orderItems[${i }].expirationDate"
+                                                                                  precision="day"
+                                                                                  default="none"
+                                                                                  class="chzn-select"
+                                                                                  noSelection="['':'']"
+                                                                                  years="${(1900 + (new Date().year))..(1900+ (new Date() + (50 * 365)).year)}"
+                                                                                  value="${orderItem?.expirationDate }"
+                                                                                  fieldType="${Date}"/>
 																</td>
 																<td>
 																	<span class="buttons" style="padding: 0px;">
@@ -255,8 +261,13 @@
 					<g:textField name="orderItems[{{= Index }}].lotNumber" value="{{= LotNumber}}" size="10" class="updateable text"/>
 				</td>
 				<td nowrap="true">
-					<g:datePicker name="orderItems[{{= Index }}].expirationDate" precision="day" default="none" value="" noSelection="['':'']"
-						years="${(1900 + (new Date().year))..(1900+ (new Date() + (50 * 365)).year)}"/>
+					<g:datePicker name="orderItems[{{= Index }}].expirationDate"
+                                  precision="day"
+                                  default="none"
+                                  value=""
+                                  fieldType="${Date}"
+                                  noSelection="['':'']"
+                                  years="${(1900 + (new Date().year))..(1900+ (new Date() + (50 * 365)).year)}"/>
 				</td>
 				<td>
 					<span class="buttons" style="padding: 0px;">

--- a/grails-app/views/requisition/_requisitionItems2.gsp
+++ b/grails-app/views/requisition/_requisitionItems2.gsp
@@ -25,7 +25,10 @@
                         </label>
                     </td>
                     <td class="value">
-                        <g:datePicker name="dateVerified" value="${requisition?.dateVerified}" precision="minute"/>
+                        <g:datePicker name="dateVerified"
+                                      value="${requisition?.dateVerified}"
+                                      fieldType="${Date}"
+                                      precision="minute"/>
 
                         <button class="button icon approve">
                             ${warehouse.message(code:'default.button.save.label')}

--- a/grails-app/views/requisition/confirm.gsp
+++ b/grails-app/views/requisition/confirm.gsp
@@ -52,7 +52,9 @@
                                 </label>
                             </td>
                             <td class="value">
-                                <g:datePicker name="dateChecked" value="${requisition?.dateChecked}"/>
+                                <g:datePicker name="dateChecked"
+                                              value="${requisition?.dateChecked}"
+                                              fieldType="${Date}"/>
                                 <button class="button icon approve">
                                     ${warehouse.message(code:'default.button.save.label')}
                                 </button>

--- a/grails-app/views/requisition/pick.gsp
+++ b/grails-app/views/requisition/pick.gsp
@@ -55,7 +55,9 @@
                                                     </label>
                                                 </td>
                                                 <td class="value">
-                                                    <g:datePicker name="picklist.datePicked" value="${requisition?.picklist?.datePicked}"/>
+                                                    <g:datePicker name="picklist.datePicked"
+                                                                  value="${requisition?.picklist?.datePicked}"
+                                                                  fieldType="${Date}"/>
 
                                                     <button class="button icon approve">
                                                         ${warehouse.message(code:'default.button.save.label')}

--- a/grails-app/views/shipment/editEvent.gsp
+++ b/grails-app/views/shipment/editEvent.gsp
@@ -51,7 +51,10 @@
 							<tr class="prop">
 								   <td valign="top" class="name"><label><warehouse:message code="shipping.eventDate.label" /></label></td>
 								   <td valign="top" class="value ${hasErrors(bean: eventInstance, field: 'eventDate', 'errors')}">
-									   <g:datePicker name="eventDate" value="${eventInstance?.eventDate}" precision="minute"/>
+									   <g:datePicker name="eventDate"
+                                                     value="${eventInstance?.eventDate}"
+                                                     fieldType="${Date}"
+                                                     precision="minute"/>
 
 								   </td>
 							</tr>

--- a/grails-app/views/shipment/receiveShipment.gsp
+++ b/grails-app/views/shipment/receiveShipment.gsp
@@ -81,7 +81,11 @@
                             <td valign="top"
                                 class="value ${hasErrors(bean: receiptInstance, field: 'actualDeliveryDate', 'errors')}"
                                 nowrap="nowrap">
-                                <g:datePicker name="actualDeliveryDate" value="${receiptInstance?.actualDeliveryDate}" precision="minute" noSelection="['':'']"/>
+                                <g:datePicker name="actualDeliveryDate"
+                                              value="${receiptInstance?.actualDeliveryDate}"
+                                              fieldType="${Date}"
+                                              precision="minute"
+                                              noSelection="['':'']"/>
                             </td>
                         </tr>
                         <tr class="prop">

--- a/grails-app/views/shipment/showDetails.gsp
+++ b/grails-app/views/shipment/showDetails.gsp
@@ -905,7 +905,10 @@
                                         <tr class="prop">
                                             <td valign="top" class="name"><label><warehouse:message code="shipping.eventDate.label" /></label></td>
                                             <td valign="top" class="value ${hasErrors(bean: eventInstance, field: 'eventDate', 'errors')}">
-                                                <g:datePicker name="eventDate" value="${eventInstance?.eventDate}" precision="minute"/>
+                                                <g:datePicker name="eventDate"
+                                                              value="${eventInstance?.eventDate}"
+                                                              fieldType="${Date}"
+                                                              precision="minute"/>
                                             </td>
                                         </tr>
                                         <tr class="prop">

--- a/grails-app/views/shipmentItem/create.gsp
+++ b/grails-app/views/shipmentItem/create.gsp
@@ -57,7 +57,11 @@
 	                                    <label for="expirationDate"><warehouse:message code="shipmentItem.expirationDate.label" default="Expiration Date" /></label>
 	                                </td>
 	                                <td valign="top" class="value ${hasErrors(bean: shipmentItemInstance, field: 'expirationDate', 'errors')}">
-	                                    <g:datePicker name="expirationDate" precision="minute" value="${shipmentItemInstance?.expirationDate}" noSelection="['': '']" />
+	                                    <g:datePicker name="expirationDate"
+                                                      precision="minute"
+                                                      value="${shipmentItemInstance?.expirationDate}"
+                                                      fieldType="${Date}"
+                                                      noSelection="['': '']" />
 	                                </td>
 	                            </tr>
 	                        
@@ -102,7 +106,10 @@
 	                                    <label for="dateCreated"><warehouse:message code="shipmentItem.dateCreated.label" default="Date Created" /></label>
 	                                </td>
 	                                <td valign="top" class="value ${hasErrors(bean: shipmentItemInstance, field: 'dateCreated', 'errors')}">
-	                                    <g:datePicker name="dateCreated" precision="minute" value="${shipmentItemInstance?.dateCreated}"  />
+	                                    <g:datePicker name="dateCreated"
+                                                      precision="minute"
+                                                      value="${shipmentItemInstance?.dateCreated}"
+                                                      fieldType="${Date}"/>
 	                                </td>
 	                            </tr>
 	                        
@@ -111,7 +118,10 @@
 	                                    <label for="lastUpdated"><warehouse:message code="shipmentItem.lastUpdated.label" default="Last Updated" /></label>
 	                                </td>
 	                                <td valign="top" class="value ${hasErrors(bean: shipmentItemInstance, field: 'lastUpdated', 'errors')}">
-	                                    <g:datePicker name="lastUpdated" precision="minute" value="${shipmentItemInstance?.lastUpdated}"  />
+	                                    <g:datePicker name="lastUpdated"
+                                                      precision="minute"
+                                                      value="${shipmentItemInstance?.lastUpdated}"
+                                                      fieldType="${Date}"/>
 	                                </td>
 	                            </tr>
 	                        

--- a/grails-app/views/shipmentItem/edit.gsp
+++ b/grails-app/views/shipmentItem/edit.gsp
@@ -59,7 +59,11 @@
 	                                  <label for="expirationDate"><warehouse:message code="shipmentItem.expirationDate.label" default="Expiration Date" /></label>
 	                                </td>
 	                                <td valign="top" class="value ${hasErrors(bean: shipmentItemInstance, field: 'expirationDate', 'errors')}">
-	                                    <g:datePicker name="expirationDate" precision="minute" value="${shipmentItemInstance?.expirationDate}" noSelection="['': '']" />
+	                                    <g:datePicker name="expirationDate"
+                                                      precision="minute"
+                                                      value="${shipmentItemInstance?.expirationDate}"
+                                                      fieldType="${Date}"
+                                                      noSelection="['': '']" />
 	                                </td>
 	                            </tr>
 
@@ -104,7 +108,10 @@
 	                                  <label for="dateCreated"><warehouse:message code="shipmentItem.dateCreated.label" default="Date Created" /></label>
 	                                </td>
 	                                <td valign="top" class="value ${hasErrors(bean: shipmentItemInstance, field: 'dateCreated', 'errors')}">
-	                                    <g:datePicker name="dateCreated" precision="minute" value="${shipmentItemInstance?.dateCreated}"  />
+	                                    <g:datePicker name="dateCreated"
+                                                      precision="minute"
+                                                      value="${shipmentItemInstance?.dateCreated}"
+                                                      fieldType="${Date}"/>
 	                                </td>
 	                            </tr>
 
@@ -113,7 +120,10 @@
 	                                  <label for="lastUpdated"><warehouse:message code="shipmentItem.lastUpdated.label" default="Last Updated" /></label>
 	                                </td>
 	                                <td valign="top" class="value ${hasErrors(bean: shipmentItemInstance, field: 'lastUpdated', 'errors')}">
-	                                    <g:datePicker name="lastUpdated" precision="minute" value="${shipmentItemInstance?.lastUpdated}"  />
+	                                    <g:datePicker name="lastUpdated"
+                                                      precision="minute"
+                                                      value="${shipmentItemInstance?.lastUpdated}"
+                                                      fieldType="${Date}"/>
 	                                </td>
 	                            </tr>
 

--- a/grails-app/views/shipmentWorkflow/create.gsp
+++ b/grails-app/views/shipmentWorkflow/create.gsp
@@ -72,7 +72,11 @@
                                     <label for="dateCreated"><warehouse:message code="shipmentWorkflow.dateCreated.label" default="Date Created" /></label>
                                 </td>
                                 <td valign="top" class="value ${hasErrors(bean: shipmentWorkflowInstance, field: 'dateCreated', 'errors')}">
-                                    <g:datePicker name="dateCreated" precision="minute" value="${shipmentWorkflowInstance?.dateCreated}" noSelection="['': '']" />
+                                    <g:datePicker name="dateCreated"
+                                                  precision="minute"
+                                                  value="${shipmentWorkflowInstance?.dateCreated}"
+                                                  fieldType="${Date}"
+                                                  noSelection="['': '']" />
                                 </td>
                             </tr>
 
@@ -81,7 +85,11 @@
                                     <label for="lastUpdated"><warehouse:message code="shipmentWorkflow.lastUpdated.label" default="Last Updated" /></label>
                                 </td>
                                 <td valign="top" class="value ${hasErrors(bean: shipmentWorkflowInstance, field: 'lastUpdated', 'errors')}">
-                                    <g:datePicker name="lastUpdated" precision="minute" value="${shipmentWorkflowInstance?.lastUpdated}" noSelection="['': '']" />
+                                    <g:datePicker name="lastUpdated"
+                                                  precision="minute"
+                                                  value="${shipmentWorkflowInstance?.lastUpdated}"
+                                                  fieldType="${Date}"
+                                                  noSelection="['': '']" />
                                 </td>
                             </tr>
 

--- a/grails-app/views/stockMovement/_events.gsp
+++ b/grails-app/views/stockMovement/_events.gsp
@@ -110,7 +110,10 @@
                     </label>
                 </td>
                 <td valign="top" class="value ${hasErrors(bean: eventInstance, field: 'eventDate', 'errors')}">
-                    <g:datePicker name="eventDate" value="${eventInstance?.eventDate}" precision="minute"/>
+                    <g:datePicker name="eventDate"
+                                  value="${eventInstance?.eventDate}"
+                                  fieldType="${Date}"
+                                  precision="minute"/>
                 </td>
             </tr>
             %{-- Comment input field --}%

--- a/grails-app/views/stockMovement/_synchronizeDialog.gsp
+++ b/grails-app/views/stockMovement/_synchronizeDialog.gsp
@@ -74,7 +74,11 @@
                         <label><g:message code="stockMovement.dateShipped.label"/></label>
                     </td>
                     <td class="value">
-                        <g:datePicker name="dateShipped" value="${stockMovement.dateShipped}" default="none" noSelection="['':'']"/>
+                        <g:datePicker name="dateShipped"
+                                      value="${stockMovement.dateShipped}"
+                                      fieldType="${Date}"
+                                      default="none"
+                                      noSelection="['':'']"/>
                     </td>
                 </tr>
             </table>


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7569

**Description:** Add a new fieldType attr to g:datePicker so that we can pre-serve the existing behaviour of defaulting to the current time in UTC when using the date picker on Date fields (Instant fields default to the user's timezone). Please see the video and code comments for details.


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

Explaining the change (turn sound on):

https://github.com/user-attachments/assets/cd07940d-34dd-4cc6-8922-74c3f007fc76


