### PR TITLE
OBS-1954 Fix slow performance on receiving page

### DIFF
--- a/src/js/components/receiving/PartialReceivingPage.jsx
+++ b/src/js/components/receiving/PartialReceivingPage.jsx
@@ -16,6 +16,7 @@ import LabelField from 'components/form-elements/LabelField';
 import SelectField from 'components/form-elements/SelectField';
 import TableRowWithSubfields from 'components/form-elements/TableRowWithSubfields';
 import TextField from 'components/form-elements/TextField';
+import ConfirmExpirationDateModal from 'components/modals/ConfirmExpirationDateModal';
 import EditLineModal from 'components/receiving/modals/EditLineModal';
 import { STOCK_MOVEMENT_URL } from 'consts/applicationUrls';
 import DateFormat from 'consts/dateFormat';
@@ -391,13 +392,19 @@ const TABLE_FIELDS = {
           defaultTitleMessage: 'Edit',
         },
         getDynamicAttr: ({
-          fieldValue, saveEditLine, parentIndex, rowIndex, shipmentReceived,
+          fieldValue,
+          saveEditLine,
+          parentIndex,
+          rowIndex,
+          shipmentReceived,
+          confirmExpirationDateSave,
         }) => ({
           fieldValue,
           saveEditLine,
           parentIndex,
           rowIndex,
           btnOpenDisabled: shipmentReceived || isReceived(true, fieldValue),
+          confirmExpirationDateSave,
         }),
       },
       comment: {
@@ -542,6 +549,9 @@ class PartialReceivingPage extends Component {
     this.state = {
       values: {},
       isFirstPageLoaded: false,
+      isExpirationModalOpen: false,
+      resolveExpirationModal: null,
+      itemsWithMismatchedExpiry: [],
     };
     this.autofillLines = this.autofillLines.bind(this);
     this.setLocation = this.setLocation.bind(this);
@@ -552,10 +562,47 @@ class PartialReceivingPage extends Component {
     this.exportTemplate = this.exportTemplate.bind(this);
     this.importTemplate = this.importTemplate.bind(this);
     this.isRowLoaded = this.isRowLoaded.bind(this);
+    this.confirmExpirationDateSave = this.confirmExpirationDateSave.bind(this);
+    this.handleExpirationModalResponse = this.handleExpirationModalResponse.bind(this);
   }
 
   componentDidMount() {
     this.fetchPartialReceiptCandidates();
+  }
+
+  /**
+   * Shows Inventory item expiration date update confirmation modal.
+   * @param {Array} itemsWithMismatchedExpiry - Array of elements with mismatched expiration dates.
+   * @returns {Promise} - Resolves to true if user confirms the update, false if not.
+   * @public
+   */
+  confirmExpirationDateSave(itemsWithMismatchedExpiry) {
+    return new Promise((resolve) => {
+      this.setState({
+        isExpirationModalOpen: true,
+        resolveExpirationModal: resolve,
+        itemsWithMismatchedExpiry,
+      });
+    });
+  }
+
+  /**
+   * Handles the response from the expiration date confirmation modal.
+   * @param {boolean} shouldUpdate - True if the user confirmed the update, false if not.
+   * @public
+   */
+  handleExpirationModalResponse(shouldUpdate) {
+    // Resolve the promise returned by confirmExpirationDateSave.
+    if (this.state.resolveExpirationModal) {
+      this.state.resolveExpirationModal(shouldUpdate);
+    }
+
+    // Close the modal and reset its state.
+    this.setState({
+      isExpirationModalOpen: false,
+      resolveExpirationModal: null,
+      itemsWithMismatchedExpiry: [],
+    });
   }
 
   confirmReceive(formValues, emptyLinesCount) {
@@ -1098,6 +1145,7 @@ class PartialReceivingPage extends Component {
                         translate: this.props.translate,
                         formatLocalizedDate: this.props.formatLocalizedDate,
                         initialReceiptCandidates: this.state.initialReceiptCandidates,
+                        confirmExpirationDateSave: this.confirmExpirationDateSave,
                       }))}
                   </div>
                   <div className="submit-buttons">
@@ -1109,6 +1157,12 @@ class PartialReceivingPage extends Component {
               </form>
             );
           }}
+        />
+        <ConfirmExpirationDateModal
+          isOpen={this.state.isExpirationModalOpen}
+          itemsWithMismatchedExpiry={this.state.itemsWithMismatchedExpiry}
+          onConfirm={() => this.handleExpirationModalResponse(true)}
+          onCancel={() => this.handleExpirationModalResponse(false)}
         />
       </div>
     );

--- a/src/js/components/receiving/modals/EditLineModal.jsx
+++ b/src/js/components/receiving/modals/EditLineModal.jsx
@@ -12,7 +12,6 @@ import DateField from 'components/form-elements/DateField';
 import ModalWrapper from 'components/form-elements/ModalWrapper';
 import ProductSelectField from 'components/form-elements/ProductSelectField';
 import TextField from 'components/form-elements/TextField';
-import ConfirmExpirationDateModal from 'components/modals/ConfirmExpirationDateModal';
 import DateFormat from 'consts/dateFormat';
 import Translate, { translateWithDefaultMessage } from 'utils/Translate';
 
@@ -119,10 +118,6 @@ class EditLineModal extends Component {
       // This is the original quantity shipped of a shipmentItem. This indicates the maximum.
       shipmentItemQuantityShippedSum: shipmentItemsQuantityMap[attr.fieldValue?.shipmentItemId],
       showMismatchQuantityShippedInfo: false,
-      isExpirationModalOpen: false,
-      // Stores the resolve function for the ConfirmExpirationDateModal promise
-      resolveExpirationModal: null,
-      itemsWithMismatchedExpiry: [],
     };
 
     this.onOpen = this.onOpen.bind(this);
