### PR TITLE
OBPIH-7765 importing multiple locations with the same new org should …

### DIFF
--- a/grails-app/services/org/pih/warehouse/core/OrganizationService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/OrganizationService.groovy
@@ -15,6 +15,8 @@ import org.apache.commons.lang.StringUtils
 @Transactional
 class OrganizationService {
 
+    private static final List<RoleType> SUPPLIER_ROLES = [RoleType.ROLE_SUPPLIER, RoleType.ROLE_MANUFACTURER]
+
     OrganizationIdentifierService organizationIdentifierService
 
     List selectOrganizations(ArrayList<RoleType> roleTypes, Boolean active = false, currentOrganizationId) {
@@ -60,34 +62,47 @@ class OrganizationService {
         return organization
     }
 
-    Organization findOrCreateOrganization(String name, String code=null, List<RoleType> roleTypes=[]) {
+    private Organization createOrUpdateOrganization(String name, String code, List<RoleType> roleTypes) {
         Organization organization = findOrganization(name, code)
         if (!organization) {
-            organization = new Organization()
-            organization.name = name
-            organization.partyType = PartyType.findByCode(Constants.DEFAULT_ORGANIZATION_CODE)
-            organization.code = code ?: organizationIdentifierService.generate(organization)
+            return createOrganization(name, code, roleTypes)
         }
-
-        if (roleTypes) {
-            roleTypes.each { RoleType roleType ->
-                if (!organization.hasRoleType(roleType)) {
-                    organization.addToRoles(new PartyRole(roleType: roleType))
-                }
-            }
-        }
-
-        if (organization.validate() && !organization.hasErrors()) {
-            organization.save()
-        }
-        return organization
+        return updateOrganization(organization, roleTypes)
     }
 
-    Organization saveOrganization(Organization organization) {
+    private Organization saveOrganization(Organization organization) {
         return organization.save(failOnError: true)
     }
 
-    Organization createOrganization(Organization organization) {
+    private void addRolesToOrganization(Organization organization, List<RoleType> roleTypes) {
+        if (!roleTypes) {
+            return
+        }
+
+        for (RoleType roleType in roleTypes) {
+            if (organization.hasRoleType(roleType)) {
+                continue
+            }
+            organization.addToRoles(new PartyRole(roleType: roleType))
+        }
+    }
+
+    /**
+     * Persists a new organization with all of the given roles
+     */
+    Organization createOrganization(String name, String code=null, List<RoleType> roleTypes=[]) {
+        Organization organization = new Organization(
+                name: name,
+                code: code,  // If this is null it will be auto-generated later
+        )
+        return createOrganization(organization, roleTypes)
+    }
+
+    /**
+     * Persists a new organization, populating it with any required default or auto-generated fields,
+     * and adding to it all of the given roles
+     */
+    Organization createOrganization(Organization organization, List<RoleType> roleTypes=[]) {
         if (!organization.code) {
             organization.code = organizationIdentifierService.generate(organization)
         }
@@ -96,11 +111,25 @@ class OrganizationService {
             organization.partyType = PartyType.findByCode(Constants.DEFAULT_ORGANIZATION_CODE)
         }
 
+        addRolesToOrganization(organization, roleTypes)
+
         return saveOrganization(organization)
     }
 
+    /**
+     * Updates an existing organization, adding to it all of the given roles
+     */
+    Organization updateOrganization(Organization organization, List<RoleType> roleTypes=[]) {
+        addRolesToOrganization(organization, roleTypes)
+        return saveOrganization(organization)
+    }
+
+    Organization createSupplierOrganization(String name, String code=null) {
+        return createOrganization(name, code, SUPPLIER_ROLES)
+    }
+
     Organization findOrCreateSupplierOrganization(String name, String code=null) {
-        return findOrCreateOrganization(name, code, [RoleType.ROLE_SUPPLIER, RoleType.ROLE_MANUFACTURER])
+        return createOrUpdateOrganization(name, code, SUPPLIER_ROLES)
     }
 
     List<Organization> getOrganizations(Map params) {

--- a/grails-app/services/org/pih/warehouse/importer/LocationImportDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/importer/LocationImportDataService.groovy
@@ -13,7 +13,6 @@ import grails.gorm.transactions.Transactional
 import grails.validation.ValidationException
 import org.pih.warehouse.LocalizationUtil
 import org.pih.warehouse.core.Address
-import org.pih.warehouse.core.OrganizationIdentifierService
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.LocationGroup
 import org.pih.warehouse.core.LocationType
@@ -25,7 +24,6 @@ import org.pih.warehouse.inventory.Inventory
 @Transactional
 class LocationImportDataService implements ImportDataService {
     OrganizationService organizationService
-    OrganizationIdentifierService organizationIdentifierService
 
     @Override
     void validateData(ImportDataCommand command) {
@@ -99,7 +97,7 @@ class LocationImportDataService implements ImportDataService {
             }
 
             if (organizations?.size() > 1) {
-                command.errors.reject("Row ${index + 1}: '${organizations.size()}' records found for organization name '${params.organization}'. Please specify by entering the organization code instead")
+                command.errors.reject("Row ${index + 1}: Organization identifier '${params.organization}' matches '${organizations.size()}' records. Please specify a unique organization code instead")
             }
 
             if (organizations && !organizations.first()?.active) {
@@ -115,15 +113,38 @@ class LocationImportDataService implements ImportDataService {
 
     @Override
     void importData(ImportDataCommand command) {
-        command.data.eachWithIndex { params, index ->
-            Location location = bindLocation(params)
+        List<Map> data = command.data
+
+        Map<Object, Organization> organizationsByIdentifier = bindExistingOrganizations(data)
+
+        for (Map params in data) {
+            Location location = bindLocation(params, organizationsByIdentifier)
             if (!location.validate() || !location.save(failOnError: true)) {
                 throw new ValidationException("Invalid location ${location.name}", location.errors)
             }
         }
     }
 
-    Location bindLocation(Map params) {
+    /**
+     * Binds all organizations that already exist in the db into a map keyed on the provided organization name or code.
+     *
+     * If the provided string does not match an existing organization, we do nothing. It will be created
+     * later when we bind the location.
+     */
+    private Map<Object, Organization> bindExistingOrganizations(List<Map> data) {
+        Map<String, Organization> organizationsByIdentifier = [:]
+        for (Map params in data) {
+            // The user can specify either the organization name or code, so make sure to look up by either
+            String identifier = params.organization
+            Organization organization = organizationService.findOrganization(identifier, identifier)
+            if (organization) {
+                organizationsByIdentifier.put(identifier, organization)
+            }
+        }
+        return organizationsByIdentifier
+    }
+
+    private Location bindLocation(Map params, Map<Object, Organization> organizationsByIdentifier) {
         Location location
         if (params.id) {
             location = Location.findById(params.id)
@@ -141,7 +162,6 @@ class LocationImportDataService implements ImportDataService {
         location.locationNumber = params.locationNumber
         location.locationGroup = params.locationGroup ? LocationGroup.findByName(params.locationGroup) : null
         location.parentLocation = params.parentLocation ? Location.findByNameOrLocationNumber(params.parentLocation, params.parentLocation) : null
-        location.organization = params.organization ? Organization.findByCodeOrName(params.organization, params.organization) : null
         location.address = bindAddress(params, location?.address?.id)
 
         if (!location.inventory && !location.parentLocation) {
@@ -169,10 +189,17 @@ class LocationImportDataService implements ImportDataService {
 
         // Add required association to organization for depots and suppliers
         if (!(location.locationType?.isInternalLocation() || location.locationType?.isZone()) && !location.organization) {
-            Organization organization = (location.locationType?.locationTypeCode == LocationTypeCode.SUPPLIER) ?
-                    organizationService.findOrCreateSupplierOrganization(params?.organization as String) :
-                    organizationService.findOrCreateOrganization(params?.organization as String)
 
+            // If the organization does not exist, we need to create it.
+            Organization organization = organizationsByIdentifier.get(params.organization)
+            if (!organization) {
+                organization = location.locationType?.locationTypeCode == LocationTypeCode.SUPPLIER ?
+                        organizationService.createSupplierOrganization(params.organization as String) :
+                        organizationService.createOrganization(params.organization as String)
+
+                // If the same, new organization appears multiple times in the import, we only want to create it once.
+                organizationsByIdentifier.put(params.organization, organization)
+            }
             location.organization = organization
         }
 

--- a/src/test/groovy/org/pih/warehouse/core/StringAbbreviatorSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/core/StringAbbreviatorSpec.groovy
@@ -33,6 +33,7 @@ class StringAbbreviatorSpec extends Specification {
         3       | 5       | null        | "***"                   || null         | "Special characters only is null"
         3       | 5       | null        | "1hi12hi"               || "1HI12"      | "Numbers allowed"
         3       | 5       | null        | " HI "                  || "HI"         | "Whitespace on ends is ignored"
+        2       | 5       | null        | "123 ship"              || "1S"         | "Number only words are allowed"
 
         // Verifying the default settings that we provide
         2       | 6       | ','         | "Do Re Me Fa So La Ti"  || "DRMFSL"     | "Too long, too many words becomes shortened acronym"


### PR DESCRIPTION
…only create one org

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7765

**Description:** When importing locations, if there were multiple rows that referenced the same, non-existing org, then each row was creating a new org, resulting in multiple copies of the same org.


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

The original bug: https://jam.dev/c/576ed727-bd2b-4b89-b523-4d11b33bfc6a

Now, importing multiple locations with the same new org only results in a single org being created:

https://github.com/user-attachments/assets/7b074642-3c7a-479f-b9a4-020a6b2e2f7a

