### PR TITLE
OBPIH-6476 fix 2. Hibernate causing event logs to not be persisted

### DIFF
--- a/grails-app/domain/org/pih/warehouse/core/history/EventLog.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/history/EventLog.groovy
@@ -95,8 +95,8 @@ class EventLog implements Comparable<EventLog>, Serializable {
         return eventDate <=> other?.eventDate ?:
                dateCreated <=> other?.dateCreated ?:
                lastUpdated <=> other?.lastUpdated ?:
-               // A failsafe in the rare case where we have two almost identical logs. This should not be possible
-               // in the real world because lastUpdated precision is to the second, but it is possible for E2E tests.
+               // A failsafe in the rare case where we have logs that are created within the same second.
+               // This is incredibly unlikely in the real world, but it happens in E2E tests.
                event?.eventType <=> other?.event?.eventType ?:
                id <=> other?.id
     }

--- a/grails-app/domain/org/pih/warehouse/shipping/Shipment.groovy
+++ b/grails-app/domain/org/pih/warehouse/shipping/Shipment.groovy
@@ -82,7 +82,6 @@ class Shipment implements Comparable, Serializable, Historizable<ShipmentHistory
 
     // One-to-many associations
     SortedSet events
-    SortedSet<EventLog> eventLogs
 
     Requisition requisition
 

--- a/src/main/groovy/org/pih/warehouse/shipping/ShipmentEventLogger.groovy
+++ b/src/main/groovy/org/pih/warehouse/shipping/ShipmentEventLogger.groovy
@@ -23,7 +23,7 @@ class ShipmentEventLogger {
      * Log the occurrence of some shipment related action.
      */
     private EventLog createEventLog(Shipment shipment, EventLog eventLog) {
-        if (!eventLog.validate()) {
+        if (!eventLog.save()) {
             throw new ValidationException("Unable to create shipment event log", eventLog.errors)
         }
         shipment.addToEventLogs(eventLog)

--- a/src/main/groovy/org/pih/warehouse/shipping/ShipmentEventManager.groovy
+++ b/src/main/groovy/org/pih/warehouse/shipping/ShipmentEventManager.groovy
@@ -23,7 +23,7 @@ class ShipmentEventManager {
      * Create a new Shipment event representing some state change to the shipment, then logs the action.
      */
     Event createEvent(Shipment shipment, Event event) {
-        if (!event.validate()) {
+        if (!event.save()) {
             throw new ValidationException("Unable to create shipment event", event.errors)
         }
         shipment.addToEvents(event)


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6476

**Description:** If you did a partial receipt and then a final receipt within the same minute, the event log for the partial receipt was not being persisted to the db. See comment for details.