@@ -211,7 +206,7 @@ class EditLineModal extends Component {
 
     if (itemsWithMismatchedExpiry.length > 0) {
       const shouldUpdateExpirationDate =
-        await this.confirmExpirationDateSave(itemsWithMismatchedExpiry);
+        await this.props.confirmExpirationDateSave(itemsWithMismatchedExpiry);
       if (!shouldUpdateExpirationDate) {
         return Promise.reject();
       }
@@ -227,22 +222,6 @@ class EditLineModal extends Component {
       this.props.values,
       this.props.rowIndex,
     );
-  }
-
-  /**
-   * Shows Inventory item expiration date update confirmation modal.
-   * @param {Array} itemsWithMismatchedExpiry - Array of elements with mismatched expiration dates.
-   * @returns {Promise} - Resolves to true if user confirms the update, false if not.
-   * @public
-   */
-  confirmExpirationDateSave(itemsWithMismatchedExpiry) {
-    return new Promise((resolve) => {
-      this.setState({
-        isExpirationModalOpen: true,
-        resolveExpirationModal: resolve,
-        itemsWithMismatchedExpiry,
-      });
-    });
   }
 
   calculateQuantityShippedSum(values) {
@@ -334,49 +313,29 @@ class EditLineModal extends Component {
     return errors;
   }
 
-  /**
-   * Handles the response from the expiration date confirmation modal.
-   * @param {boolean} shouldUpdate - True if the user confirmed the update, false if not.
-   * @public
-   */
-  handleExpirationModalResponse(shouldUpdate) {
-    // Resolve the promise returned by confirmExpirationDateSave.
-    if (this.state.resolveExpirationModal) {
-      this.state.resolveExpirationModal(shouldUpdate);
-    }
-
-    // Close the modal and reset its state.
-    this.setState({
-      isExpirationModalOpen: false,
-      resolveExpirationModal: null,
-      itemsWithMismatchedExpiry: [],
-    });
-  }
-
   render() {
     return (
-      <>
-        <ModalWrapper
-          {...this.state.attr}
-          onOpen={this.onOpen}
-          onSave={this.onSave}
-          validate={this.validate}
-          initialValues={this.state.formValues}
-          fields={FIELDS}
-          wrapperClassName={this.props.wrapperClassName}
-          formProps={{
-            shipmentItemId: this.state.attr.fieldValue.shipmentItemId,
-            binLocation: this.state.attr.fieldValue.binLocation,
-            product: this.state.attr.fieldValue.product,
-          }}
-        >
-          <div>
-            <div className="font-weight-bold mb-3">
-              <Translate id="react.partialReceiving.originalQtyShipped.label" defaultMessage="Original quantity shipped" />
-              :
-              {this.state.attr.fieldValue.quantityShipped}
-            </div>
-            {this.state.showMismatchQuantityShippedInfo
+      <ModalWrapper
+        {...this.state.attr}
+        onOpen={this.onOpen}
+        onSave={this.onSave}
+        validate={this.validate}
+        initialValues={this.state.formValues}
+        fields={FIELDS}
+        wrapperClassName={this.props.wrapperClassName}
+        formProps={{
+          shipmentItemId: this.state.attr.fieldValue.shipmentItemId,
+          binLocation: this.state.attr.fieldValue.binLocation,
+          product: this.state.attr.fieldValue.product,
+        }}
+      >
+        <div>
+          <div className="font-weight-bold mb-3">
+            <Translate id="react.partialReceiving.originalQtyShipped.label" defaultMessage="Original quantity shipped" />
+            :
+            {this.state.attr.fieldValue.quantityShipped}
+          </div>
+          {this.state.showMismatchQuantityShippedInfo
             && (
               <div className="font-weight-bold font-red-ob">
                 <Translate
@@ -385,15 +344,8 @@ class EditLineModal extends Component {
                 />
               </div>
             )}
-          </div>
-        </ModalWrapper>
-        <ConfirmExpirationDateModal
-          isOpen={this.state.isExpirationModalOpen}
-          itemsWithMismatchedExpiry={this.state.itemsWithMismatchedExpiry}
-          onConfirm={() => this.handleExpirationModalResponse(true)}
-          onCancel={() => this.handleExpirationModalResponse(false)}
-        />
-      </>
+        </div>
+      </ModalWrapper>
     );
   }
 }
@@ -429,6 +381,7 @@ EditLineModal.propTypes = {
   initialReceiptCandidates: PropTypes.shape({
     containers: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   }).isRequired,
+  confirmExpirationDateSave: PropTypes.func.isRequired,
 };
 
 EditLineModal.defaultProps = {


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:**
https://pihemr.atlassian.net/browse/OBS-1954

**Description:**
During the investigation, I found that the performance issue was caused by ConfirmExpirationDateModal.jsx, which was fetching translations using `useTranslation('confirmExpirationDate');` As shown in the video, when we had, for example, 100 rows, there were 100 fetch requests in network tab. This happened because ConfirmExpirationDateModal.jsx was used inside EditLineModal.jsx, and that component was rendered for every row.

I moved ConfirmExpirationDateModal.jsx to a higher-level component, PartialReceivingPage.jsx. As a result, the translations are now fetched only once.

As you can see, the performance is still not ideal when we have a large number of rows, but it is noticeably better and the page no longer lags as it did before. I hope this change is enough for now, as we plan to refactor the entire Partial Receiving workflow in the future.

before changes:
https://github.com/user-attachments/assets/dc43389f-2ba3-4025-be33-b0681f41f45f

after changes:
https://github.com/user-attachments/assets/0c90c6ed-e1c0-48db-9b99-8f3f684d7f7c





---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
