### PR TITLE
OBPIH-7712 disable edit ship date if inbound is already shipped

### DIFF
--- a/src/js/components/stock-movement-wizard/inboundV2/sections/send/InboundSendForm.jsx
+++ b/src/js/components/stock-movement-wizard/inboundV2/sections/send/InboundSendForm.jsx
@@ -131,6 +131,7 @@ const InboundSendForm = ({ previous }) => {
                     errorMessage={errors.shipDate?.message}
                     showTimeSelect
                     required
+                    disabled={isDispatched}
                     customDateFormat={DateFormatDateFns.DD_MMM_YYYY}
                     customTooltip
                     showCustomInput={false}


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7712

**Description:** Disable ship date from being edited when an inbound has been shipped (it can only be edited before the shipment is sent).


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

<img width="2020" height="596" alt="image" src="https://github.com/user-attachments/assets/6c4e8aa9-bd75-4036-aedc-65c5356168fb" />

