### PR TITLE
OBPIH-7709 Fix displaying fetched lot numbers in select in resolve step

### DIFF
--- a/src/js/hooks/cycleCount/useResolveStepTable.jsx
+++ b/src/js/hooks/cycleCount/useResolveStepTable.jsx
@@ -9,7 +9,7 @@ import _ from 'lodash';
 import { RiChat3Line, RiDeleteBinLine, RiErrorWarningLine } from 'react-icons/ri';
 import { useDispatch, useSelector } from 'react-redux';
 import { Tooltip } from 'react-tippy';
-import { makeGetLotNumbersByProductId } from 'selectors';
+import { getLotNumbersByProductId } from 'selectors';
 
 import { fetchReasonCodes } from 'actions';
 import { FETCH_CYCLE_COUNT_REASON_CODES } from 'actions/types';
@@ -53,8 +53,6 @@ const useResolveStepTable = ({
   // State for saving data for binLocation dropdown
   const translate = useTranslate();
   const events = new EventEmitter();
-
-  const getLotNumbersByProductId = useMemo(() => makeGetLotNumbersByProductId(), []);
 
   const {
     users,

--- a/src/js/selectors/index.js
+++ b/src/js/selectors/index.js
@@ -233,13 +233,6 @@ export const getShipmentTypes = (state) => state.stockMovementCommon.shipmentTyp
 export const getLotNumbersByProductId = (state, productId) =>
   getLotNumbersWithExpiration(state)?.[productId] || [];
 
-export const makeGetLotNumbersByProductId = () =>
-  createSelector(
-    [getLotNumbersWithExpiration],
-    (_, productId) => productId,
-    (lotNumbers, productId) => lotNumbers?.[productId] || [],
-  );
-
 /**
  * COUNT WORKFLOW
  */


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:**
https://pihemr.atlassian.net/browse/OBPIH-7709

**Description:**
After investigating the issue, it turned out that the validation described in the ticket works correctly. Even when we are on a location that doesn't support bin locations, products assigned to bin locations can still exist. Because of this, validation may sometimes not show errors, since everything works correctly, but we don't see the bin location in the recount step for locations that don't support bin locations.

Example on obdev3 (the lot number “227400245” already exists with the bin location “Biomed”. When we add a new row with the same lot number, we don't see any validation errors because a default bin location is created instead of “Biomed”):
https://github.com/user-attachments/assets/a5c306a7-1da3-4f8e-b9aa-cf529c8eadcd

After discussing this with Kuba, we decided not to change the validation logic.

However, I found another issue. Even though lot numbers for the product were correctly fetched from the backend, they were not displayed properly in the select field. This PR fixes that issue.
https://github.com/user-attachments/assets/97bcedad-c40b-482a-8ad7-9c75ee80773b

 


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
