### PR TITLE
OBPIH-6476 fix1: revert getStatus calculation for shipment and fix compareTo for event…

### DIFF
--- a/grails-app/domain/org/pih/warehouse/core/Event.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Event.groovy
@@ -66,15 +66,6 @@ class Event implements Comparable, Serializable {
         return diff
     }
 
-    @Override
-    boolean equals(Object obj) {
-        if (!(obj instanceof Event)) {
-            return false
-        }
-
-        return this.id == obj.id
-    }
-
     Map toJson() {
         return [
                 id: id,

--- a/grails-app/domain/org/pih/warehouse/core/Event.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Event.groovy
@@ -56,6 +56,8 @@ class Event implements Comparable, Serializable {
     String toString() { return "$eventType $eventLocation on $eventDate" }
 
     int compareTo(obj) {
+        // Note the order of the operands here! The the object being compared to is on the left side of the operator,
+        // resulting in Events being sorted descending (ie largest to smallest, ie newest first)
         def diff = obj?.eventDate <=> eventDate
         if (diff == 0) {
             diff = obj?.eventType <=> eventType

--- a/grails-app/domain/org/pih/warehouse/core/history/EventLog.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/history/EventLog.groovy
@@ -94,7 +94,11 @@ class EventLog implements Comparable<EventLog>, Serializable {
     int compareTo(EventLog other) {
         return eventDate <=> other?.eventDate ?:
                dateCreated <=> other?.dateCreated ?:
-               lastUpdated <=> other?.lastUpdated
+               lastUpdated <=> other?.lastUpdated ?:
+               // A failsafe in the rare case where we have two almost identical logs. This should not be possible
+               // in the real world because lastUpdated precision is to the second, but it is possible for E2E tests.
+               event?.eventType <=> other?.event?.eventType ?:
+               id <=> other?.id
     }
 
     Map toJson() {

--- a/grails-app/domain/org/pih/warehouse/shipping/Shipment.groovy
+++ b/grails-app/domain/org/pih/warehouse/shipping/Shipment.groovy
@@ -436,9 +436,9 @@ class Shipment implements Comparable, Serializable, Historizable<ShipmentHistory
      * Dynamically recomputes the current status of the shipment based on the shipment events that have occurred.
      */
     ShipmentStatus getStatus() {
-        // TODO: we should call getMostRecentSystemEvent() here and set the status based on that, but the Events
-        //       seem to be sorted incorrectly. Ex: PARTIALLY_RECEIVED can be before RECEIVED if they share the same
-        //       eventDate. Look into the Event.compareTo(obj) method to see if something unexpected is going on.
+        // TODO: we should set the status based on getMostRecentSystemEvent(), but there is a bug in the compareTo()
+        //       check in EventType that causes PARTIALLY_RECEIVED events to be before RECEIVED ones if they share the
+        //       same eventDate. Once that is fixed then we can refactor this method to use getMostRecentSystemEvent()
         if (this.wasReceived()) {
             return new ShipmentStatus([code    : ShipmentStatusCode.RECEIVED,
                                        date    : this.getActualDeliveryDate(),

--- a/grails-app/domain/org/pih/warehouse/shipping/Shipment.groovy
+++ b/grails-app/domain/org/pih/warehouse/shipping/Shipment.groovy
@@ -436,24 +436,25 @@ class Shipment implements Comparable, Serializable, Historizable<ShipmentHistory
      * Dynamically recomputes the current status of the shipment based on the shipment events that have occurred.
      */
     ShipmentStatus getStatus() {
-        Event event = getMostRecentSystemEvent()
-        switch(event?.eventType?.eventCode) {
-            case EventCode.SHIPPED:
-                return new ShipmentStatus(code      : ShipmentStatusCode.SHIPPED,
-                                            date    : event.eventDate,
-                                            location: this.origin)
-            case EventCode.PARTIALLY_RECEIVED:
-                return new ShipmentStatus(code      : ShipmentStatusCode.PARTIALLY_RECEIVED,
-                                            date    : event.eventDate,
-                                            location: this.destination)
-            case EventCode.RECEIVED:
-                return new ShipmentStatus(code      : ShipmentStatusCode.RECEIVED,
-                                            date    : event.eventDate,
-                                            location: this.destination)
-            default:
-                return new ShipmentStatus(code      : ShipmentStatusCode.PENDING,
-                                            date    : null,
-                                            location: null)
+        // TODO: we should call getMostRecentSystemEvent() here and set the status based on that, but the Events
+        //       seem to be sorted incorrectly. Ex: PARTIALLY_RECEIVED can be before RECEIVED if they share the same
+        //       eventDate. Look into the Event.compareTo(obj) method to see if something unexpected is going on.
+        if (this.wasReceived()) {
+            return new ShipmentStatus([code    : ShipmentStatusCode.RECEIVED,
+                                       date    : this.getActualDeliveryDate(),
+                                       location: this.destination])
+        } else if (wasPartiallyReceived()) {
+            return new ShipmentStatus([code    : ShipmentStatusCode.PARTIALLY_RECEIVED,
+                                       date    : this.getActualDeliveryDate(),
+                                       location: this.destination])
+        } else if (this.hasShipped()) {
+            return new ShipmentStatus([code    : ShipmentStatusCode.SHIPPED,
+                                       date    : this.getActualShippingDate(),
+                                       location: this.origin])
+        } else {
+            return new ShipmentStatus([code    : ShipmentStatusCode.PENDING,
+                                       date    : null,
+                                       location: null])
         }
     }
 


### PR DESCRIPTION
… and event log

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6476

**Description:**

original PR: https://github.com/openboxes/openboxes/pull/5760

Changes here:

1) revert Shipment.getStatus() calculation. This appears to be a bug unrelated to my change (Event.compareTo doesn't work when two receipts happen within the same minute) but Justin is right in that we should avoid any logic changes to Shipment at this point so I'm simply reverting to the old way.

2) fix compareTo for Event and EventLog. This is an E2E test specific issue from what I can see. It happens when everything happens within the same second, so eventDate, dateCreated, and lastUpdated are all the same for multiple event logs. I added an extra check on eventtype and id as fallback options. Those should never get reached in a real world scenario