### PR TITLE
OBPIH-6969 Add inventory difference calculation before data import

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/api/InventoryApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/InventoryApiController.groovy
@@ -40,6 +40,7 @@ class InventoryApiController {
                 location: Location.get(params.facilityId)
         )
 
+        inventoryImportDataService.calculateAndApplyInventoryDifferences(command)
         inventoryImportDataService.validateData(command)
         inventoryImportDataService.importData(command)
 

--- a/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
@@ -406,6 +406,26 @@ class InventoryImportDataService implements ImportDataService {
         return binLocation
     }
 
+    void calculateAndApplyInventoryDifferences(ImportDataCommand command) {
+        command.data = command.data.findResults { entry ->
+            Product product = Product.findByProductCode(entry['productCode'])
+            InventoryItem inventoryItem =
+                    inventoryService.findInventoryItemByProductAndLotNumber(product, entry['lotNumber'])
+
+            Integer currentQuantity =
+                    productAvailabilityService.getQuantityOnHand(inventoryItem)
+
+            Integer quantityToImport = entry['quantity'] as Integer
+            Integer quantity = quantityToImport - currentQuantity
+
+            if (quantity > 0) {
+                return entry
+            }
+            // Remove rows that have quantity 0, so that they won't be imported
+            return null
+        }
+    }
+
     /**
      * Convenience POJO for holding the results of the inventory import.
      */

--- a/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/importer/InventoryImportDataService.groovy
@@ -416,9 +416,8 @@ class InventoryImportDataService implements ImportDataService {
                     productAvailabilityService.getQuantityOnHand(inventoryItem)
 
             Integer quantityToImport = entry['quantity'] as Integer
-            Integer quantity = quantityToImport - currentQuantity
 
-            if (quantity > 0) {
+            if (quantityToImport > currentQuantity) {
                 return entry
             }
             // Remove rows that have quantity 0, so that they won't be imported


### PR DESCRIPTION
This PR is a fix for the data import used for e2e. Previously, we were importing every line of the file, so it created a baseline during every import, even if the data didn't change. The fix filters rows in the import, so that we are not importing lines when we have more quantity in the inventory item than the quantity in the file.