### PR TITLE
OBPIH-7547 Fix wrong inbound URL When we edit inbound from view page

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/inventory/StockMovementController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/inventory/StockMovementController.groovy
@@ -142,7 +142,8 @@ class StockMovementController {
                 redirect(action: "createOutbound", params: params)
                 break
             case StockMovementDirection.INBOUND:
-                redirect(action: "createInbound", params: params)
+                // We need to add 'SEND' step to the params to redirect to the correct step
+                redirect(action: "createInbound", params: params + [step: 'SEND'])
                 break
             default:
                 redirect(action: "createOutbound", params: params)

--- a/src/js/components/stock-movement-wizard/outboundImport/OutboundImport.jsx
+++ b/src/js/components/stock-movement-wizard/outboundImport/OutboundImport.jsx
@@ -76,7 +76,7 @@ const OutboundImport = () => {
   /** Redirect to first step if there is no cached data */
   useEffect(() => {
     if (_.isEmpty(cachedData) && !is(OutboundImportStep.DETAILS)) {
-      navigateToStep(OutboundImportStep.DETAILS);
+      navigateToStep({ step: OutboundImportStep.DETAILS });
     }
   }, []);
 

--- a/src/js/hooks/inboundV2/addItems/useInboundAddItemsActions.js
+++ b/src/js/hooks/inboundV2/addItems/useInboundAddItemsActions.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import queryString from 'query-string';
 import { useFieldArray } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 
 import { updateWorkflowHeader } from 'actions';
 import stockMovementApi from 'api/services/StockMovementApi';
@@ -50,6 +50,7 @@ const useInboundAddItemsActions = ({
   const history = useHistory();
   const location = useLocation();
   const queryParams = useQueryParams();
+  const { stockMovementId } = useParams();
 
   const {
     fields: lineItemsArrayFields,
@@ -155,7 +156,7 @@ const useInboundAddItemsActions = ({
       };
       try {
         spinner.show();
-        const resp = await apiClient.post(STOCK_MOVEMENT_UPDATE_ITEMS(queryParams.id),
+        const resp = await apiClient.post(STOCK_MOVEMENT_UPDATE_ITEMS(stockMovementId),
           payload);
         const { data } = resp.data;
         const transformedLineItems = data.lineItems.map(transformLineItem);
@@ -193,7 +194,7 @@ const useInboundAddItemsActions = ({
   };
 
   const fetchLineItems = async (showOnlyImportedItems = false) => {
-    const response = await stockMovementApi.getStockMovementItems(queryParams.id, {
+    const response = await stockMovementApi.getStockMovementItems(stockMovementId, {
       stepNumber: InboundWorkflowState.ADD_ITEMS,
     });
     setLineItems(response, showOnlyImportedItems);
@@ -211,7 +212,7 @@ const useInboundAddItemsActions = ({
   const removeAllRows = async () => {
     try {
       spinner.show();
-      await apiClient.delete(STOCK_MOVEMENT_REMOVE_ALL_ITEMS(queryParams.id));
+      await apiClient.delete(STOCK_MOVEMENT_REMOVE_ALL_ITEMS(stockMovementId));
       setValue('currentLineItems', []);
       setValue('values.lineItems', defaultTableRow);
       await fetchLineItems();
@@ -221,7 +222,7 @@ const useInboundAddItemsActions = ({
   };
 
   const fetchAddItemsPageData = async () => {
-    const response = await apiClient.get(STOCK_MOVEMENT_BY_ID(queryParams.id));
+    const response = await apiClient.get(STOCK_MOVEMENT_BY_ID(stockMovementId));
     const { data } = response.data;
     const transformedData = {
       ...data,
@@ -301,7 +302,7 @@ const useInboundAddItemsActions = ({
       spinner.show();
       const payload = { status: RequisitionStatus.CHECKING };
       if (formValues.values.statusCode === RequisitionStatus.CREATED) {
-        await apiClient.post(STOCK_MOVEMENT_UPDATE_STATUS(queryParams.id), payload);
+        await apiClient.post(STOCK_MOVEMENT_UPDATE_STATUS(stockMovementId), payload);
       }
       next();
     } finally {
@@ -316,7 +317,7 @@ const useInboundAddItemsActions = ({
     };
     try {
       spinner.show();
-      await apiClient.post(STOCK_MOVEMENT_UPDATE_INVENTORY_ITEMS(queryParams.id), payload);
+      await apiClient.post(STOCK_MOVEMENT_UPDATE_INVENTORY_ITEMS(stockMovementId), payload);
       await transitionToNextStep();
     } finally {
       spinner.hide();
@@ -456,7 +457,7 @@ const useInboundAddItemsActions = ({
     if (!isFormValid) {
       confirmAction(
         () => {
-          window.location = STOCK_MOVEMENT_URL.show(queryParams.id);
+          window.location = STOCK_MOVEMENT_URL.show(stockMovementId);
         },
         'react.stockMovement.confirmExit.message',
         'Validation errors occurred. Are you sure you want to exit and lose unsaved data?',
@@ -467,7 +468,7 @@ const useInboundAddItemsActions = ({
     try {
       spinner.show();
       await saveRequisitionItemsInCurrentStep(getValues('values.lineItems'));
-      window.location = STOCK_MOVEMENT_URL.show(queryParams.id);
+      window.location = STOCK_MOVEMENT_URL.show(stockMovementId);
     } finally {
       spinner.hide();
     }
@@ -489,7 +490,7 @@ const useInboundAddItemsActions = ({
   };
 
   const fetchData = async () => {
-    if (!queryParams.id) {
+    if (!stockMovementId) {
       dispatch(updateWorkflowHeader([], null));
       previous();
       return;

--- a/src/js/hooks/inboundV2/create/useInboundCreateForm.js
+++ b/src/js/hooks/inboundV2/create/useInboundCreateForm.js
@@ -4,7 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import queryString from 'query-string';
 import { useForm } from 'react-hook-form';
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useHistory, useParams } from 'react-router-dom';
 import { getCurrentLocation } from 'selectors';
 
 import { fetchUsers, updateWorkflowHeader } from 'actions';
@@ -13,7 +13,6 @@ import stockMovementApi from 'api/services/StockMovementApi';
 import { STOCK_MOVEMENT_BY_ID } from 'api/urls';
 import { DateFormat, DateFormatDateFns } from 'consts/timeFormat';
 import useInboundCreateValidation from 'hooks/inboundV2/create/useInboundCreateValidation';
-import useQueryParams from 'hooks/useQueryParams';
 import useSpinner from 'hooks/useSpinner';
 import apiClient from 'utils/apiClient';
 import createInboundWorkflowHeader from 'utils/createInboundWorkflowHeader';
@@ -26,10 +25,9 @@ const useInboundCreateForm = ({ next }) => {
   }));
   const spinner = useSpinner();
   const { validationSchema } = useInboundCreateValidation();
-  const queryParams = useQueryParams();
   const dispatch = useDispatch();
   const history = useHistory();
-  const location = useLocation();
+  const { stockMovementId } = useParams();
 
   const defaultValues = useMemo(() => {
     const values = {
@@ -76,11 +74,11 @@ const useInboundCreateForm = ({ next }) => {
       requestedBy: { id: values.requestedBy.id },
     };
     try {
-      const response = queryParams.id
-        ? await stockMovementApi.updateStockMovement(queryParams.id, formattedValues)
+      const response = stockMovementId
+        ? await stockMovementApi.updateStockMovement(stockMovementId, formattedValues)
         : await stockMovementApi.createStockMovement(formattedValues);
 
-      next({ id: response.data.data.id });
+      next({ pathId: response.data.data.id });
     } finally {
       spinner.hide();
     }
@@ -137,13 +135,13 @@ const useInboundCreateForm = ({ next }) => {
   }, [origin?.id, destination?.id]);
 
   const fetchData = async () => {
-    if (!queryParams.id) {
+    if (!stockMovementId) {
       dispatch(updateWorkflowHeader([], null));
       return;
     }
     spinner.show();
     try {
-      const response = await apiClient.get(STOCK_MOVEMENT_BY_ID(queryParams.id));
+      const response = await apiClient.get(STOCK_MOVEMENT_BY_ID(stockMovementId));
 
       const { data } = response.data;
       setValue('description', data.description);
@@ -170,11 +168,8 @@ const useInboundCreateForm = ({ next }) => {
     } catch {
       dispatch(updateWorkflowHeader([], null));
       history.push({
-        pathname: location.pathname,
-        search: queryString.stringify({
-          ...queryParams,
-          id: undefined,
-        }, { skipNull: true }),
+        pathname: '/openboxes/stockMovement/createInbound',
+        search: queryString.stringify({ direction: 'INBOUND' }),
       });
     } finally {
       spinner.hide();

--- a/src/js/hooks/inboundV2/send/useInboundSendForm.js
+++ b/src/js/hooks/inboundV2/send/useInboundSendForm.js
@@ -3,6 +3,7 @@ import { useEffect, useMemo } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { useDispatch, useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 import {
   getCurrentLocale,
   getCurrentLocation,
@@ -21,7 +22,6 @@ import { InboundWorkflowState } from 'consts/StockMovementState';
 import { DateFormat, DateFormatDateFns } from 'consts/timeFormat';
 import useInboundSendValidation from 'hooks/inboundV2/send/useInboundSendValidation';
 import useFileActions from 'hooks/useFileActions';
-import useQueryParams from 'hooks/useQueryParams';
 import useSpinner from 'hooks/useSpinner';
 import useTranslate from 'hooks/useTranslate';
 import useUserHasPermissions from 'hooks/useUserHasPermissions';
@@ -44,7 +44,7 @@ const useInboundSendForm = ({ previous }) => {
     minRequiredRole: RoleType.ROLE_ADMIN,
   });
   const translate = useTranslate();
-  const { id: stockMovementId } = useQueryParams();
+  const { stockMovementId } = useParams();
   const dispatch = useDispatch();
   const spinner = useSpinner();
   const { validationSchema } = useInboundSendValidation();

--- a/src/js/hooks/inboundV2/send/useInboundSendTable.jsx
+++ b/src/js/hooks/inboundV2/send/useInboundSendTable.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { createColumnHelper } from '@tanstack/react-table';
 import * as locales from 'date-fns/locale';
 import { useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 import { getCurrentLocale } from 'selectors';
 
 import stockMovementApi from 'api/services/StockMovementApi';
@@ -11,7 +12,6 @@ import TableHeaderCell from 'components/DataTable/TableHeaderCell';
 import inboundColumns from 'consts/inboundColumns';
 import { OutboundWorkflowState } from 'consts/StockMovementState';
 import { DateFormatDateFns } from 'consts/timeFormat';
-import useQueryParams from 'hooks/useQueryParams';
 import useSpinner from 'hooks/useSpinner';
 import useTranslate from 'hooks/useTranslate';
 import { formatDateToString } from 'utils/dateUtils';
@@ -25,7 +25,7 @@ const useInboundSendTable = () => {
     currentLocale: getCurrentLocale(state),
   }));
   const spinner = useSpinner();
-  const queryParams = useQueryParams();
+  const { stockMovementId } = useParams();
   const translate = useTranslate();
   const columnHelper = createColumnHelper();
 
@@ -41,7 +41,7 @@ const useInboundSendTable = () => {
       spinner.show();
       setLoading(true);
 
-      const response = await stockMovementApi.getStockMovementItems(queryParams.id,
+      const response = await stockMovementApi.getStockMovementItems(stockMovementId,
         { stepNumber: OutboundWorkflowState.SEND_SHIPMENT });
 
       const { data } = response.data;

--- a/src/js/hooks/useWizard.js
+++ b/src/js/hooks/useWizard.js
@@ -12,12 +12,36 @@ const useWizard = ({ initialKey, steps }) => {
   const history = useHistory();
   const location = useLocation();
 
-  const navigateToStep = (step, params = {}) => {
+  /**
+   * Navigate to a specific wizard step.
+   *
+   * @param {Object} params - The parameters object.
+   * @param {string} params.step - Step key to navigate to.
+   * @param {Object} params.queryParams - Optional extra query params to merge into the URL.
+   * @param {string|null} params.pathId - Optional id from `useParams()` hook from
+   * 'react-router-dom' library to append to the pathname.
+   */
+  const navigateToStep = ({ step, queryParams = {}, pathId = null } = {}) => {
+    const currentPath = location.pathname;
+    // We split the current path to get the last segment because last element can be already
+    // our pathId
+    const segments = currentPath.split('/').filter(Boolean);
+    const lastSegment = segments[segments.length - 1];
+    // Trim possible trailing slash to avoid double slashes in the URL
+    const trimmedPath = currentPath.endsWith('/') ? currentPath.slice(0, -1) : currentPath;
+
+    // Now we check if we passed a pathId and if it's different from the last segment
+    // of the current path to avoid duplicating the id in the URL.
+    const targetPath =
+      pathId && lastSegment !== pathId ? `${trimmedPath}/${pathId}` : currentPath;
+
     history.push(
-      queryString.stringifyUrl({
-        url: location.pathname,
-        query: { ...parsedQueryParams, step, ...params },
-      }),
+      queryString.stringifyUrl(
+        {
+          url: targetPath,
+          query: { ...parsedQueryParams, step, ...queryParams },
+        },
+      ),
     );
   };
 
@@ -53,27 +77,27 @@ const useWizard = ({ initialKey, steps }) => {
   }, [currentStepKey]);
 
   const first = () => {
-    navigateToStep(steps[0]?.key);
+    navigateToStep({ step: steps[0]?.key });
   };
 
   const last = () => {
     const lastIdx = steps.length - 1;
-    navigateToStep(steps[lastIdx]?.key);
+    navigateToStep({ step: steps[lastIdx]?.key });
   };
 
   // params might be needed to join some query params to the URL while switching the step
-  const next = (params = {}) => {
+  const next = ({ queryParams = {}, pathId = null } = {}) => {
     const nextStepIdx = stepProperties.currentStepIdx + 1;
     const nextStep = steps[nextStepIdx];
     if (nextStep) {
-      navigateToStep(nextStep.key, params);
+      navigateToStep({ step: nextStep.key, queryParams, pathId });
     }
   };
 
   const previous = () => {
     const previousStepIdx = stepProperties.currentStepIdx - 1;
     if (previousStepIdx >= 0) {
-      navigateToStep(steps[previousStepIdx]?.key);
+      navigateToStep({ step: steps[previousStepIdx]?.key });
     }
   };
 

--- a/src/js/tests/hooks/useWizard.test.jsx
+++ b/src/js/tests/hooks/useWizard.test.jsx
@@ -80,7 +80,7 @@ describe('Changing steps', () => {
     );
 
     act(() => {
-      result.current[1].navigateToStep(STEP_KEYS.FOURTH);
+      result.current[1].navigateToStep({ step: STEP_KEYS.FOURTH });
     });
 
     expect(result.current[0].key).toEqual(STEP_KEYS.FOURTH);


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:**

**Description:**
This ticket should be merged after this ticket: https://github.com/openboxes/openboxes/pull/5636

Issue:
When inbound stock movement was completed (user clicks "Send Shipment" on the final step) and then we edit inbound from view page, the generated URL contained the ID in the path:
`http://localhost:8080/openboxes/stockMovement/createInbound/ff8081819adbec31019ae08a77c30078`
but our frontend expects that stock movement ID will be passed only as a query parameter:
`http://localhost:8080/openboxes/stockMovement/createInbound?id=ff8081819adbec31019ae08a77c30078`
Instead of modifying the  stockMovement/show.gsp file (which is also used by the outbound workflow), I decided to handle this case on the frontend in useWizard.js hook. I updated the navigateToStep function to accept an optional pathId parameter. When provided, it appends the ID to the pathname (if not already present)

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
