### PR TITLE
Switch to the Eclipse Temurin JDK/JRE as our default option

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 8
-          distribution: zulu
+          distribution: temurin
           cache: gradle
 
       # Run all tests against each of the databases defined in the above matrix. We could split the integration

--- a/.github/workflows/dbdocs.yml
+++ b/.github/workflows/dbdocs.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 8
-          distribution: zulu
+          distribution: temurin
           cache: gradle
 
       - name: Install dbdocs

--- a/.github/workflows/do-github-release.yml
+++ b/.github/workflows/do-github-release.yml
@@ -35,8 +35,8 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 8
-          distribution: zulu
-          cache: 'gradle'
+          distribution: temurin
+          cache: gradle
 
       - name: Build WAR file
         run: ./grailsw war --info --no-daemon

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 8
-          distribution: zulu
-          cache: 'gradle'
+          distribution: temurin
+          cache: gradle
 
       - name: Build dependencies, project and prepare files for Docker build
         run: ./gradlew prepareDocker -Dgrails.env=prod --console=plain

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,7 @@
-FROM openjdk:8u292-jre-slim-buster
+# We previously used openjdk 8 (which itself was based on Debian 10 aka "buster") as our base image, but they have
+# since deprecated their images. Following their recommendation, we have switched to Temurin. The Temurin image for
+# Java 8 is based on Ubuntu 22.04 (which has LTS until April 2027).
+FROM eclipse-temurin:8-jre-jammy
 
 LABEL maintainer="support@openboxes.com"
 EXPOSE 8080
@@ -20,4 +23,6 @@ RUN mkdir uploads && chown openboxes:openboxes uploads/
 COPY --chown=openboxes:openboxes openboxes.war openboxes.war
 
 USER openboxes
+
+# Directly execute the WAR file, which runs the application with an embedded Tomcat servlet
 CMD ["java","-Dgrails.env=prod","-jar","/app/openboxes.war"]


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** Fixes https://github.com/openboxes/openboxes/issues/5483

**Description:** Switch our docker base image to use Eclipse Temurin as our JDK/JRE.

The OpenJDK docker images have been deprecated and the mirrors no longer work. OpenJDK does not offer official LTS beyond the first year of their releases (the docker images were being maintained unofficially by Red Hat as a community driven initiative until 2022). They themselves suggest using Temurin and it offers better LTS and they say they build it as close to the the original OpenJDK as possible (no proprietary features) so it feels like the logical choice.

I also switched our github actions to build from Temurin for the sake of consistency.

I'll also update our install docs to say that Temurin is our recommended distro.
