### PR TITLE
OBPIH-7589 Hide custom input in datePicker to ensure E2E tests pass

### DIFF
--- a/src/js/components/form-elements/v2/DateFieldDateFns.jsx
+++ b/src/js/components/form-elements/v2/DateFieldDateFns.jsx
@@ -132,7 +132,9 @@ const DateFieldDateFns = ({
         ariaLiveMessages={{}}
         locale={dateFnsLocale()}
         showTimeSelect={showTimeSelect}
-        customInput={showCustomInput ? <DateFieldInput onClear={onClear} clearable={clearable} /> : null}
+        customInput={showCustomInput
+          ? <DateFieldInput onClear={onClear} clearable={clearable} />
+          : undefined}
         className={`form-element-input ${errorMessage ? 'has-errors' : ''} ${className}`}
         dropdownMode="scroll"
         dateFormat={getDateFormat()}
@@ -227,7 +229,7 @@ DateFieldDateFns.defaultProps = {
   clearable: true,
   triggerValidation: null,
   customTooltip: false,
-  // If true, the 'x' icon for clearing the date will be hidden,
+  // If false, the 'x' icon for clearing the date will be hidden,
   // but the date can still be cleared using Backspace.
   // Thanks to this, the E2E tests won't fail and we won't need to
   // write new getters for the datePicker in the E2E tests.

--- a/src/js/components/form-elements/v2/DateFieldDateFns.jsx
+++ b/src/js/components/form-elements/v2/DateFieldDateFns.jsx
@@ -39,6 +39,7 @@ const DateFieldDateFns = ({
   wrapperClassName,
   focusProps = {},
   customTooltip,
+  showCustomInput,
   ...fieldProps
 }) => {
   const translate = useTranslate();
@@ -131,7 +132,7 @@ const DateFieldDateFns = ({
         ariaLiveMessages={{}}
         locale={dateFnsLocale()}
         showTimeSelect={showTimeSelect}
-        customInput={<DateFieldInput onClear={onClear} clearable={clearable} />}
+        customInput={showCustomInput && <DateFieldInput onClear={onClear} clearable={clearable} />}
         className={`form-element-input ${errorMessage ? 'has-errors' : ''} ${className}`}
         dropdownMode="scroll"
         dateFormat={getDateFormat()}
@@ -203,6 +204,7 @@ DateFieldDateFns.propTypes = {
   // Optional function to trigger validation for this field
   triggerValidation: PropTypes.func,
   customTooltip: PropTypes.bool,
+  showCustomInput: PropTypes.bool,
 };
 
 DateFieldDateFns.defaultProps = {
@@ -225,4 +227,9 @@ DateFieldDateFns.defaultProps = {
   clearable: true,
   triggerValidation: null,
   customTooltip: false,
+  // If true, the 'x' icon for clearing the date will be hidden,
+  // but the date can still be cleared using Backspace.
+  // Thanks to this, the E2E tests won't fail and we won't need to
+  // write new getters for the datePicker in the E2E tests.
+  showCustomInput: true,
 };

--- a/src/js/components/form-elements/v2/DateFieldDateFns.jsx
+++ b/src/js/components/form-elements/v2/DateFieldDateFns.jsx
@@ -132,7 +132,7 @@ const DateFieldDateFns = ({
         ariaLiveMessages={{}}
         locale={dateFnsLocale()}
         showTimeSelect={showTimeSelect}
-        customInput={showCustomInput && <DateFieldInput onClear={onClear} clearable={clearable} />}
+        customInput={showCustomInput ? <DateFieldInput onClear={onClear} clearable={clearable} /> : null}
         className={`form-element-input ${errorMessage ? 'has-errors' : ''} ${className}`}
         dropdownMode="scroll"
         dateFormat={getDateFormat()}

--- a/src/js/components/modals/ModalWithTable.jsx
+++ b/src/js/components/modals/ModalWithTable.jsx
@@ -21,27 +21,29 @@ const ModalWithTable = ({
   useHideScroll({ hide: isOpen });
 
   return (
-    <Modal isOpen={isOpen} className="modal-content min-width-1000" data-testid="modal-with-table">
-      <div className="modal-content__header">
-        <p className="modal-content__header__title">{title}</p>
-        <p className="modal-content__header__subtitle">{subtitle}</p>
-      </div>
-      <div className="modal-content__main">
-        <DataTable data={data} columns={columns} disablePagination />
-      </div>
-      <div className="modal-content__buttons">
-        <Button
-          defaultLabel={cancelLabel.default}
-          label={cancelLabel.key}
-          variant="secondary"
-          onClick={onCancel}
-        />
-        <Button
-          defaultLabel={confirmLabel.default}
-          label={confirmLabel.key}
-          variant="primary"
-          onClick={onConfirm}
-        />
+    <Modal isOpen={isOpen} className="modal-content min-width-1000">
+      <div data-testid="modal-with-table">
+        <div className="modal-content__header">
+          <p className="modal-content__header__title">{title}</p>
+          <p className="modal-content__header__subtitle">{subtitle}</p>
+        </div>
+        <div className="modal-content__main">
+          <DataTable data={data} columns={columns} disablePagination />
+        </div>
+        <div className="modal-content__buttons">
+          <Button
+            defaultLabel={cancelLabel.default}
+            label={cancelLabel.key}
+            variant="secondary"
+            onClick={onCancel}
+          />
+          <Button
+            defaultLabel={confirmLabel.default}
+            label={confirmLabel.key}
+            variant="primary"
+            onClick={onConfirm}
+          />
+        </div>
       </div>
     </Modal>
   );

--- a/src/js/components/stock-movement-wizard/inboundV2/sections/create/InboundCreate.jsx
+++ b/src/js/components/stock-movement-wizard/inboundV2/sections/create/InboundCreate.jsx
@@ -168,6 +168,7 @@ const InboundCreate = ({ next }) => {
                     setValue('dateRequested', newDate);
                     await trigger();
                   }}
+                  showCustomInput={false}
                 />
               )}
             />

--- a/src/js/components/stock-movement-wizard/inboundV2/sections/send/InboundSendForm.jsx
+++ b/src/js/components/stock-movement-wizard/inboundV2/sections/send/InboundSendForm.jsx
@@ -123,6 +123,7 @@ const InboundSendForm = ({ previous }) => {
                     required
                     customDateFormat={DateFormatDateFns.DD_MMM_YYYY}
                     customTooltip
+                    showCustomInput={false}
                     onChange={async (newDate) => {
                       setValue('shipDate', newDate);
                       await trigger();
@@ -227,6 +228,7 @@ const InboundSendForm = ({ previous }) => {
                     customDateFormat={DateFormatDateFns.DD_MMM_YYYY}
                     triggerValidation={trigger}
                     customTooltip
+                    showCustomInput={false}
                     onChange={async (newDate) => {
                       setValue('expectedDeliveryDate', newDate);
                       await trigger();

--- a/src/js/hooks/inboundV2/addItems/useInboundAddItemsColumns.jsx
+++ b/src/js/hooks/inboundV2/addItems/useInboundAddItemsColumns.jsx
@@ -387,6 +387,7 @@ const useInboundAddItemsColumns = ({
                   className="input-xs"
                   hasErrors={hasErrors}
                   showErrorBorder={hasErrors}
+                  showCustomInput={false}
                   onKeyDown={(e) => handleKeyDown(e, row.index, column.id)}
                   onBlur={() => handleBlur(field)}
                   focusProps={{


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:**

**Description:**
At this moment, after agreeing with Katarzyna, we decided not to create a new getter for the DatePicker used in our E2E tests. The customInput in the DatePicker would require a new getter because it generates a different HTML structure.

For now, the "x" icon will be hidden, but the date can still be removed using Backspace, which is the same behavior like in the old inbound and this is acceptable.

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
