### PR TITLE
OBS-1938 fix date validation errors in non-english locales

### DIFF
--- a/src/js/hooks/outboundImport/useOutboundImportValidation.js
+++ b/src/js/hooks/outboundImport/useOutboundImportValidation.js
@@ -1,10 +1,15 @@
+import moment from 'moment/moment';
+import { useSelector } from 'react-redux';
+import { getCurrentLocale } from 'selectors';
 import { z } from 'zod';
 
+import { DateFormat } from 'consts/timeFormat';
 import useTranslate from 'hooks/useTranslate';
 import { validateDateIsSameOrAfter, validateFutureDate } from 'utils/form-utils';
 
 const useOutboundImportValidation = () => {
   const translate = useTranslate();
+  const locale = useSelector(getCurrentLocale);
   const requestedBySchema = z.object({
     id: z.string(),
     label: z.string(),
@@ -42,22 +47,29 @@ const useOutboundImportValidation = () => {
     dateRequested: z.string({
       required_error: translate('react.outboundImport.validation.dateRequested.required.label', 'Date requested is required'),
       invalid_type_error: translate('react.outboundImport.validation.dateRequested.required.label', 'Date requested is required'),
-    }).refine((pickedDate) =>
-      validateFutureDate(pickedDate), {
+    }).refine((pickedDate) => {
+      const pickedDateMoment = moment(pickedDate, DateFormat.MMM_DD_YYYY, locale);
+      return validateFutureDate(pickedDateMoment);
+    }, {
       message: translate('react.outboundImport.validation.dateRequested.futureDate.label', 'The date cannot be in the future'),
     }),
     dateShipped: z.string({
       required_error: translate('react.outboundImport.validation.dateShipped.required.label', 'Date shipped is required'),
       invalid_type_error: translate('react.outboundImport.validation.dateShipped.required.label', 'Date shipped is required'),
     }).superRefine((pickedDate, ctx) => {
-      if (!validateFutureDate(pickedDate)) {
+      const pickedDateMoment = moment(pickedDate, DateFormat.MMM_DD_YYYY_HH_MM_SS, locale);
+      if (!validateFutureDate(pickedDateMoment)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: translate('react.outboundImport.validation.dateRequested.futureDate.label', 'The date cannot be in the future'),
         });
       }
       const { expectedDeliveryDate, dateShipped } = data;
-      if (!validateDateIsSameOrAfter(expectedDeliveryDate, dateShipped)) {
+      const expectedDeliveryDateMoment = moment(
+        expectedDeliveryDate, DateFormat.MMM_DD_YYYY, locale,
+      );
+      const dateShippedMoment = moment(dateShipped, DateFormat.MMM_DD_YYYY_HH_MM_SS, locale);
+      if (!validateDateIsSameOrAfter(expectedDeliveryDateMoment, dateShippedMoment)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: translate('react.outboundImport.validation.expectedDeliveryDate.afterDateShipped.label',
@@ -82,7 +94,9 @@ const useOutboundImportValidation = () => {
       invalid_type_error: translate('react.outboundImport.validation.expectedDeliveryDate.required.label', 'Expected delivery date is required'),
     }).refine(() => {
       const { expectedDeliveryDate, dateShipped } = data;
-      return validateDateIsSameOrAfter(expectedDeliveryDate, dateShipped);
+      const deliveryDateMoment = moment(expectedDeliveryDate, DateFormat.MMM_DD_YYYY, locale);
+      const dateShippedMoment = moment(dateShipped, DateFormat.MMM_DD_YYYY_HH_MM_SS, locale);
+      return validateDateIsSameOrAfter(deliveryDateMoment, dateShippedMoment);
     }, {
       message: translate('react.outboundImport.validation.expectedDeliveryDate.afterDateShipped.label',
         'Please verify timeline. Delivery date cannot be before Ship date.'),

--- a/src/js/utils/form-utils.jsx
+++ b/src/js/utils/form-utils.jsx
@@ -155,25 +155,21 @@ export const decimalParser = (value, precision) => {
 /**
  * Method to check if picked date is from the future
  * @return true if the date is not from the future; false if the date is from the future
- * @param pickedDate
+ * @param {Moment} pickedDate
  */
 export const validateFutureDate = (pickedDate) => {
-  const date = moment(pickedDate);
   const today = moment(new Date());
-  return date.startOf('day').isSameOrBefore(today.startOf('day'));
+  return pickedDate.startOf('day').isSameOrBefore(today.startOf('day'));
 };
 
 /**
  * Method to check if first date is later or same as the second date
  * @return true if the first date is later or same as the second date
- * @param laterDate
- * @param earlierDate
+ * @param {Moment} laterDate
+ * @param {Moment} earlierDate
  */
-export const validateDateIsSameOrAfter = (laterDate, earlierDate) => {
-  const laterDateParsed = moment(laterDate);
-  const earlierDateParsed = moment(earlierDate);
-  return laterDateParsed.startOf('day').isSameOrAfter(earlierDateParsed.startOf('day'));
-};
+export const validateDateIsSameOrAfter = (laterDate, earlierDate) =>
+  laterDate.startOf('day').isSameOrAfter(earlierDate.startOf('day'));
 
 /**
  * * Mutator function to set all values in a specified column for each entry in an array field.


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBS-1938

**Description:** Date validation during outbound import wasn't working for non-english locales. I switched the logic to include locale when constructing the moment object.


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

<img width="1890" height="1044" alt="image" src="https://github.com/user-attachments/assets/ed97b749-e5e7-460a-9f4c-e4abd4e7c26e" />
