### PR TITLE
Get integration tests working on Apple Silicon

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -226,6 +226,11 @@ configurations {
                     }
                 }
 
+                if (details.requested.group.startsWith('net.java.dev.jna')) {
+                    details.because 'support testcontainers and Mac-based development'
+                    details.useVersion(jnaVersion)
+                }
+
                 if (details.requested.group == 'org.apache.httpcomponents') {
                     details.because 'enforce consistent httpcomponents versioning'
                     if (details.requested.name == 'httpcore') {

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,14 @@ htmlUnitVersion=2.70.0
 httpComponentsVersion=4.5.14
 httpCoreVersion=4.4.16
 jacksonVersion=2.9.10
+# grails-core pulls in 4.2.2 via directory-watcher. This breaks
+# Macs, which need 5.8.0+, and testcontainers, which requests 5.13+.
+# JNA's only breaking changes between 4.2.2 and today remove APIs
+# that directory-watcher does not use.
+# https://github.com/java-native-access/jna/blob/master/CHANGES.md#release-580
+# https://github.com/java-native-access/jna/blob/master/CHANGES.md#breaking-changes
+# https://github.com/java-native-access/jna/blob/master/CHANGES.md#breaking-changes-1
+jnaVersion=5.13.0
 # Grails's Spring Boot dependency doesn't play well with Logback 1.3+
 logbackVersion=1.2.12
 tomcatVersion=8.5.88

--- a/src/integration-test/groovy/org/pih/warehouse/common/base/IntegrationSpec.groovy
+++ b/src/integration-test/groovy/org/pih/warehouse/common/base/IntegrationSpec.groovy
@@ -2,13 +2,19 @@ package org.pih.warehouse.common.base
 
 import grails.buildtestdata.TestDataBuilder
 import grails.test.mixin.integration.Integration
+import org.pih.warehouse.Application
 import org.springframework.context.annotation.Import
 import spock.lang.Specification
 
 /**
  * Base class for all integration tests.
+ *
+ * Explicitly assigning applicationClass here makes integration tests work on a Mac.
+ * This workaround may not be needed on other platforms, or at all in Grails 4+.
+ * I learned about it from an old SO post detailing a similar issue in IntelliJ.
+ * See https://stackoverflow.com/questions/48823524/grails-3-intellij-running-integration-tests-yields-no-gorm-implementations-c
  */
-@Integration
+@Integration(applicationClass = Application.class)
 @Import(IntegrationSpecConfig.class)
 abstract class IntegrationSpec extends Specification implements TestDataBuilder {
 }


### PR DESCRIPTION
Grails uses JNA 4.2.2, which won't work on Macs (which need 5.8+) or testcontainers (which requests 5.13+). I poked around and found that Grails only uses a small subset of the JNA api, and between 4.2.x and the latest release, the only breaking changes were removals of functions we don't use. Should be safe. (Works for me!)

I also needed to add a small assignment to the `@Integration` annotation to get integration tests to load the grails environment correctly. It seems very low risk to me because it's so obvious. But since I'm not at all sure what it does (except get tests to run) I'm flagging it here for review and discussion.

Fixes #5683.