### PR TITLE
OBLS-358 Add reallocation endpoint for pick tasks during picking

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/api/picking/PickTaskApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/picking/PickTaskApiController.groovy
@@ -14,7 +14,8 @@ class PickTaskApiController extends RestfulController<PickTask> {
             search: 'GET',
             read: 'GET',
             patch: 'PATCH',
-            drop: 'PATCH'
+            drop: 'PATCH',
+            reallocate: 'POST'
     ]
 
     PickTaskService pickTaskService
@@ -62,6 +63,20 @@ class PickTaskApiController extends RestfulController<PickTask> {
         }
 
         render([data: task.toJson()] as JSON)
+    }
+
+    def reallocate() {
+        def jsonBody = request.JSON ?: [:]
+
+        PickTask task = pickTaskService.get(params.id)
+        if (!task) {
+            render (status: HttpStatus.NOT_FOUND.value(), [errorCode: 404, message: "Pick task not found"] as JSON)
+            return
+        }
+
+        List<PickTask> newTasks = pickTaskService.reallocate(task, jsonBody.picklistItems as List)
+
+        render([data: newTasks.collect { it.toJson() }] as JSON)
     }
 
     def drop() {

--- a/grails-app/controllers/org/pih/warehouse/api/picking/PickUrlMappings.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/picking/PickUrlMappings.groovy
@@ -13,6 +13,11 @@ class PickUrlMappings {
             action = [GET: "read", PATCH: "patch"]
         }
 
+        "/api/facilities/$facility/pick-tasks/$id/reallocate" {
+            controller = "pickTaskApi"
+            action = [POST: "reallocate"]
+        }
+
         "/api/facilities/$facility/pick-tasks/containers/$outboundContainerId" {
             controller = "pickTaskApi"
             action = [PATCH: "drop"]

--- a/grails-app/domain/org/pih/warehouse/picking/PickTask.groovy
+++ b/grails-app/domain/org/pih/warehouse/picking/PickTask.groovy
@@ -87,6 +87,7 @@ class PickTask {
                 id              : id,
                 identifier      : identifier,
                 requisitionId   : requisition?.id,
+                requisitionItemId: requisitionItem?.id,
                 requisitionNumber : requisition?.requestNumber,
                 deliveryTypeCode: deliveryTypeCode?.name(),
                 dateRequested   : dateRequested,

--- a/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
+++ b/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
@@ -12,6 +12,7 @@ import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.DeliveryTypeCode
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.Person
+import org.pih.warehouse.inventory.InventoryItem
 import org.pih.warehouse.inventory.InventoryService
 import org.pih.warehouse.inventory.ProductAvailabilityService
 import org.pih.warehouse.inventory.StockMovementService
@@ -19,6 +20,7 @@ import org.pih.warehouse.inventory.Transaction
 import org.pih.warehouse.inventory.TransactionAction
 import org.pih.warehouse.inventory.TransactionSource
 import org.pih.warehouse.inventory.TransferStockCommand
+import org.pih.warehouse.picklist.Picklist
 import org.pih.warehouse.picklist.PicklistItem
 import org.pih.warehouse.picklist.PicklistService
 import org.pih.warehouse.requisition.Requisition
@@ -200,6 +202,53 @@ class PickTaskService {
         }
 
         save(task)
+    }
+
+    List<PickTask> reallocate(PickTask task, List picklistItems) {
+        if (!picklistItems) {
+            throw new IllegalArgumentException("Must specify picklistItems")
+        }
+
+        RequisitionItem requisitionItem = task.requisitionItem
+        if (!requisitionItem) {
+            throw new IllegalStateException("Pick task ${task.id} has no associated requisition item")
+        }
+
+        // Delete only the specific picklist item being reallocated (task.id === picklistItem.id)
+        PicklistItem currentPicklistItem = PicklistItem.get(task.id)
+        if (currentPicklistItem) {
+            Picklist picklist = currentPicklistItem.picklist
+            currentPicklistItem.disableRefresh = Boolean.TRUE
+            picklist?.removeFromPicklistItems(currentPicklistItem)
+            requisitionItem.removeFromPicklistItems(currentPicklistItem)
+            currentPicklistItem.delete(flush: true)
+        }
+
+        // Create new picklist items for each selected bin location
+        picklistItems.each { item ->
+            InventoryItem inventoryItem = item.inventoryItem?.id ?
+                    InventoryItem.get(item.inventoryItem.id) : null
+
+            Location binLocation = item.binLocation?.id ?
+                    Location.get(item.binLocation.id) : null
+
+            Integer quantityToPick = item.quantity ? new Integer(item.quantity) : null
+
+            stockMovementService.createOrUpdatePicklistItem(
+                    requisitionItem,
+                    null,
+                    inventoryItem,
+                    binLocation,
+                    0,
+                    null,
+                    null,
+                    false,
+                    quantityToPick
+            )
+        }
+
+        // Return newly created pick tasks for this requisition item
+        return PickTask.findAllByRequisitionItem(requisitionItem)
     }
 
     def drop(String outboundContainerId, Map data = [:]) {


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket: https://openboxes.atlassian.net/browse/OBLS-358**

**Description:**                                                      
  - Add POST `/api/facilities/{facility}/pick-tasks/{id}/reallocate` endpoint
  - Add `reallocate` method in PickTaskService that deletes only the specific picklist item
  being reallocated and creates new ones per selected bin location
  - Add `requisitionItemId` to `PickTask.toJson()` so mobile can fetch available items
  - New pick tasks are created with `quantityPicked=0` and `quantityToPick` set to the
  allocation quantity, matching mobile picking behavior

Before rellocation (1 pick task - qty required 2)
[pick_task_202603101627.json](https://github.com/user-attachments/files/25874867/pick_task_202603101627.json)
After rellocation: (2 pick tasks - qty required 1 each)
[pick_task_202603101628.json](https://github.com/user-attachments/files/25874883/pick_task_202603101628.json)


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
