### PR TITLE
OBPIH-6242 Display organization name as code and name across the UI

### DIFF
--- a/grails-app/domain/org/pih/warehouse/core/Organization.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Organization.groovy
@@ -49,7 +49,7 @@ class Organization extends Party {
     }
 
     String getDisplayName() {
-        return "${code} ${name}"
+        return "${code} - ${name}"
     }
 
     String toString() {

--- a/grails-app/domain/org/pih/warehouse/core/Organization.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Organization.groovy
@@ -30,6 +30,8 @@ class Organization extends Party {
 
     Map<IdentifierTypeCode, String> sequences
 
+    static transients = ['displayName']
+
     static mapping = {
         id generator: 'uuid'
         sequences joinTable: [key: 'sequences']
@@ -44,6 +46,10 @@ class Organization extends Party {
         description(nullable: true, maxSize: 255)
         defaultLocation(nullable: true)
         active(nullable: false)
+    }
+
+    String getDisplayName() {
+        return "${code} ${name}"
     }
 
     String toString() {
@@ -85,6 +91,7 @@ class Organization extends Party {
         return [
                 id             : id,
                 name           : name,
+                displayName    : displayName,
                 description    : description,
                 code           : code,
                 dateCreated    : dateCreated,

--- a/grails-app/domain/org/pih/warehouse/product/ProductSupplier.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/ProductSupplier.groovy
@@ -241,9 +241,7 @@ class ProductSupplier implements Serializable, Comparable<ProductSupplier> {
                 id: supplier?.id,
                 name: supplier?.name,
                 code: supplier?.code,
-                displayName: supplier?.name
-                        ? supplier.name + (supplier?.code ? " (${supplier.code})" : "")
-                        : ""
+                displayName: supplier?.displayName,
             ] : null,
             supplierCode: supplierCode,
             defaultProductPackage: defaultProductPackage ?: defaultProductPackageDerived,
@@ -272,6 +270,7 @@ class ProductSupplier implements Serializable, Comparable<ProductSupplier> {
             manufacturer: manufacturer ? [
                 id: manufacturer?.id,
                 name: manufacturer?.name,
+                displayName: manufacturer?.displayName,
             ] : null,
             description: description,
             manufacturerCode: manufacturerCode,

--- a/grails-app/views/invoice/_summary.gsp
+++ b/grails-app/views/invoice/_summary.gsp
@@ -9,7 +9,7 @@
             </g:hasRoleInvoice>
             <td>
                 <div class="title">
-                    ${invoiceInstance?.invoiceNumber} ${invoiceInstance?.party?.name} ${invoiceInstance?.vendorInvoiceNumber}
+                    ${invoiceInstance?.invoiceNumber} ${invoiceInstance?.party?.displayName} ${invoiceInstance?.vendorInvoiceNumber}
                 </div>
             </td>
             <td class="top right" width="1%">

--- a/grails-app/views/invoice/show.gsp
+++ b/grails-app/views/invoice/show.gsp
@@ -49,7 +49,7 @@
                                             <label><warehouse:message code="invoice.vendor.label"/></label>
                                         </td>
                                         <td valign="top" class="value">
-                                            ${invoiceInstance?.party?.code} ${invoiceInstance?.party?.name}
+                                            ${invoiceInstance?.party?.displayName}
                                         </td>
                                     </tr>
                                     <tr class="prop">
@@ -57,7 +57,7 @@
                                             <label><warehouse:message code="invoice.partyFrom.label"/></label>
                                         </td>
                                         <td valign="top" class="value">
-                                            ${invoiceInstance?.partyFrom?.name}
+                                            ${invoiceInstance?.partyFrom?.displayName}
                                         </td>
                                     </tr>
                                     <tr class="prop">

--- a/grails-app/views/order/print.gsp
+++ b/grails-app/views/order/print.gsp
@@ -44,7 +44,7 @@
             </div>
         </div>
         <div class="left">
-            ${orderInstance?.destinationParty?.name }
+            ${orderInstance?.destinationParty?.displayName}
             <g:if test="${orderInstance?.destinationParty?.defaultLocation?.address}">
                 <br/>
                 ${orderInstance?.destinationParty?.defaultLocation?.address?.address}<br/>
@@ -84,7 +84,7 @@
                         <label><warehouse:message code="purchaseOrder.buyer.label" default="Buyer"/></label>
                     </td>
                     <td class="top left">
-                        ${orderInstance?.destinationParty?.name}
+                        ${orderInstance?.destinationParty?.displayName}
                     </td>
                 </tr>
                 <tr>

--- a/grails-app/views/purchaseOrder/_enterOrderDetails.gsp
+++ b/grails-app/views/purchaseOrder/_enterOrderDetails.gsp
@@ -98,7 +98,7 @@
                             <tr class='prop'>
                                 <td class='name middle'><label><warehouse:message code="order.destinationParty.label"/></label></td>
                                 <td valign='top' class='value ${hasErrors(bean:order,field:'destinationParty','errors')}'>
-                                    ${order.destinationParty?.name} (${order.destinationParty?.code})
+                                    ${order.destinationParty?.displayName}
                                     <g:hiddenField name="destinationParty.id" value="${order?.destinationParty?.id}"/>
                                 </td>
                             </tr>

--- a/grails-app/views/supplier/show.gsp
+++ b/grails-app/views/supplier/show.gsp
@@ -14,7 +14,7 @@
             </g:if>
             <div>
                 <div style="border-width: 5px">
-                    <h2>${supplier?.name}</h2>
+                    <h2>${supplier?.displayName}</h2>
                     <g:each var="location" in="${supplier.locations.sort { it.name } }">
                         <div style="margin: 10px 0 10px 30px;">
                             <g:link controller="location" action="show" id="${location.id}">

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -539,7 +539,7 @@ export function fetchSuppliers({
               id: obj.id,
               value: obj.id,
               name: obj.name,
-              label: `${obj.name}`,
+              label: obj.displayName,
             }
           ));
           dispatch({
@@ -566,7 +566,7 @@ export function fetchBuyers(active = false) {
               id: obj.id,
               value: obj.id,
               name: obj.name,
-              label: `${obj.name}`,
+              label: obj.displayName,
             }
           ));
           dispatch({

--- a/src/js/components/invoice/list/FilterFields.jsx
+++ b/src/js/components/invoice/list/FilterFields.jsx
@@ -18,7 +18,7 @@ export default {
           id: organization.id,
           value: organization.id,
           name: organization.name,
-          label: organization.name,
+          label: organization.displayName,
         },
       ],
     }),

--- a/src/js/components/productSupplier/modals/PreferenceTypeModal.jsx
+++ b/src/js/components/productSupplier/modals/PreferenceTypeModal.jsx
@@ -52,7 +52,7 @@ const PreferenceTypeModal = ({
       preferenceTypes: [
         ...acc.preferenceTypes,
         {
-          destination: destinationParty?.name,
+          destination: destinationParty?.displayName,
           name,
         },
       ],
@@ -124,6 +124,7 @@ PreferenceTypeModal.propTypes = {
     destinationParty: PropTypes.shape({
       id: PropTypes.string.isRequired,
       name: PropTypes.string,
+      displayName: PropTypes.string,
       description: PropTypes.string,
       code: PropTypes.string,
       dateCreated: PropTypes.string,

--- a/src/js/hooks/list-pages/invoice/useInvoiceFilters.jsx
+++ b/src/js/hooks/list-pages/invoice/useInvoiceFilters.jsx
@@ -77,7 +77,7 @@ const useInvoiceFilters = ({ setFilterParams }) => {
         id: currentLocation?.organization?.id,
         value: currentLocation?.organization?.id,
         name: currentLocation?.organization?.name,
-        label: currentLocation?.organization?.name,
+        label: currentLocation?.organization?.displayName,
       },
     });
     setFiltersInitialized(true);

--- a/src/js/hooks/list-pages/productSupplier/useProductSupplierFilters.jsx
+++ b/src/js/hooks/list-pages/productSupplier/useProductSupplierFilters.jsx
@@ -77,7 +77,7 @@ const useProductSupplierFilters = (ignoreClearFilters) => {
     if (queryProps.supplier) {
       const supplier = await fetchOrganization(queryProps.supplier);
       if (supplier) {
-        supplier.label = `${supplier.code} ${supplier.name}`;
+        supplier.label = supplier.displayName;
         defaultValues.supplier = supplier;
       }
     }

--- a/src/js/hooks/productSupplier/form/useProductSupplierForm.js
+++ b/src/js/hooks/productSupplier/form/useProductSupplierForm.js
@@ -69,7 +69,7 @@ const useProductSupplierForm = () => {
           ? {
             id: productSupplier?.supplier?.id,
             value: productSupplier?.supplier?.id,
-            label: `${productSupplier?.supplier?.code} ${productSupplier?.supplier?.name}`,
+            label: productSupplier?.supplier?.displayName,
           } : undefined,
         supplierCode: productSupplier?.supplierCode ?? undefined,
         name: productSupplier?.name ?? undefined,
@@ -90,7 +90,7 @@ const useProductSupplierForm = () => {
           ? {
             id: productSupplier?.manufacturer.id,
             value: productSupplier?.manufacturer.id,
-            label: productSupplier?.manufacturer.name,
+            label: productSupplier?.manufacturer.displayName,
           }
           : undefined,
         ratingTypeCode: productSupplier?.ratingTypeCode
@@ -107,7 +107,7 @@ const useProductSupplierForm = () => {
         ...preferenceType,
         destinationParty: {
           id: preferenceType.destinationParty?.id,
-          label: preferenceType.destinationParty?.name,
+          label: preferenceType.destinationParty?.displayName,
           value: preferenceType.destinationParty?.id,
         },
         preferenceType: {

--- a/src/js/utils/option-utils.jsx
+++ b/src/js/utils/option-utils.jsx
@@ -194,7 +194,7 @@ export const debounceOrganizationsFetch = (waitTime, minSearchLength, roleTypes 
             value: obj.id,
             id: obj.id,
             name: obj.name,
-            label: `${obj.code} ${obj.name}`,
+            label: obj.displayName,
           }
         ))))
         .catch(() => callback([]));
@@ -230,7 +230,7 @@ export const organizationsFetch = (roleTypes = ['ROLE_SUPPLIER'], active = false
             id: obj.id,
             value: obj.id,
             name: obj.name,
-            label: `${obj.name}`,
+            label: obj.displayName,
           }
         ));
       }


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:**
https://pihemr.atlassian.net/browse/OBPIH-6242

**Description:**
Where I made changes:
  
  **Invoice**
  - create page -> Vendor dropdown
  - show page -> summary header + Vendor and Buyer organization fields
  - list page -> Vendor + Buyer Organization filters
  
  **Purchase Order**
  - create/edit -> Purchasing Organization field
  - pprint order view -> title and Buyer field
  
  **Product Source (Product Supplier)**
  - list page -> Supplier filter dropdown + Preference Type modal (click "Multiple" in Preference Type column)
  - create/edit form -> Supplier and Manufacturer dropdowns + Ogranization dropdown in Preference Type Variations section

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
