### PR TITLE
OBPIH-7683 hash passwords when importing users

### DIFF
--- a/grails-app/services/org/pih/warehouse/importer/UserImportDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/importer/UserImportDataService.groovy
@@ -74,7 +74,7 @@ class UserImportDataService implements ImportDataService {
         if (!user) {
             user = new User(params)
             user.active = true
-            user.password = "password"
+            user.password = "password".encodeAsPassword()
         } else {
             user.properties = params
         }


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7683

**Description:** When importing users we weren't encoding the password. This change uses the same encoding mechanism that we use when users set their password normally
