### PR TITLE
Add proposed Docker setup for OpenBoxes

### DIFF
--- a/docker-2026/.dockerignore
+++ b/docker-2026/.dockerignore
@@ -1,0 +1,5 @@
+README.md
+LICENSE
+.git
+.gitignore
+docker-compose.yml

--- a/docker-2026/.env.example
+++ b/docker-2026/.env.example
@@ -1,0 +1,19 @@
+# OpenBoxes Docker Configuration
+# Copy this file to .env and adjust values as needed
+
+# Database
+OPENBOXES_DB_HOST=mariadb
+OPENBOXES_DB_PORT=3306
+OPENBOXES_DB_NAME=openboxes
+OPENBOXES_DB_USERNAME=openboxes
+OPENBOXES_DB_PASSWORD=openboxes
+
+# The public URL where OpenBoxes will be accessible
+# Used for redirects and email links
+OPENBOXES_SERVER_URL=http://localhost:8080
+
+# MariaDB root password
+MARIADB_ROOT_PASSWORD=root
+
+# JVM memory (optional - override defaults)
+# EXTRA_CATALINA_OPTS=-Xmx2g

--- a/docker-2026/Dockerfile
+++ b/docker-2026/Dockerfile
@@ -1,0 +1,67 @@
+# OpenBoxes Docker Image
+# Runs OpenBoxes (open-source supply chain management) on Tomcat 9 with JDK 11
+#
+# Build:
+#   docker build -t openboxes .
+#   docker build --build-arg OPENBOXES_VERSION=v0.9.6-hotfix1 -t openboxes:0.9.6 .
+#
+# Run (with external database):
+#   docker run -d -p 8080:8080 \
+#     -e OPENBOXES_DB_HOST=mariadb \
+#     -e OPENBOXES_DB_NAME=openboxes \
+#     -e OPENBOXES_DB_USERNAME=openboxes \
+#     -e OPENBOXES_DB_PASSWORD=secret \
+#     openboxes
+
+FROM tomcat:9-jdk11-temurin
+
+LABEL org.opencontainers.image.title="OpenBoxes"
+LABEL org.opencontainers.image.description="Open-source supply chain management system"
+LABEL org.opencontainers.image.url="https://openboxes.com"
+LABEL org.opencontainers.image.source="https://github.com/openboxes/openboxes"
+LABEL org.opencontainers.image.licenses="EPL-1.0"
+
+# Remove default Tomcat webapps
+RUN rm -rf /usr/local/tomcat/webapps/*
+
+# Download OpenBoxes WAR from GitHub releases
+ARG OPENBOXES_VERSION=v0.9.6-hotfix1
+ADD https://github.com/openboxes/openboxes/releases/download/${OPENBOXES_VERSION}/openboxes.war \
+    /usr/local/tomcat/webapps/ROOT.war
+
+# Create directories for config, data, and logs
+RUN mkdir -p /app/data/uploads /app/data/documents /app/logs && \
+    chmod 644 /usr/local/tomcat/webapps/ROOT.war
+
+# Copy configuration template and entrypoint
+COPY openboxes-config.properties /app/config/openboxes-config.properties.template
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+# JVM tuning for OpenBoxes
+# OpenBoxes uses ~1.2-1.4GB during startup (Liquibase migrations), settling to ~1GB steady state.
+# Adjust -Xmx based on available memory. Minimum recommended: 1.5GB.
+ENV CATALINA_OPTS="-Xms512m -Xmx1536m \
+    -XX:+UseG1GC \
+    -XX:MaxGCPauseMillis=200 \
+    -XX:+HeapDumpOnOutOfMemoryError \
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager"
+
+# Database connection defaults (override at runtime)
+ENV OPENBOXES_DB_HOST="localhost" \
+    OPENBOXES_DB_PORT="3306" \
+    OPENBOXES_DB_NAME="openboxes" \
+    OPENBOXES_DB_USERNAME="openboxes" \
+    OPENBOXES_DB_PASSWORD="" \
+    OPENBOXES_SERVER_URL="http://localhost:8080"
+
+EXPOSE 8080
+
+# OpenBoxes takes 2-3 minutes to start on first run (Liquibase migrations).
+# start-period accounts for this; subsequent health checks are faster.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=300s --retries=3 \
+    CMD curl -sf http://localhost:8080/ || exit 1
+
+VOLUME ["/app/data"]
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-2026/README.md
+++ b/docker-2026/README.md
@@ -1,0 +1,252 @@
+# OpenBoxes Docker
+
+Run [OpenBoxes](https://openboxes.com) — open-source supply chain management — in Docker with minimal setup.
+
+## Quick Start
+
+The fastest way to get OpenBoxes running:
+
+```bash
+docker compose up -d
+```
+
+This starts OpenBoxes and a MariaDB database. On first startup, OpenBoxes runs database migrations (Liquibase) which takes **2-3 minutes**. You can monitor progress:
+
+```bash
+docker compose logs -f openboxes
+```
+
+Once you see `Server startup in [xxx] milliseconds`, open **http://localhost:8080** and log in with:
+
+- **Username:** `admin`
+- **Password:** `password`
+
+> **Important:** Change the default admin password immediately after first login.
+
+## Requirements
+
+- Docker Engine 20.10+ and Docker Compose v2
+- At least **2GB of RAM** available to Docker (OpenBoxes uses ~1.4GB during startup)
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OPENBOXES_DB_HOST` | `localhost` | MariaDB/MySQL hostname |
+| `OPENBOXES_DB_PORT` | `3306` | Database port |
+| `OPENBOXES_DB_NAME` | `openboxes` | Database name (created automatically) |
+| `OPENBOXES_DB_USERNAME` | `openboxes` | Database user |
+| `OPENBOXES_DB_PASSWORD` | *(empty)* | Database password |
+| `OPENBOXES_SERVER_URL` | `http://localhost:8080` | Public URL (used for redirects and email links) |
+| `EXTRA_CATALINA_OPTS` | *(empty)* | Additional JVM options (appended to defaults) |
+
+Copy `.env.example` to `.env` to customize:
+
+```bash
+cp .env.example .env
+# Edit .env with your values
+```
+
+### Using an External Database
+
+To connect to an existing MariaDB/MySQL instance instead of the bundled one:
+
+```bash
+docker run -d -p 8080:8080 \
+  -e OPENBOXES_DB_HOST=your-db-host \
+  -e OPENBOXES_DB_PORT=3306 \
+  -e OPENBOXES_DB_NAME=openboxes \
+  -e OPENBOXES_DB_USERNAME=openboxes \
+  -e OPENBOXES_DB_PASSWORD=your-password \
+  -e OPENBOXES_SERVER_URL=https://your-domain.com \
+  -v openboxes-data:/app/data \
+  openboxes
+```
+
+**Database requirements:**
+- MariaDB 10.x+ or MySQL 5.7+ (MariaDB 11 recommended)
+- The database specified in `OPENBOXES_DB_NAME` will be created automatically if it doesn't exist
+- The user needs `CREATE`, `ALTER`, `DROP`, `INSERT`, `UPDATE`, `DELETE`, `SELECT`, `INDEX`, `REFERENCES` privileges
+
+### Data Persistence
+
+The Docker Compose setup uses named volumes for persistence:
+
+| Volume | Mount Point | Contents |
+|--------|------------|----------|
+| `openboxes-data` | `/app/data` | Uploaded files and documents |
+| `mariadb-data` | `/var/lib/mysql` | Database files |
+
+To back up your data:
+
+```bash
+# Database backup
+docker compose exec mariadb mariadb-dump -u root -proot openboxes > backup.sql
+
+# File backup
+docker compose cp openboxes:/app/data ./data-backup
+```
+
+To restore:
+
+```bash
+# Database restore
+docker compose exec -T mariadb mariadb -u root -proot openboxes < backup.sql
+```
+
+### JVM Memory Tuning
+
+The default JVM settings allocate up to 1.5GB of heap memory. To adjust:
+
+```yaml
+# docker-compose.yml
+services:
+  openboxes:
+    environment:
+      EXTRA_CATALINA_OPTS: "-Xmx2g"
+```
+
+Or when using `docker run`:
+
+```bash
+docker run -e EXTRA_CATALINA_OPTS="-Xmx2g" ...
+```
+
+**Minimum recommended:** 1.5GB (`-Xmx1536m`)
+**For larger deployments:** 2-4GB (`-Xmx2g` to `-Xmx4g`)
+
+## Building a Specific Version
+
+To build an image for a different OpenBoxes release:
+
+```bash
+# Use any tag from https://github.com/openboxes/openboxes/releases
+docker build --build-arg OPENBOXES_VERSION=v0.9.6-hotfix1 -t openboxes:0.9.6 .
+```
+
+## Production Deployment
+
+For production use, make sure to:
+
+1. **Set strong passwords** for both MariaDB and the OpenBoxes admin user
+2. **Set `OPENBOXES_SERVER_URL`** to your public URL (required for correct redirects)
+3. **Use a reverse proxy** (nginx, Traefik, etc.) for TLS termination
+4. **Back up regularly** — both the database and the `/app/data` volume
+5. **Monitor disk space** — uploaded documents accumulate in `/app/data`
+
+### Example with TLS (nginx reverse proxy)
+
+```yaml
+# docker-compose.prod.yml
+version: "3.8"
+
+services:
+  openboxes:
+    build: .
+    environment:
+      OPENBOXES_DB_HOST: mariadb
+      OPENBOXES_DB_NAME: openboxes
+      OPENBOXES_DB_USERNAME: openboxes
+      OPENBOXES_DB_PASSWORD: ${DB_PASSWORD}
+      OPENBOXES_SERVER_URL: https://openboxes.example.com
+    volumes:
+      - openboxes-data:/app/data
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    restart: unless-stopped
+
+  mariadb:
+    image: mariadb:11
+    environment:
+      MARIADB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+      MARIADB_DATABASE: openboxes
+      MARIADB_USER: openboxes
+      MARIADB_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+    depends_on:
+      - openboxes
+    restart: unless-stopped
+
+volumes:
+  openboxes-data:
+  mariadb-data:
+```
+
+## Troubleshooting
+
+### OpenBoxes won't start / exits immediately
+
+Check the logs:
+```bash
+docker compose logs openboxes
+```
+
+Common causes:
+- **Database not ready:** OpenBoxes waits for MariaDB but if it takes too long, restart: `docker compose restart openboxes`
+- **Out of memory:** Increase Docker's memory limit to at least 2GB
+- **Port conflict:** Change the host port: `ports: ["9090:8080"]`
+
+### Liquibase lock error on startup
+
+If a container was killed during database migrations, Liquibase leaves a stale lock:
+
+```bash
+docker compose exec mariadb mariadb -u openboxes -popenboxes openboxes -e \
+  "UPDATE DATABASECHANGELOGLOCK SET LOCKED=0, LOCKGRANTED=NULL, LOCKEDBY=NULL WHERE ID=1;"
+docker compose restart openboxes
+```
+
+### First startup is very slow
+
+This is normal. Liquibase runs ~1000 database migration changesets on first startup, creating 125+ tables. Subsequent startups are much faster (30-60 seconds).
+
+### Cannot connect to database
+
+Verify the database is running and accessible:
+
+```bash
+docker compose exec mariadb mariadb -u openboxes -popenboxes -e "SELECT 1"
+```
+
+## Architecture
+
+```
+┌──────────────┐     ┌──────────────┐
+│   Browser    │────▶│   Tomcat 9   │
+│              │     │  (port 8080) │
+└──────────────┘     │              │
+                     │  OpenBoxes   │
+                     │   (WAR)     │
+                     └──────┬───────┘
+                            │
+                     ┌──────▼───────┐
+                     │  MariaDB 11  │
+                     │ (port 3306)  │
+                     └──────────────┘
+```
+
+OpenBoxes is a Grails application packaged as a WAR file, deployed on Tomcat 9 with JDK 11. It uses Liquibase for database migrations, which run automatically on startup.
+
+## License
+
+OpenBoxes is licensed under the [Eclipse Public License 1.0](https://www.eclipse.org/legal/epl-v10.html).

--- a/docker-2026/docker-compose.yml
+++ b/docker-2026/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.8"
+
+services:
+  openboxes:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      OPENBOXES_DB_HOST: mariadb
+      OPENBOXES_DB_PORT: "3306"
+      OPENBOXES_DB_NAME: openboxes
+      OPENBOXES_DB_USERNAME: openboxes
+      OPENBOXES_DB_PASSWORD: openboxes
+      OPENBOXES_SERVER_URL: http://localhost:8080
+    volumes:
+      - openboxes-data:/app/data
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    restart: unless-stopped
+
+  mariadb:
+    image: mariadb:11
+    environment:
+      MARIADB_ROOT_PASSWORD: root
+      MARIADB_DATABASE: openboxes
+      MARIADB_USER: openboxes
+      MARIADB_PASSWORD: openboxes
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+volumes:
+  openboxes-data:
+  mariadb-data:

--- a/docker-2026/docker-entrypoint.sh
+++ b/docker-2026/docker-entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+# OpenBoxes reads its config from ~/.grails/openboxes-config.properties
+CONFIG_DIR="${HOME}/.grails"
+mkdir -p "$CONFIG_DIR"
+
+# Process the config template, substituting environment variables
+cp /app/config/openboxes-config.properties.template "$CONFIG_DIR/openboxes-config.properties"
+
+sed -i "s|OPENBOXES_DB_HOST|${OPENBOXES_DB_HOST:-localhost}|g" "$CONFIG_DIR/openboxes-config.properties"
+sed -i "s|OPENBOXES_DB_PORT|${OPENBOXES_DB_PORT:-3306}|g" "$CONFIG_DIR/openboxes-config.properties"
+sed -i "s|OPENBOXES_DB_NAME|${OPENBOXES_DB_NAME:-openboxes}|g" "$CONFIG_DIR/openboxes-config.properties"
+sed -i "s|OPENBOXES_DB_USERNAME|${OPENBOXES_DB_USERNAME:-openboxes}|g" "$CONFIG_DIR/openboxes-config.properties"
+sed -i "s|OPENBOXES_DB_PASSWORD|${OPENBOXES_DB_PASSWORD:-}|g" "$CONFIG_DIR/openboxes-config.properties"
+sed -i "s|OPENBOXES_SERVER_URL|${OPENBOXES_SERVER_URL:-http://localhost:8080}|g" "$CONFIG_DIR/openboxes-config.properties"
+
+# Apply any additional connection pool settings
+if [ -n "$OPENBOXES_DB_MAX_ACTIVE" ]; then
+    sed -i "s|dataSource.properties.maxActive=.*|dataSource.properties.maxActive=${OPENBOXES_DB_MAX_ACTIVE}|g" "$CONFIG_DIR/openboxes-config.properties"
+fi
+
+# Allow CATALINA_OPTS override from environment
+if [ -n "$EXTRA_CATALINA_OPTS" ]; then
+    export CATALINA_OPTS="$CATALINA_OPTS $EXTRA_CATALINA_OPTS"
+fi
+
+echo "============================================"
+echo "  OpenBoxes starting..."
+echo "  Database: ${OPENBOXES_DB_HOST}:${OPENBOXES_DB_PORT}/${OPENBOXES_DB_NAME}"
+echo "  Server URL: ${OPENBOXES_SERVER_URL:-http://localhost:8080}"
+echo "============================================"
+
+# Start Tomcat
+exec catalina.sh run

--- a/docker-2026/openboxes-config.properties
+++ b/docker-2026/openboxes-config.properties
@@ -1,0 +1,33 @@
+# OpenBoxes Configuration
+# Placeholders are replaced by docker-entrypoint.sh at startup
+
+# Database connection
+dataSource.dbCreate=none
+dataSource.url=jdbc:mysql://OPENBOXES_DB_HOST:OPENBOXES_DB_PORT/OPENBOXES_DB_NAME?useSSL=false&autoReconnect=true&createDatabaseIfNotExist=true&characterEncoding=UTF-8
+dataSource.username=OPENBOXES_DB_USERNAME
+dataSource.password=OPENBOXES_DB_PASSWORD
+
+# Connection pool
+dataSource.properties.maxActive=50
+dataSource.properties.minIdle=5
+dataSource.properties.maxIdle=25
+dataSource.properties.maxWait=10000
+
+# Server URL (used for redirects and links in emails)
+grails.serverURL=OPENBOXES_SERVER_URL
+
+# Mail - disabled by default; configure via environment or override this file
+grails.mail.enabled=false
+
+# Security
+openboxes.security.enabled=true
+
+# Disable fixtures in production
+openboxes.fixtures.enabled=false
+
+# File storage (persisted via Docker volume at /app/data)
+openboxes.uploads.dir=/app/data/uploads
+openboxes.documents.dir=/app/data/documents
+
+# Logging
+grails.logging.jul.usebridge=false


### PR DESCRIPTION
## Summary
- Adds a `docker-2026/` directory with a complete Docker configuration for running OpenBoxes
- Includes Dockerfile (Tomcat 9 + JDK 11), docker-compose.yml (with MariaDB 11), entrypoint script, config template, `.env.example`, and `.dockerignore`
- Comprehensive README covering quick start, configuration, production deployment, and troubleshooting

## Details
This is a proposed new Docker setup for OpenBoxes. The configuration:
- Downloads the OpenBoxes WAR from GitHub releases and deploys it on Tomcat 9
- Uses environment variables for all database and server settings
- Includes health checks, JVM tuning defaults, and volume persistence for data and database
- Provides examples for external database usage, TLS/nginx reverse proxy, and JVM memory tuning

## Test plan
- [ ] Build the Docker image: `cd docker-2026 && docker build -t openboxes .`
- [ ] Run with docker-compose: `docker compose up -d`
- [ ] Verify OpenBoxes starts and is accessible at http://localhost:8080
- [ ] Verify database migrations complete successfully
- [ ] Test with an external database configuration