### PR TITLE
OBLS-588 Fix incorrect STAGED status on partial pick and 0-qty short …

### DIFF
--- a/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
+++ b/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
@@ -186,7 +186,13 @@ class PickTaskService {
 
         if (quantityPicked == 0 && reasonCode) { // 0-quantity short pick, we skip transfer to container
             existingPickItem.reasonCode = reasonCode
-            executeStateTransition(task, PickTaskStatus.STAGED) // dummy transition
+            // Only use STAGED if nothing was ever picked (pure cancellation)
+            if (!existingPickItem.quantityPicked || existingPickItem.quantityPicked == 0) {
+                // STAGED is used as a terminal status for items that were never picked - there's nothing to physically stage
+                executeStateTransition(task, PickTaskStatus.STAGED)
+            } else {
+                executeStateTransition(task, PickTaskStatus.PICKED)
+            }
         } else if (reasonCode || isFullyPicked) {
             executeStateTransition(task, PickTaskStatus.PICKED)
         }


### PR DESCRIPTION
…pick

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://openboxes.atlassian.net/browse/OBLS-588

**Description:**
- Fixed incorrect STAGED status on partial pick + 0-qty short pick

When a 0-qty short pick was performed on a task that already had items picked, the system incorrectly set status to STAGED instead of PICKED.

Added check for existingPickitem.quantityPicked:
- If 0 or null (nothing picked) -> STAGED (nothing to stage)
- If >0 (items picked) -> PICKED (must go though staging flow)

This ensures requisition only becomes STAGED after explicit `dropToStaging`.
