### PR TITLE
OBLS-363 Changed short-pick logic to support reallocation feature

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/api/ReasonCodeApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/ReasonCodeApiController.groovy
@@ -33,6 +33,8 @@ class ReasonCodeApiController {
             reasonCodes.addAll(getReasonCodes(ReasonCode.listInventoryAdjustmentReasonCodes()))
         } else if (ActivityCode.PUTAWAY_DISCREPANCY in activityCodes) {
             reasonCodes.addAll(getReasonCodes(ReasonCode.listPutawayDiscrepancyCodes()))
+        } else if (ActivityCode.PICKING_SHORTAGE in activityCodes) {
+            reasonCodes.addAll(getReasonCodes(ReasonCode.listPickingShortageReasonCodes()))
         } else {
             reasonCodes.addAll(getReasonCodes(ReasonCode.listDefault()))
         }

--- a/grails-app/controllers/org/pih/warehouse/api/picking/SearchPickTaskCommand.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/picking/SearchPickTaskCommand.groovy
@@ -14,6 +14,7 @@ class SearchPickTaskCommand implements Validateable {
     List<PickTaskStatus> status
     Integer priority
     String outboundContainerId
+    String requisitionId
 
     static constraints = {
         facility nullable: false
@@ -23,5 +24,6 @@ class SearchPickTaskCommand implements Validateable {
         status nullable: true
         priority nullable: true
         outboundContainerId nullable: true
+        requisitionId nullable: true
     }
 }

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -791,6 +791,7 @@ enum.ActivityCode.INBOUND_SORTATION=Inbound sortation
 enum.ActivityCode.LOST_AND_FOUND=Lost and found
 enum.ActivityCode.PUTAWAY_CART=Putaway Cart
 enum.ActivityCode.OUTBOUND_CONTAINER=Outbound Container
+enum.ActivityCode.STAGING_LOCATION=Staging Location
 enum.ActivityCode.DELIVERY_TYPE_LOCAL_DELIVERY=Local Delivery
 enum.ActivityCode.DELIVERY_TYPE_PICKUP=Pickup
 enum.ActivityCode.DELIVERY_TYPE_SERVICE=Service

--- a/grails-app/migrations/views/pick-task.sql
+++ b/grails-app/migrations/views/pick-task.sql
@@ -27,13 +27,13 @@ SELECT
     pli.outbound_container_id AS outbound_container_id,
     (SELECT loc.id
      FROM location loc
-     JOIN location_type lt ON lt.id = loc.location_type_id
      JOIN location_effective_supported_activities lesa ON lesa.location_id = loc.id
      WHERE loc.parent_location_id = r.origin_id
        AND loc.active = true
-       AND lt.name = 'Cross-docking'
      GROUP BY loc.id
      HAVING
+         SUM(CASE WHEN lesa.supported_activities_string = 'STAGING_LOCATION' THEN 1 ELSE 0 END) > 0
+         AND
          SUM(CASE WHEN lesa.supported_activities_string = 'HOLD_STOCK' THEN 1 ELSE 0 END) > 0
          AND
          SUM(CASE WHEN lesa.supported_activities_string =

--- a/grails-app/migrations/views/pick-task.sql
+++ b/grails-app/migrations/views/pick-task.sql
@@ -26,21 +26,28 @@ SELECT
     pli.bin_location_id AS location_id,
     pli.outbound_container_id AS outbound_container_id,
     (SELECT loc.id
-         FROM location loc
-         JOIN location_effective_supported_activities act ON act.location_id = loc.id
-         WHERE loc.parent_location_id = r.origin_id
-           AND loc.active = true
-           AND act.supported_activities_string =
-               CASE r.delivery_type_code
-                   WHEN 'PICK_UP' THEN 'DELIVERY_TYPE_PICKUP'
-                   WHEN 'LOCAL_DELIVERY' THEN 'DELIVERY_TYPE_LOCAL_DELIVERY'
-                   WHEN 'SERVICE' THEN 'DELIVERY_TYPE_SERVICE'
-                   WHEN 'WILL_CALL' THEN 'DELIVERY_TYPE_WILL_CALL'
-                   WHEN 'SHIP_TO' THEN 'DELIVERY_TYPE_SHIPPING'
-                   ELSE NULL
-               END
-         LIMIT 1
-        ) AS staging_location_id,
+     FROM location loc
+     JOIN location_type lt ON lt.id = loc.location_type_id
+     JOIN location_effective_supported_activities lesa ON lesa.location_id = loc.id
+     WHERE loc.parent_location_id = r.origin_id
+       AND loc.active = true
+       AND lt.name = 'Cross-docking'
+     GROUP BY loc.id
+     HAVING
+         SUM(CASE WHEN lesa.supported_activities_string = 'HOLD_STOCK' THEN 1 ELSE 0 END) > 0
+         AND
+         SUM(CASE WHEN lesa.supported_activities_string =
+                       CASE r.delivery_type_code
+                           WHEN 'PICK_UP' THEN 'DELIVERY_TYPE_PICKUP'
+                           WHEN 'LOCAL_DELIVERY' THEN 'DELIVERY_TYPE_LOCAL_DELIVERY'
+                           WHEN 'SERVICE' THEN 'DELIVERY_TYPE_SERVICE'
+                           WHEN 'WILL_CALL' THEN 'DELIVERY_TYPE_WILL_CALL'
+                           WHEN 'SHIP_TO' THEN 'DELIVERY_TYPE_SHIPPING'
+                           ELSE NULL
+                       END
+            THEN 1 ELSE 0 END) > 0
+     LIMIT 1
+    ) AS staging_location_id,
     pli.inventory_item_id AS inventory_item_id,
     pli.quantity AS quantity_required,
     pli.quantity_picked AS quantity_picked,

--- a/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
+++ b/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
@@ -344,10 +344,6 @@ class PickTaskService {
             throw new IllegalArgumentException("Outbound container does not exist")
         }
 
-        if (!Constants.OUTBOUND_CONTAINER_LOCATION_TYPE_NAME.equalsIgnoreCase(outboundContainer.getLocationType().getName())) {
-            throw new IllegalArgumentException("Container ${outboundContainer.name} is not of ${Constants.OUTBOUND_CONTAINER_LOCATION_TYPE_NAME} type")
-        }
-
         if (!outboundContainer.supports(ActivityCode.OUTBOUND_CONTAINER)) {
             throw new IllegalArgumentException("Container ${outboundContainer.name} does not support ${ActivityCode.OUTBOUND_CONTAINER} activity")
         }
@@ -367,8 +363,8 @@ class PickTaskService {
             throw new IllegalArgumentException("Staging location does not exist")
         }
 
-        if (!Constants.CROSS_DOCKING_LOCATION_TYPE_NAME.equalsIgnoreCase(stagingLocation.getLocationType().getName())) {
-            throw new IllegalArgumentException("Staging location ${stagingLocation.name} is not of ${Constants.CROSS_DOCKING_LOCATION_TYPE_NAME} type")
+        if (!stagingLocation.supports(ActivityCode.STAGING_LOCATION)) {
+            throw new IllegalArgumentException("Staging location ${stagingLocation.name} does not support ${ActivityCode.STAGING_LOCATION} activity")
         }
 
         if (!stagingLocation.supports(ActivityCode.HOLD_STOCK)) {

--- a/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
+++ b/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
@@ -36,7 +36,7 @@ class PickTaskService {
         List<String> requisitionIds = findRequisitionIdsForPicking(command)
 
         List<PickTaskStatus> statusesToSearch = command.status
-        if (!statusesToSearch && !command.outboundContainerId) {
+        if (!statusesToSearch  && !command.outboundContainerId && !command.requisitionId) {
             statusesToSearch = [PickTaskStatus.PENDING, PickTaskStatus.PICKING]
         }
 
@@ -71,6 +71,15 @@ class PickTaskService {
                 or {
                     eq("oc.id", command.outboundContainerId)
                     eq("oc.locationNumber", command.outboundContainerId)
+                }
+            }
+
+            if (command.requisitionId) {
+                createAlias("requisition", "r")
+
+                or {
+                    eq("r.id", command.requisitionId)
+                    eq("r.requestNumber", command.requisitionId)
                 }
             }
 

--- a/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
+++ b/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
@@ -14,6 +14,7 @@ import org.pih.warehouse.inventory.InventoryService
 import org.pih.warehouse.inventory.ProductAvailabilityService
 import org.pih.warehouse.inventory.TransferStockCommand
 import org.pih.warehouse.picklist.PicklistItem
+import org.pih.warehouse.picklist.PicklistService
 import org.pih.warehouse.requisition.Requisition
 import org.pih.warehouse.requisition.RequisitionStatus
 
@@ -23,6 +24,7 @@ class PickTaskService {
     GrailsApplication grailsApplication
     InventoryService inventoryService
     ProductAvailabilityService productAvailabilityService
+    PicklistService picklistService
 
     @Transactional(readOnly = true)
     List<PickTask> search(SearchPickTaskCommand command, Map params = [:]) {
@@ -143,10 +145,9 @@ class PickTaskService {
         if (!outboundContainer.supports(ActivityCode.OUTBOUND_CONTAINER)) {
             throw new IllegalArgumentException("Container ${outboundContainer.name} does not support OUTBOUND_CONTAINER activity")
         }
-        task.outboundContainer = outboundContainer
 
         executeStateTransition(task, PickTaskStatus.PICKED)
-        transferToContainer(task, task.quantityRequired.toInteger())
+        transferToContainer(task, outboundContainer, task.quantityRequired.toInteger())
 
         PicklistItem existingPickItem = PicklistItem.get(task.id)
         existingPickItem.pickedBy = Person.get(pickedById)
@@ -166,23 +167,16 @@ class PickTaskService {
         if (!outboundContainer.supports(ActivityCode.OUTBOUND_CONTAINER)) {
             throw new IllegalArgumentException("Container ${outboundContainer.name} does not support OUTBOUND_CONTAINER activity")
         }
-        task.outboundContainer = outboundContainer
 
         PicklistItem existingPickItem = PicklistItem.get(task.id)
-        Integer newQuantityPicked = existingPickItem.quantityPicked += quantityPicked
-        if (newQuantityPicked > existingPickItem.quantity) {
-            throw new IllegalArgumentException("Picked quantity cannot be greater than required quantity")
+        picklistService.updatePicklistItem(existingPickItem.id, task.product?.id, quantityPicked.toBigDecimal(), pickedById, reasonCode)
+
+        if (reasonCode) {
+            executeStateTransition(task, PickTaskStatus.PICKED)
         }
 
-        executeStateTransition(task, PickTaskStatus.PICKED)
-        transferToContainer(task, quantityPicked)
-
-        existingPickItem.pickedBy = Person.get(pickedById)
-        existingPickItem.datePicked = new Date()
+        transferToContainer(task, outboundContainer, quantityPicked)
         existingPickItem.outboundContainer = outboundContainer
-        existingPickItem.quantityPicked = newQuantityPicked
-        existingPickItem.reasonCode = reasonCode
-
         save(task)
     }
 
@@ -275,14 +269,14 @@ class PickTaskService {
         }
     }
 
-    void transferToContainer(PickTask task, Integer quantity) {
+    void transferToContainer(PickTask task, Location container, Integer quantity) {
         TransferStockCommand command = new TransferStockCommand()
         command.location = task.facility
         command.binLocation = task.location
         command.inventoryItem = task.inventoryItem
         command.quantity = quantity
         command.otherLocation = task.facility
-        command.otherBinLocation = task.outboundContainer
+        command.otherBinLocation = container
         command.transferOut = Boolean.TRUE
         command.disableRefresh = Boolean.TRUE
         transfer(task, command)

--- a/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
+++ b/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
@@ -7,6 +7,7 @@ import org.pih.warehouse.api.AvailableItem
 import org.pih.warehouse.api.PickTaskStatus
 import org.pih.warehouse.api.picking.SearchPickTaskCommand
 import org.pih.warehouse.core.ActivityCode
+import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.DeliveryTypeCode
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.Person
@@ -147,13 +148,7 @@ class PickTaskService {
 
     void pick(PickTask task, String outboundContainerId, String pickedById) {
         Location outboundContainer = Location.findByLocationNumberOrId(outboundContainerId, outboundContainerId)
-        if (!outboundContainer) {
-            throw new IllegalStateException("Outbound container does not exist")
-        }
-
-        if (!outboundContainer.supports(ActivityCode.OUTBOUND_CONTAINER)) {
-            throw new IllegalArgumentException("Container ${outboundContainer.name} does not support OUTBOUND_CONTAINER activity")
-        }
+        validateOutboundContainer(outboundContainer, task)
 
         executeStateTransition(task, PickTaskStatus.PICKED)
         transferToContainer(task, outboundContainer, task.quantityRequired.toInteger())
@@ -169,13 +164,7 @@ class PickTaskService {
 
     void shortPick(PickTask task, String outboundContainerId, Integer quantityPicked, String pickedById, String reasonCode) {
         Location outboundContainer = Location.findByLocationNumberOrId(outboundContainerId, outboundContainerId)
-        if (!outboundContainer) {
-            throw new IllegalStateException("Outbound container does not exist")
-        }
-
-        if (!outboundContainer.supports(ActivityCode.OUTBOUND_CONTAINER)) {
-            throw new IllegalArgumentException("Container ${outboundContainer.name} does not support OUTBOUND_CONTAINER activity")
-        }
+        validateOutboundContainer(outboundContainer, task)
 
         PicklistItem existingPickItem = PicklistItem.get(task.id)
         picklistService.updatePicklistItem(existingPickItem.id, task.product?.id, quantityPicked.toBigDecimal(), pickedById, reasonCode)
@@ -192,7 +181,7 @@ class PickTaskService {
     def drop(String outboundContainerId, Map data = [:]) {
         Location outboundContainer = Location.findByLocationNumberOrId(outboundContainerId, outboundContainerId)
         if (!outboundContainer) {
-            throw new ObjectNotFoundException(outboundContainerId, "Outbound container was not found")
+            throw new IllegalArgumentException("Outbound container with identifier ${outboundContainerId} does not exist")
         }
 
         switch (data?.action) {
@@ -250,14 +239,12 @@ class PickTaskService {
 
     void dropToStaging(Location outboundContainer, String stagingLocationId, String stagedById) {
         Location stagingLocation = Location.findByLocationNumberOrId(stagingLocationId, stagingLocationId)
-        if (!stagingLocation) {
-            throw new ObjectNotFoundException(stagingLocationId, "Staging location was not found")
-        }
+        validateStagingLocation(stagingLocation)
 
         List<AvailableItem> itemsToMove = productAvailabilityService.getAvailableItems(outboundContainer)
 
         if (!itemsToMove) {
-            throw new IllegalStateException("Outbound container is empty")
+            throw new IllegalStateException("Outbound container with number ${outboundContainer.locationNumber} is empty")
         }
 
         Person stagedBy = Person.get(stagedById)
@@ -350,5 +337,42 @@ class PickTaskService {
         }
 
         return []
+    }
+
+    private void validateOutboundContainer(Location outboundContainer, PickTask pickTask) {
+        if (!outboundContainer) {
+            throw new IllegalArgumentException("Outbound container does not exist")
+        }
+
+        if (!Constants.OUTBOUND_CONTAINER_LOCATION_TYPE_NAME.equalsIgnoreCase(outboundContainer.getLocationType().getName())) {
+            throw new IllegalArgumentException("Container ${outboundContainer.name} is not of ${Constants.OUTBOUND_CONTAINER_LOCATION_TYPE_NAME} type")
+        }
+
+        if (!outboundContainer.supports(ActivityCode.OUTBOUND_CONTAINER)) {
+            throw new IllegalArgumentException("Container ${outboundContainer.name} does not support ${ActivityCode.OUTBOUND_CONTAINER} activity")
+        }
+
+        if (!outboundContainer.supports(ActivityCode.HOLD_STOCK)) {
+            throw new IllegalArgumentException("Container ${outboundContainer.name} does not support ${ActivityCode.HOLD_STOCK} activity")
+        }
+
+        ActivityCode taskDeliveryTypeActivity = pickTask.getDeliveryTypeCode().getActivityCode()
+        if (!outboundContainer.supports(taskDeliveryTypeActivity)) {
+            throw new IllegalArgumentException("Container ${outboundContainer.name} does not support ${taskDeliveryTypeActivity} activity")
+        }
+    }
+
+    private void validateStagingLocation(Location stagingLocation) {
+        if (!stagingLocation) {
+            throw new IllegalArgumentException("Staging location does not exist")
+        }
+
+        if (!Constants.CROSS_DOCKING_LOCATION_TYPE_NAME.equalsIgnoreCase(stagingLocation.getLocationType().getName())) {
+            throw new IllegalArgumentException("Staging location ${stagingLocation.name} is not of ${Constants.CROSS_DOCKING_LOCATION_TYPE_NAME} type")
+        }
+
+        if (!stagingLocation.supports(ActivityCode.HOLD_STOCK)) {
+            throw new IllegalArgumentException("Staging location ${stagingLocation.name} does not support ${ActivityCode.HOLD_STOCK} activity")
+        }
     }
 }

--- a/grails-app/services/org/pih/warehouse/putaway/PutawayTaskService.groovy
+++ b/grails-app/services/org/pih/warehouse/putaway/PutawayTaskService.groovy
@@ -12,6 +12,7 @@ import org.pih.warehouse.api.PutawayTaskStatus
 import org.pih.warehouse.api.putaway.SearchPutawayTaskCommand
 import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.ActivityCode
+import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.Person
 import org.pih.warehouse.core.ReasonCode
@@ -249,8 +250,12 @@ class PutawayTaskService {
             throw new IllegalStateException("Container does not exist")
         }
 
+        if (!Constants.PUTAWAY_CONTAINER_LOCATION_TYPE_NAME.equalsIgnoreCase(container.getLocationType().getName())) {
+            throw new IllegalArgumentException("Container ${container.name} is not of ${Constants.PUTAWAY_CONTAINER_LOCATION_TYPE_NAME} type")
+        }
+
         if (!container.supports(ActivityCode.PUTAWAY_CART)) {
-            throw new IllegalArgumentException("Container ${container?.name} does not support PUTAWAY_CART activity")
+            throw new IllegalArgumentException("Container ${container?.name} does not support ${ActivityCode.PUTAWAY_CART} activity")
         }
 
         // validate that the container matches the task putaway container

--- a/grails-app/services/org/pih/warehouse/putaway/PutawayTaskService.groovy
+++ b/grails-app/services/org/pih/warehouse/putaway/PutawayTaskService.groovy
@@ -250,10 +250,6 @@ class PutawayTaskService {
             throw new IllegalStateException("Container does not exist")
         }
 
-        if (!Constants.PUTAWAY_CONTAINER_LOCATION_TYPE_NAME.equalsIgnoreCase(container.getLocationType().getName())) {
-            throw new IllegalArgumentException("Container ${container.name} is not of ${Constants.PUTAWAY_CONTAINER_LOCATION_TYPE_NAME} type")
-        }
-
         if (!container.supports(ActivityCode.PUTAWAY_CART)) {
             throw new IllegalArgumentException("Container ${container?.name} does not support ${ActivityCode.PUTAWAY_CART} activity")
         }

--- a/src/main/groovy/org/pih/warehouse/core/ActivityCode.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/ActivityCode.groovy
@@ -128,6 +128,9 @@ enum ActivityCode {
     // Outbound container codes
     OUTBOUND_CONTAINER('OUTBOUND_CONTAINER'),
 
+    // Staging location codes
+    STAGING_LOCATION('STAGING_LOCATION'),
+
     PICKING_SHORTAGE('PICKING_SHORTAGE'),
 
     NONE('NONE')
@@ -203,6 +206,7 @@ enum ActivityCode {
 
                 // Internal locations used for picking
                 OUTBOUND_CONTAINER,
+                STAGING_LOCATION,
 
                 // Allows classification of location by delivery type
                 DELIVERY_TYPE_LOCAL_DELIVERY,

--- a/src/main/groovy/org/pih/warehouse/core/ActivityCode.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/ActivityCode.groovy
@@ -128,6 +128,8 @@ enum ActivityCode {
     // Outbound container codes
     OUTBOUND_CONTAINER('OUTBOUND_CONTAINER'),
 
+    PICKING_SHORTAGE('PICKING_SHORTAGE'),
+
     NONE('NONE')
 
     final String id

--- a/src/main/groovy/org/pih/warehouse/core/Constants.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/Constants.groovy
@@ -202,4 +202,8 @@ class Constants {
     static final String DEFAULT_CONTAINER_LABEL_DOCUMENT_NUMBER = "barcodeLabel:container"
     static final String DEFAULT_INTERNAL_LOCATION_LABEL_DOCUMENT_NUMBER = "barcodeLabel:internalLocation"
     static final String DEFAULT_PRODUCT_LABEL_DOCUMENT_NUMBER = "barcodeLabel:product"
+
+    static final String PUTAWAY_CONTAINER_LOCATION_TYPE_NAME = "Putaway Container"
+    static final String OUTBOUND_CONTAINER_LOCATION_TYPE_NAME = "Outbound Container"
+    static final String CROSS_DOCKING_LOCATION_TYPE_NAME = "Cross-docking"
 }

--- a/src/main/groovy/org/pih/warehouse/core/ReasonCode.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/ReasonCode.groovy
@@ -228,4 +228,12 @@ enum ReasonCode {
                 WRONG_ITEM
         ]
     }
+
+    static listPickingShortageReasonCodes() {
+        [
+                INSUFFICIENT_QUANTITY_AVAILABLE,
+                DIFFERENT_LOCATION,
+                DAMAGED
+        ]
+    }
 }


### PR DESCRIPTION
The idea for short pick is to support reallocation (PICKING_STRATEGY_AUTOMATIC_REALLOCATION activity code needs to be enabled on facility) - so new picklist items are created when shortage occurs.

Endpoint:
```
PATCH /api/facilities/{facilityId}/pick-tasks/{taskId}

{
    "action": "short-pick",
    "outboundContainerId": "ff8081819aa6a587019aa6b481230011",
    "quantityPicked": 5,
    "pickedById": "ff80818196aa115a0196aa714094000d",
    "reasonCode": "STOCKOUT"
}
```
It works similar to 'old' picking. When mobile app triggers this endpoint:
* with no reason code - quantity picked of picklist item is updated, item is still pickable so status = PICKING
* with reason code - quantity picked of picklist item is updated, reason code is set, item is no longer pickable so status = PICKED, new picklist item(s) is(are) created with quantity = quantity remaining from original item

At this point mobile app needs to refetch tasks to add these newly created tasks at the end of the pick task list to process them in the 'current warehouse walk'. I think the best way to refetch tasks will be fetching pick tasks by requisition (requisition is the same for the new task and it relates to the current order), compare to the original pick-task list and add these newly created pick-tasks to pick-task list

@jmiranda @awalkowiak @olewandowski1

Does it sound +/- correct/logical?