### PR TITLE
If using a Gradle daemon, don’t use its working directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,6 +136,9 @@ bootRun {
         '-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005'
     ]
     systemProperties System.properties
+
+    // if using a Gradle daemon, don't use its working directory
+    systemProperty 'user.dir', project.projectDir.absolutePath
 }
 
 configurations {


### PR DESCRIPTION
Fixes #5681.

This is a little quality-of-life patch that allows `./gradlew bootRun` to use a Gradle daemon more smoothly.