### PR TITLE
OBPIH-6735 fix duplicate key errors on multiple rows in record stock with the sa…

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
@@ -1726,13 +1726,9 @@ class InventoryService implements ApplicationContextAware {
     }
 
     /**
-     * TODO Need to finish this method.
-     *
-     * @param product
-     * @param lotNumber
-     * @param expirationDate
-     * @return
+     * @deprecated use {@link InventoryItemManager} instead.
      */
+    @Deprecated
     InventoryItem findOrCreateInventoryItem(Product product, String lotNumber, Date expirationDate) {
         def inventoryItem =
                 findInventoryItemByProductAndLotNumber(product, lotNumber)

--- a/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
@@ -29,6 +29,7 @@ import org.pih.warehouse.importer.ImporterUtil
 import org.pih.warehouse.inventory.product.ExpirationHistoryReport
 import org.pih.warehouse.inventory.product.availability.AvailableItemKey
 import org.pih.warehouse.inventory.product.availability.AvailableItemMap
+import org.pih.warehouse.product.lot.ProductLot
 import org.pih.warehouse.product.Category
 import org.pih.warehouse.product.Product
 import org.pih.warehouse.product.ProductAvailability
@@ -1462,19 +1463,25 @@ class InventoryService implements ApplicationContextAware {
                     baselineTransaction?.transactionSource
             )
 
-            List<AvailableItem> currentRecordStockItems = []
+            List<RecordInventoryRowCommand> groupedRows = groupDuplicatedRecordInventoryRows(cmd)
+
+            // Collect all unique product lots (ie inventory items) across all rows...
+            List<ProductLot> itemsToGetOrCreate = groupedRows.collect {
+                new ProductLot(product: cmd.product, lotNumber: it.lotNumber, expirationDate: it.expirationDate)
+            }
+            // ...Then get/create them all in bulk. Don't refresh product availability for any newly created items.
+            // We will manually perform a product availability refresh at the end.
+            InventoryItemByProductLot inventoryItemMap = inventoryItemManager.getOrCreateInventoryItems(
+                    itemsToGetOrCreate, true)
+
             // 3. Process each row added to the record inventory page
-            groupDuplicatedRecordInventoryRows(cmd).each { RecordInventoryRowCommand row ->
+            List<AvailableItem> currentRecordStockItems = []
+            for (RecordInventoryRowCommand row in groupedRows) {
                 if (!row) {
                     return null
                 }
 
-                InventoryItem inventoryItem = inventoryItemManager.getOrCreateInventoryItem(
-                        cmd.product,
-                        row.lotNumber,
-                        row.expirationDate,
-                        true,  // Don't refresh product availability. That will get done manually at the end.
-                )
+                InventoryItem inventoryItem = inventoryItemMap.get(cmd.product, row.lotNumber)
 
                 // Create new transaction entries (but only if the quantity changed)
                 TransactionEntry transactionEntry = recordStockProductInventoryTransactionService.createAdjustmentTransactionEntry(

--- a/src/main/groovy/org/pih/warehouse/inventory/InventoryItemByProductLot.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/InventoryItemByProductLot.groovy
@@ -1,6 +1,5 @@
 package org.pih.warehouse.inventory
 
-
 import org.pih.warehouse.product.Product
 import org.pih.warehouse.product.lot.ProductLot
 
@@ -14,7 +13,6 @@ class InventoryItemByProductLot extends HashMap<ProductLot, InventoryItem> {
      * so we don't need to bother passing any other fields (such as expirationDate).
      */
     InventoryItem get(Product product, String lotNumber) {
-        //InventoryItem x = get(new ProductLot(product: product, lotNumber: lotNumber))
         return get(new ProductLot(product: product, lotNumber: lotNumber))
     }
 }

--- a/src/main/groovy/org/pih/warehouse/inventory/InventoryItemByProductLot.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/InventoryItemByProductLot.groovy
@@ -1,0 +1,20 @@
+package org.pih.warehouse.inventory
+
+
+import org.pih.warehouse.product.Product
+import org.pih.warehouse.product.lot.ProductLot
+
+/**
+ * A simple convenience wrapper on hashmap representing a map of inventory items keyed on product lot.
+ */
+class InventoryItemByProductLot extends HashMap<ProductLot, InventoryItem> {
+
+    /**
+     * Fetch an InventoryItem by product and lot number. ProductLot is unique on these two fields alone,
+     * so we don't need to bother passing any other fields (such as expirationDate).
+     */
+    InventoryItem get(Product product, String lotNumber) {
+        //InventoryItem x = get(new ProductLot(product: product, lotNumber: lotNumber))
+        return get(new ProductLot(product: product, lotNumber: lotNumber))
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/inventory/InventoryItemManager.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/InventoryItemManager.groovy
@@ -4,6 +4,7 @@ import grails.validation.ValidationException
 import org.apache.commons.lang3.StringUtils
 import org.springframework.stereotype.Component
 
+import org.pih.warehouse.product.lot.ProductLot
 import org.pih.warehouse.product.Product
 
 @Component
@@ -29,6 +30,37 @@ class InventoryItemManager {
         }
 
         return createInventoryItem(product, lotNumber, expirationDate, disableRefresh)
+    }
+
+    /**
+     * Finds the inventory item for the given product lot, creating it if it doesn't exist.
+     *
+     * @param productLot The product + lot of the item to get or create.
+     * @param disableRefresh True if the creation of a new InventoryItem should NOT trigger an asynchronous
+     *                       product availability refresh. Typically this is only true when callers want to
+     *                       trigger the refresh themselves, manually.
+     */
+    InventoryItem getOrCreateInventoryItem(ProductLot productLot, boolean disableRefresh = false) {
+        return getOrCreateInventoryItem(
+                productLot.product, productLot.lotNumber, productLot.expirationDate, disableRefresh)
+    }
+
+    /**
+     * Bulk method for finding the inventory items for the given product lots, creating them if they don't exist.
+     */
+    InventoryItemByProductLot getOrCreateInventoryItems(Collection<ProductLot> productLots,
+                                                        boolean disableRefresh = false) {
+        InventoryItemByProductLot inventoryItemMap = new InventoryItemByProductLot()
+        for (ProductLot productLot in productLots) {
+            if (inventoryItemMap.containsKey(productLot)) {
+                // We could consider adding some validation here, such as checking that the expiration dates match,
+                // but for now we simply continue if we've already fetched or created this inventory item.
+                continue
+            }
+            InventoryItem inventoryItem = getOrCreateInventoryItem(productLot, disableRefresh)
+            inventoryItemMap.put(productLot, inventoryItem)
+        }
+        return inventoryItemMap
     }
 
     /**

--- a/src/main/groovy/org/pih/warehouse/product/lot/ProductLot.groovy
+++ b/src/main/groovy/org/pih/warehouse/product/lot/ProductLot.groovy
@@ -1,0 +1,42 @@
+package org.pih.warehouse.product.lot
+
+import org.apache.commons.lang.builder.HashCodeBuilder
+
+import org.pih.warehouse.product.Product
+
+/**
+ * Represents a specific lot number of a product. Lot numbers represent a group of a product instances that
+ * were all made under the same conditions. As such, the lot is typically controlled by the product supplier.
+ * Note that product lot has no association with an inventory. It is tied only to the product itself.
+ *
+ * This class acts like a simplified InventoryItem. We'd like to one day refactor InventoryItem to either use
+ * or be more like this class, but for now this class is a simple POJO.
+ */
+class ProductLot {
+
+    // Primary Key
+    Product product
+    String lotNumber
+
+    Date expirationDate
+
+    @Override
+    boolean equals(Object o) {
+        if (!(o instanceof ProductLot)) {
+            return false
+        }
+        ProductLot that = (ProductLot) o
+
+        // Only product and lotNumber determine uniqueness. We shouldn't have two ProductLots with the same
+        // product and lotNumber but a different expirationDate, but we let that validation be checked elsewhere.
+        return this.product == that.product && this.lotNumber == that.lotNumber
+    }
+
+    @Override
+    int hashCode() {
+        return new HashCodeBuilder()
+                .append(product?.id)
+                .append(lotNumber)
+                .toHashCode()
+    }
+}


### PR DESCRIPTION
…me new lot

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6735

**Description:** We were getting errors on record stock if you add two or more rows with a lot number that does not yet exist. This is because we were looping through the rows, creating the items, and since both rows were in the same transaction, they both try to create the same lot. The fix was to first collect all unique lots from all rows and then get or create them in bulk.