### PR TITLE
OBPIH-7773 add parser components for converting data types

### DIFF
--- a/grails-app/services/org/pih/warehouse/importer/ProductSupplierImportDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/importer/ProductSupplierImportDataService.groovy
@@ -81,7 +81,7 @@ class ProductSupplierImportDataService implements ImportDataService {
                 }
             }
 
-            if (params.ratingType && !EnumParser.parse(params.ratingType as String, RatingTypeCode)) {
+            if (params.ratingType && !EnumParser.parseString(params.ratingType as String, RatingTypeCode)) {
                 command.errors.reject("Row ${index + 1}: Rating Type with value '${params.ratingType}' does not exist")
             }
 
@@ -150,7 +150,7 @@ class ProductSupplierImportDataService implements ImportDataService {
                     minOrderQuantity: params.minOrderQuantity,
                     contractPricePrice: params.contractPricePrice ? BigDecimal.valueOf(params.contractPricePrice as double) : null,
                     contractPriceValidUntil: params.contractPriceValidUntil ?: null,
-                    ratingType: EnumParser.parse(params.ratingType as String, RatingTypeCode),
+                    ratingType: EnumParser.parseString(params.ratingType as String, RatingTypeCode),
                     globalPreferenceTypeName: sanitizeStringInput(params.globalPreferenceTypeName),
                     globalPreferenceTypeValidityStartDate: params.globalPreferenceTypeValidityStartDate ?: null,
                     globalPreferenceTypeValidityEndDate: params.globalPreferenceTypeValidityEndDate ?: null,

--- a/grails-app/services/org/pih/warehouse/importer/ProductSupplierImportDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/importer/ProductSupplierImportDataService.groovy
@@ -19,6 +19,7 @@ import org.pih.warehouse.core.PreferenceType
 import org.pih.warehouse.core.RatingTypeCode
 import org.pih.warehouse.core.RoleType
 import org.pih.warehouse.core.UnitOfMeasure
+import org.pih.warehouse.core.parser.ParserContext
 import org.pih.warehouse.data.ProductSupplierService
 import org.pih.warehouse.product.Product
 import org.pih.warehouse.product.ProductSupplier
@@ -135,7 +136,7 @@ class ProductSupplierImportDataService implements ImportDataService {
         command.data.each { params ->
             // Sanitize the raw import data into a strongly-typed command object
             ProductSupplierImportCommand productSupplierImportCommand = new ProductSupplierImportCommand(
-                    active: BooleanParser.parse(params.active as String, true),  // Default to active if left blank
+                    active: BooleanParser.parseString(params.active as String, new ParserContext<Boolean>(defaultValue: true)),
                     id: sanitizeStringInput(params.id),
                     code: sanitizeStringInput(params.code),
                     name: sanitizeStringInput(params.name),

--- a/src/main/groovy/org/pih/warehouse/core/date/AbstractDateParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/date/AbstractDateParser.groovy
@@ -3,6 +3,7 @@ package org.pih.warehouse.core.date
 import java.time.ZoneId
 import org.springframework.beans.factory.annotation.Autowired
 
+import org.pih.warehouse.core.parser.Parser
 import org.pih.warehouse.core.session.SessionManager
 
 /**
@@ -11,16 +12,10 @@ import org.pih.warehouse.core.session.SessionManager
  * For use only by data importers. Controllers should always use command objects containing date fields,
  * which can automatically handle data binding.
  */
-abstract class AbstractDateParser<T> {
+abstract class AbstractDateParser<T> extends Parser<T, DateParserContext<T>> {
 
     @Autowired
     SessionManager sessionManager
-
-    /**
-     * Deserializes a date object into a date type. Assumes the date is in the user's timezone if the given date
-     * does not have a timezone component.
-     */
-    abstract T parse(Object date, DateParserContext context=null)
 
     /**
      * @return ZoneId the timezone of the requesting user.

--- a/src/main/groovy/org/pih/warehouse/core/date/DateParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/date/DateParser.groovy
@@ -28,28 +28,28 @@ class DateParser {
     /**
      * Parses a given date object into an Instant.
      */
-    Instant parseToInstant(Object date, DateParserContext context=null) {
+    Instant parseToInstant(Object date, DateParserContext<Instant> context=null) {
         return instantParser.parse(date, context)
     }
 
     /**
      * Parses a given date object into a LocalDate.
      */
-    LocalDate parseToLocalDate(Object date, DateParserContext context=null) {
+    LocalDate parseToLocalDate(Object date, DateParserContext<LocalDate> context=null) {
         return localDateParser.parse(date, context)
     }
 
     /**
      * Parses a given date object into a ZonedDateTime.
      */
-    ZonedDateTime parseToZonedDateTime(Object date, DateParserContext context=null) {
+    ZonedDateTime parseToZonedDateTime(Object date, DateParserContext<ZonedDateTime> context=null) {
         return zonedDateTimeParser.parse(date, context)
     }
 
     /**
      * Parses a given date object into a java.util.Date.
      */
-    Date parseToDate(Object date, DateParserContext context=null) {
+    Date parseToDate(Object date, DateParserContext<Date> context=null) {
         return javaUtilDateParser.parse(date, context)
     }
 }

--- a/src/main/groovy/org/pih/warehouse/core/date/DateParserContext.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/date/DateParserContext.groovy
@@ -2,11 +2,13 @@ package org.pih.warehouse.core.date
 
 import org.apache.poi.ss.usermodel.Workbook
 
+import org.pih.warehouse.core.parser.ParserContext
+
 /**
  * Context object containing the configuration fields for parsing in dates.
  * For a majority of cases the default settings can be used and so this context object will not be required.
  */
-class DateParserContext {
+class DateParserContext<T> extends ParserContext<T> {
 
     /**
      * The .xlsx or .xls file used when importing via Excel.

--- a/src/main/groovy/org/pih/warehouse/core/date/InstantParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/date/InstantParser.groovy
@@ -22,7 +22,7 @@ import org.pih.warehouse.databinding.DataBindingConstants
 class InstantParser extends AbstractDateParser<Instant> {
 
     @Override
-    Instant parseImpl(Object date, DateParserContext<Instant> context=null) {
+    protected Instant parseImpl(Object date, DateParserContext<Instant> context) {
         switch (date) {
             case String:
                 return asInstant(date as String, currentTimezone, context)

--- a/src/main/groovy/org/pih/warehouse/core/date/InstantParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/date/InstantParser.groovy
@@ -22,7 +22,7 @@ import org.pih.warehouse.databinding.DataBindingConstants
 class InstantParser extends AbstractDateParser<Instant> {
 
     @Override
-    Instant parse(Object date, DateParserContext context=null) {
+    Instant parseImpl(Object date, DateParserContext<Instant> context=null) {
         switch (date) {
             case String:
                 return asInstant(date as String, currentTimezone, context)
@@ -38,8 +38,6 @@ class InstantParser extends AbstractDateParser<Instant> {
                 return asInstant(date as Date)
             case Calendar:
                 return asInstant(date as Calendar)
-            case null:
-                return null
             default:
                 throw new UnsupportedOperationException("Cannot parse date of type [${date.class}]")
         }
@@ -52,7 +50,7 @@ class InstantParser extends AbstractDateParser<Instant> {
      * @param excelDate An Excel formatted double representing a date
      * @param zone "Z", or "UTC" or "+01:00" or "America/Anchorage" for example.
      */
-    static Instant asInstant(Double excelDate, ZoneId zone, DateParserContext context) {
+    static Instant asInstant(Double excelDate, ZoneId zone, DateParserContext<Instant> context) {
         if (excelDate == null) {
             return null
         }
@@ -79,7 +77,7 @@ class InstantParser extends AbstractDateParser<Instant> {
      *
      * https://support.microsoft.com/en-us/office/date-systems-in-excel-e7fe7167-48a9-4b96-bb53-5612a800b487
      */
-    private static boolean use1904Windowing(DateParserContext context) {
+    private static boolean use1904Windowing(DateParserContext<Instant> context) {
         switch (context.excelWorkbook) {
             case XSSFWorkbook:  // .xlsx files
                 return (context.excelWorkbook as XSSFWorkbook).isDate1904()
@@ -103,7 +101,7 @@ class InstantParser extends AbstractDateParser<Instant> {
      *                    This will typically be the user's timezone. If null, will fail to bind date strings
      *                    that don't have a timezone component.
      */
-    static Instant asInstant(String date, ZoneId defaultZone=null, DateParserContext context=null) {
+    static Instant asInstant(String date, ZoneId defaultZone=null, DateParserContext<Instant> context=null) {
         if (StringUtils.isBlank(date)) {
             return null
         }

--- a/src/main/groovy/org/pih/warehouse/core/date/JavaUtilDateParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/date/JavaUtilDateParser.groovy
@@ -21,7 +21,7 @@ import org.pih.warehouse.databinding.DataBindingConstants
 class JavaUtilDateParser extends AbstractDateParser<Date> {
 
     @Override
-    Date parse(Object date, DateParserContext context=null) {
+    Date parseImpl(Object date, DateParserContext<Date> context=null) {
         switch (date) {
             case String:
                 return asDate(date as String)
@@ -31,8 +31,6 @@ class JavaUtilDateParser extends AbstractDateParser<Date> {
                 return asDate(date as ZonedDateTime)
             case LocalDate:
                 return asDate(date as LocalDate)
-            case null:
-                return null
             default:
                 throw new UnsupportedOperationException("Cannot parse date of type [${date.class}]")
         }

--- a/src/main/groovy/org/pih/warehouse/core/date/JavaUtilDateParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/date/JavaUtilDateParser.groovy
@@ -21,7 +21,7 @@ import org.pih.warehouse.databinding.DataBindingConstants
 class JavaUtilDateParser extends AbstractDateParser<Date> {
 
     @Override
-    Date parseImpl(Object date, DateParserContext<Date> context=null) {
+    protected Date parseImpl(Object date, DateParserContext<Date> context) {
         switch (date) {
             case String:
                 return asDate(date as String)

--- a/src/main/groovy/org/pih/warehouse/core/date/LocalDateParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/date/LocalDateParser.groovy
@@ -2,11 +2,9 @@ package org.pih.warehouse.core.date
 
 import java.time.LocalDate
 import java.time.ZoneId
-import java.time.ZoneOffset
 import org.apache.commons.lang.StringUtils
 import org.springframework.stereotype.Component
 
-import org.pih.warehouse.DateUtil
 import org.pih.warehouse.databinding.DataBindingConstants
 
 /**
@@ -18,14 +16,12 @@ import org.pih.warehouse.databinding.DataBindingConstants
 class LocalDateParser extends AbstractDateParser<LocalDate> {
 
     @Override
-    LocalDate parse(Object date, DateParserContext context=null) {
+    LocalDate parseImpl(Object date, DateParserContext<LocalDate> context=null) {
         switch (date) {
             case String:
                 return asLocalDate(date as String)
             case Date:
                 return asLocalDate(date as Date, currentTimezone)
-            case null:
-                return null
             default:
                 throw new UnsupportedOperationException("Cannot parse date of type [${date.class}]")
         }

--- a/src/main/groovy/org/pih/warehouse/core/date/LocalDateParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/date/LocalDateParser.groovy
@@ -16,7 +16,7 @@ import org.pih.warehouse.databinding.DataBindingConstants
 class LocalDateParser extends AbstractDateParser<LocalDate> {
 
     @Override
-    LocalDate parseImpl(Object date, DateParserContext<LocalDate> context=null) {
+    protected LocalDate parseImpl(Object date, DateParserContext<LocalDate> context) {
         switch (date) {
             case String:
                 return asLocalDate(date as String)

--- a/src/main/groovy/org/pih/warehouse/core/date/ZonedDateTimeParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/date/ZonedDateTimeParser.groovy
@@ -19,7 +19,7 @@ import org.pih.warehouse.databinding.DataBindingConstants
 class ZonedDateTimeParser extends AbstractDateParser<ZonedDateTime> {
 
     @Override
-    ZonedDateTime parseImpl(Object date, DateParserContext<ZonedDateTime> context=null) {
+    protected ZonedDateTime parseImpl(Object date, DateParserContext<ZonedDateTime> context) {
         switch (date) {
             case String:
                 return asZonedDateTime(date as String, currentTimezone)

--- a/src/main/groovy/org/pih/warehouse/core/date/ZonedDateTimeParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/date/ZonedDateTimeParser.groovy
@@ -19,7 +19,7 @@ import org.pih.warehouse.databinding.DataBindingConstants
 class ZonedDateTimeParser extends AbstractDateParser<ZonedDateTime> {
 
     @Override
-    ZonedDateTime parse(Object date, DateParserContext context=null) {
+    ZonedDateTime parseImpl(Object date, DateParserContext<ZonedDateTime> context=null) {
         switch (date) {
             case String:
                 return asZonedDateTime(date as String, currentTimezone)
@@ -31,8 +31,6 @@ class ZonedDateTimeParser extends AbstractDateParser<ZonedDateTime> {
                 return asZonedDateTime(date as Calendar, currentTimezone)
             case Date:
                 return asZonedDateTime(date as Date, currentTimezone)
-            case null:
-                return null
             default:
                 throw new UnsupportedOperationException("Cannot parse date of type [${date.class}]")
         }

--- a/src/main/groovy/org/pih/warehouse/core/parser/BigDecimalParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/BigDecimalParser.groovy
@@ -1,0 +1,48 @@
+package org.pih.warehouse.core.parser
+
+import org.apache.commons.lang.StringUtils
+import org.springframework.stereotype.Component
+
+/**
+ * For converting objects into BigDecimal types.
+ */
+@Component
+class BigDecimalParser extends Parser<BigDecimal, ParserContext<BigDecimal>> {
+
+    @Override
+    boolean isDefaultParserForType() {
+        return true
+    }
+
+    /**
+     * Converts the given String to a BigDecimal.
+     *
+     * Prefer the parse(Object) method when possible as it is much more flexible to variable input.
+     *
+     * @param toParse the String to convert
+     * @param context The context object containing information about how to parse the string
+     */
+    static BigDecimal parseString(String toParse, ParserContext<BigDecimal> context=null) {
+        if (StringUtils.isBlank(toParse)) {
+            return context?.defaultValue == null ? null : context.defaultValue
+        }
+
+        return toParse.toBigDecimal()
+    }
+
+    @Override
+    protected BigDecimal parseImpl(Object toParse, ParserContext<BigDecimal> context) {
+        switch (toParse) {
+            case String:
+                return parseString(toParse as String)
+            case Double:
+                return BigDecimal.valueOf(toParse)
+            case Long:
+                return BigDecimal.valueOf(toParse)
+            case BigDecimal:
+                return toParse
+            default:
+                return toParse as BigDecimal
+        }
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/parser/BigDecimalParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/BigDecimalParser.groovy
@@ -34,7 +34,7 @@ class BigDecimalParser extends Parser<BigDecimal, ParserContext<BigDecimal>> {
     protected BigDecimal parseImpl(Object toParse, ParserContext<BigDecimal> context) {
         switch (toParse) {
             case String:
-                return parseString(toParse as String)
+                return parseString(toParse as String, context)
             case Double:
                 return BigDecimal.valueOf(toParse)
             case Long:

--- a/src/main/groovy/org/pih/warehouse/core/parser/BigDecimalParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/BigDecimalParser.groovy
@@ -24,7 +24,7 @@ class BigDecimalParser extends Parser<BigDecimal, ParserContext<BigDecimal>> {
      */
     static BigDecimal parseString(String toParse, ParserContext<BigDecimal> context=null) {
         if (StringUtils.isBlank(toParse)) {
-            return context?.defaultValue == null ? null : context.defaultValue
+            return context?.defaultValue
         }
 
         return toParse.toBigDecimal()

--- a/src/main/groovy/org/pih/warehouse/core/parser/BooleanParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/BooleanParser.groovy
@@ -27,7 +27,7 @@ class BooleanParser extends Parser<Boolean, ParserContext<Boolean>> {
      */
     static Boolean parseString(String toParse, ParserContext<Boolean> context=null) {
         if (StringUtils.isBlank(toParse)) {
-            return context?.defaultValue == null ? null : context.defaultValue
+            return context?.defaultValue
         }
 
         String parsedValue = toParse.trim().toLowerCase()

--- a/src/main/groovy/org/pih/warehouse/core/parser/BooleanParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/BooleanParser.groovy
@@ -43,7 +43,7 @@ class BooleanParser extends Parser<Boolean, ParserContext<Boolean>> {
     protected Boolean parseImpl(Object toParse, ParserContext<Boolean> context) {
         switch (toParse) {
             case String:
-                return parseString(toParse as String)
+                return parseString(toParse as String, context)
             case Boolean:
                 return toParse
             default:

--- a/src/main/groovy/org/pih/warehouse/core/parser/BooleanParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/BooleanParser.groovy
@@ -1,29 +1,53 @@
 package org.pih.warehouse.core.parser
 
 import org.apache.commons.lang.StringUtils
+import org.springframework.stereotype.Component
 
 /**
- * For converting input objects (typically Strings) into Boolean types.
+ * For converting objects into Boolean types.
  */
-class BooleanParser {
+@Component
+class BooleanParser extends Parser<Boolean, ParserContext<Boolean>> {
 
     static final Set<String> VALID_BOOLEAN_VALUES = ['t', 'f', 'true', 'false', '1', '0', 'y', 'n', 'yes', 'no']
     static final Set<String> TRUE_BOOLEAN_VALUES = ['t', 'true', '1', 'y', 'yes']
 
+    @Override
+    boolean isDefaultParserForType() {
+        return true
+    }
+
     /**
-     * Converts the given string to a Boolean, defaulting to a given default if the given value is null or empty.
+     * Converts the given String to a Boolean.
+     *
+     * Prefer the parse(Object) method when possible as it is much more flexible to variable input.
+     *
+     * @param toParse the String to convert
+     * @param context The context object containing information about how to parse the string
      */
-    static Boolean parse(String value, Boolean defaultValue=null) {
-        if (StringUtils.isBlank(value)) {
-            return defaultValue
+    static Boolean parseString(String toParse, ParserContext<Boolean> context=null) {
+        if (StringUtils.isBlank(toParse)) {
+            return context?.defaultValue == null ? null : context.defaultValue
         }
 
-        String parsedValue = value.trim().toLowerCase()
+        String parsedValue = toParse.trim().toLowerCase()
 
         if (!(parsedValue in VALID_BOOLEAN_VALUES)) {
-            throw new IllegalArgumentException("Given string [${value}] is not a valid boolean value.")
+            throw new IllegalArgumentException("Given string [${toParse}] is not a valid boolean value.")
         }
 
         return parsedValue in TRUE_BOOLEAN_VALUES
+    }
+
+    @Override
+    protected Boolean parseImpl(Object toParse, ParserContext<Boolean> context) {
+        switch (toParse) {
+            case String:
+                return parseString(toParse as String)
+            case Boolean:
+                return toParse
+            default:
+                return toParse as Boolean
+        }
     }
 }

--- a/src/main/groovy/org/pih/warehouse/core/parser/DefaultTypeParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/DefaultTypeParser.groovy
@@ -1,0 +1,44 @@
+package org.pih.warehouse.core.parser
+
+import org.springframework.stereotype.Component
+
+/**
+ * A convenience wrapper on all of the default parser components.
+ */
+@Component
+class DefaultTypeParser {
+
+    /**
+     * Maps a type to the default parser associated with that type. For example, Integer : IntegerParser.
+     */
+    private final Map<Class, Parser> parsersByType = [:]
+
+    DefaultTypeParser(List<Parser> parsers) {
+        // Build the map of default parsers, keyed on the output type of the parser
+        for (Parser parser in parsers) {
+            if (!parser.isDefaultParserForType()) {
+                continue
+            }
+
+            Class type = parser.getTargetType()
+            if (parsersByType.containsKey(type)) {
+                throw new RuntimeException("Found multiple default parsers for type ${type}. Only one is allowed.")
+            }
+            parsersByType.put(type, parser)
+        }
+    }
+
+    /**
+     * Converts the given object to the given type using the default parser associated with that type.
+     * For example, if clazzToParseTo == Integer, this will parse using the IntegerParser.
+     *
+     * @throws IllegalArgumentException If the given type does not have a default parser.
+     */
+    public <T> T parse(Object toParse, Class<T> clazzToParseTo, ParserContext<T> context=null) {
+        Parser parser = parsersByType.get(clazzToParseTo)
+        if (!parser) {
+            throw new IllegalArgumentException("No default parser exists for class ${clazzToParseTo}")
+        }
+        return parser.parse(toParse, context) as T
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/parser/DoubleParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/DoubleParser.groovy
@@ -25,7 +25,7 @@ class DoubleParser extends Parser<Double, ParserContext<Double>> {
      */
     static Double parseString(String toParse, ParserContext<Double> context=null) {
         if (StringUtils.isBlank(toParse)) {
-            return context?.defaultValue == null ? null : context.defaultValue
+            return context?.defaultValue
         }
 
         return toParse.toDouble()

--- a/src/main/groovy/org/pih/warehouse/core/parser/DoubleParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/DoubleParser.groovy
@@ -1,0 +1,47 @@
+package org.pih.warehouse.core.parser
+
+import org.apache.commons.lang.StringUtils
+import org.springframework.stereotype.Component
+
+/**
+ * For converting objects into Double types.
+ */
+@Component
+class DoubleParser extends Parser<Double, ParserContext<Double>> {
+
+    @Override
+    boolean isDefaultParserForType() {
+        return true
+    }
+
+    /**
+     * Converts the given String to a Double.
+     *
+     * Prefer the parse(Object) method when possible as it is much more flexible to variable input.
+     *
+     * @param toParse the object to convert
+     * @param context The context object containing information about how to parse the string
+     *
+     */
+    static Double parseString(String toParse, ParserContext<Double> context=null) {
+        if (StringUtils.isBlank(toParse)) {
+            return context?.defaultValue == null ? null : context.defaultValue
+        }
+
+        return toParse.toDouble()
+    }
+
+    @Override
+    protected Double parseImpl(Object toParse, ParserContext<Double> context) {
+        switch (toParse) {
+            case String:
+                return parseString(toParse as String)
+            case BigDecimal:
+                return toParse.doubleValue()
+            case Double:
+                return toParse
+            default:
+                return toParse as Double
+        }
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/parser/DoubleParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/DoubleParser.groovy
@@ -35,7 +35,7 @@ class DoubleParser extends Parser<Double, ParserContext<Double>> {
     protected Double parseImpl(Object toParse, ParserContext<Double> context) {
         switch (toParse) {
             case String:
-                return parseString(toParse as String)
+                return parseString(toParse as String, context)
             case BigDecimal:
                 return toParse.doubleValue()
             case Double:

--- a/src/main/groovy/org/pih/warehouse/core/parser/EnumParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/EnumParser.groovy
@@ -21,7 +21,7 @@ class EnumParser<T extends Enum> extends Parser<T, ParserContext<T>> {
      */
     static T parseString(String toParse, Class<T> enumClass, ParserContext<T> context=null) {
         if (StringUtils.isBlank(toParse)) {
-            return context?.defaultValue == null ? null : context.defaultValue
+            return context?.defaultValue
         }
 
         // Because enum values are constants, the naming convention is for them to be uppercase so try that first.

--- a/src/main/groovy/org/pih/warehouse/core/parser/EnumParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/EnumParser.groovy
@@ -43,7 +43,8 @@ class EnumParser<T extends Enum> extends Parser<T, ParserContext<T>> {
 
     @Override
     protected T parseImpl(Object toParse, ParserContext<T> context) {
-        // This parser is generic for all enums, and so
+        // This parser is generic and can be used for any enum. Due to Java type erasure, this unfortunately means that
+        // we need to manually specify the Enum class that this parser resolves to.
         if (context.typeToParseTo == null) {
             throw new IllegalArgumentException("Due to type erasure, when parsing Enums you must either specify ParserContext.typeToParseTo, or use the static EnumParser.parseString method")
         }

--- a/src/main/groovy/org/pih/warehouse/core/parser/EnumParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/EnumParser.groovy
@@ -12,13 +12,14 @@ class EnumParser<T extends Enum> extends Parser<T, ParserContext<T>> {
     /**
      * Converts the given String to an instance of the given Enum.
      *
-     * Prefer the parse(Object) method when possible as it is much more flexible to variable input.
+     * Due to the complexities in resolving the enum type, in a majority of use cases, this method is likely
+     * preferred over the non-static parse(Object) method.
      *
      * @param toParse the object to convert
      * @param enumClass the class of the Enum that we are parsing into
      * @param context the context object containing information about how to parse the string
      */
-    static T parse(String toParse, Class<T> enumClass, ParserContext<T> context=null) {
+    static T parseString(String toParse, Class<T> enumClass, ParserContext<T> context=null) {
         if (StringUtils.isBlank(toParse)) {
             return context?.defaultValue == null ? null : context.defaultValue
         }
@@ -42,9 +43,14 @@ class EnumParser<T extends Enum> extends Parser<T, ParserContext<T>> {
 
     @Override
     protected T parseImpl(Object toParse, ParserContext<T> context) {
+        // This parser is generic for all enums, and so
+        if (context.typeToParseTo == null) {
+            throw new IllegalArgumentException("Due to type erasure, when parsing Enums you must either specify ParserContext.typeToParseTo, or use the static EnumParser.parseString method")
+        }
+
         switch (toParse) {
             case String:
-                return parse(toParse as String, targetType, context)
+                return parseString(toParse as String, context.typeToParseTo, context)
             default:
                 throw new IllegalArgumentException("Cannot parse given value [${toParse}] to the ${targetType} Enum")
         }

--- a/src/main/groovy/org/pih/warehouse/core/parser/EnumParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/EnumParser.groovy
@@ -1,34 +1,52 @@
 package org.pih.warehouse.core.parser
 
 import org.apache.commons.lang.StringUtils
+import org.springframework.stereotype.Component
 
 /**
- * For converting input objects (typically Strings) into Enum types.
+ * For converting objects into Enum types.
  */
-class EnumParser {
+@Component
+class EnumParser<T extends Enum> extends Parser<T, ParserContext<T>> {
 
     /**
-     * Converts the given string to an instance of the given Enum.
+     * Converts the given String to an instance of the given Enum.
+     *
+     * Prefer the parse(Object) method when possible as it is much more flexible to variable input.
+     *
+     * @param toParse the object to convert
+     * @param enumClass the class of the Enum that we are parsing into
+     * @param context the context object containing information about how to parse the string
      */
-    static <T extends Enum> T parse(String value, Class<T> enumClass) {
-        if (StringUtils.isBlank(value)) {
-            return null
+    static T parse(String toParse, Class<T> enumClass, ParserContext<T> context=null) {
+        if (StringUtils.isBlank(toParse)) {
+            return context?.defaultValue == null ? null : context.defaultValue
         }
 
         // Because enum values are constants, the naming convention is for them to be uppercase so try that first.
-        String valueSanitized = value.trim().toUpperCase()
+        String toParseSanitized = toParse.trim().toUpperCase()
         try {
-            return Enum.valueOf(enumClass, valueSanitized)
+            return Enum.valueOf(enumClass, toParseSanitized)
         } catch (IllegalArgumentException ignored) {
             // Do nothing
         }
 
         // In the rare case where we have an enum that is not uppercase, we can try a case-insensitive compare instead.
         for (T enumValue : enumClass.getEnumConstants()) {
-            if (enumValue.name().compareToIgnoreCase(valueSanitized) == 0) {
+            if (enumValue.name().compareToIgnoreCase(toParseSanitized) == 0) {
                 return enumValue
             }
         }
         return null
+    }
+
+    @Override
+    protected T parseImpl(Object toParse, ParserContext<T> context) {
+        switch (toParse) {
+            case String:
+                return parse(toParse as String, targetType)
+            default:
+                throw new IllegalArgumentException("Cannot parse given value [${toParse}] to the ${targetType} Enum")
+        }
     }
 }

--- a/src/main/groovy/org/pih/warehouse/core/parser/EnumParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/EnumParser.groovy
@@ -44,7 +44,7 @@ class EnumParser<T extends Enum> extends Parser<T, ParserContext<T>> {
     protected T parseImpl(Object toParse, ParserContext<T> context) {
         switch (toParse) {
             case String:
-                return parse(toParse as String, targetType)
+                return parse(toParse as String, targetType, context)
             default:
                 throw new IllegalArgumentException("Cannot parse given value [${toParse}] to the ${targetType} Enum")
         }

--- a/src/main/groovy/org/pih/warehouse/core/parser/IntegerParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/IntegerParser.groovy
@@ -1,0 +1,56 @@
+package org.pih.warehouse.core.parser
+
+import org.apache.commons.lang.StringUtils
+import org.springframework.stereotype.Component
+
+/**
+ * For converting objects into Integer types.
+ */
+@Component
+class IntegerParser extends Parser<Integer, ParserContext<Integer>> {
+
+    @Override
+    boolean isDefaultParserForType() {
+        return true
+    }
+
+    /**
+     * Converts the given String to an Integer.
+     *
+     * Prefer the parse(Object) method when possible as it is much more flexible to variable input.
+     *
+     * @param toParse the String to convert
+     * @param context The context object containing information about how to parse the string
+     */
+    static Integer parseString(String toParse, ParserContext<Integer> context=null) {
+        if (StringUtils.isBlank(toParse)) {
+            return context?.defaultValue == null ? null : context.defaultValue
+        }
+
+        try {
+            return toParse.toInteger()
+        } catch (NumberFormatException ignore) {
+            // The String.toInteger() method will error if given a String like "1.1" but since our default
+            // behaviour is to round down decimals, we allow stringified decimals to be converted to integers.
+            return toParse.toDouble().toInteger()
+        }
+    }
+
+    @Override
+    protected Integer parseImpl(Object toParse, ParserContext<Integer> context) {
+        switch (toParse) {
+            case String:
+                return parseString(toParse as String)
+            case Double:
+                return toParse.toInteger()
+            case Long:
+                return toParse.toInteger()
+            case BigDecimal:
+                return toParse.toInteger()
+            case Integer:
+                return toParse
+            default:
+                return toParse as Integer
+        }
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/parser/IntegerParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/IntegerParser.groovy
@@ -24,7 +24,7 @@ class IntegerParser extends Parser<Integer, ParserContext<Integer>> {
      */
     static Integer parseString(String toParse, ParserContext<Integer> context=null) {
         if (StringUtils.isBlank(toParse)) {
-            return context?.defaultValue == null ? null : context.defaultValue
+            return context?.defaultValue
         }
 
         try {

--- a/src/main/groovy/org/pih/warehouse/core/parser/IntegerParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/IntegerParser.groovy
@@ -40,7 +40,7 @@ class IntegerParser extends Parser<Integer, ParserContext<Integer>> {
     protected Integer parseImpl(Object toParse, ParserContext<Integer> context) {
         switch (toParse) {
             case String:
-                return parseString(toParse as String)
+                return parseString(toParse as String, context)
             case Double:
                 return toParse.toInteger()
             case Long:

--- a/src/main/groovy/org/pih/warehouse/core/parser/ListOfIntegerParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/ListOfIntegerParser.groovy
@@ -1,0 +1,21 @@
+package org.pih.warehouse.core.parser
+
+import org.springframework.stereotype.Component
+
+/**
+ * For converting input objects into a List of Integer types.
+ */
+@Component
+class ListOfIntegerParser extends ListParser<Integer> {
+
+    IntegerParser integerParser
+
+    ListOfIntegerParser(IntegerParser integerParser) {
+        this.integerParser = integerParser
+    }
+
+    @Override
+    protected Parser<Integer, ParserContext> getListElementParser() {
+        return integerParser
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/parser/ListOfStringParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/ListOfStringParser.groovy
@@ -1,0 +1,27 @@
+package org.pih.warehouse.core.parser
+
+import org.springframework.stereotype.Component
+
+/**
+ * For converting input objects into a List of String types.
+ */
+@Component
+class ListOfStringParser extends ListParser<String> {
+
+    StringParser stringParser
+
+    ListOfStringParser(StringParser stringParser) {
+        this.stringParser = stringParser
+    }
+
+    @Override
+    boolean isDefaultParserForType() {
+        // Due to type erasure, this is the default for *all* list parsers, not just lists of Strings.
+        return true
+    }
+
+    @Override
+    protected Parser<String, ParserContext> getListElementParser() {
+        return stringParser
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/parser/ListParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/ListParser.groovy
@@ -1,0 +1,69 @@
+package org.pih.warehouse.core.parser
+
+import org.apache.commons.lang.StringUtils
+
+/**
+ * For converting input objects into a List of objects.
+ */
+abstract class ListParser<T> extends Parser<List<T>, ListParserContext<T>> {
+
+    /**
+     * Returns an instance of the parser to use when parsing the individual elements of the list.
+     */
+    protected abstract Parser<T, ParserContext> getListElementParser()
+
+    private List<T> getDefaultValue(ListParserContext<T> context) {
+        if (context?.defaultValue == null) {
+            return null
+        }
+        return context?.defaultValue as List<T>
+    }
+
+    /**
+     * Converts the given String to a List.
+     */
+    private List<T> parseString(String toParse, ListParserContext<T> context=null) {
+        if (StringUtils.isBlank(toParse)) {
+            return getDefaultValue(context)
+        }
+
+        // Filters out blank and invalid elements. For example, if given " , , x,  y , ,, " it will output [x, y]
+        return toParse.split(context?.delimiter)
+                .findAll { StringUtils.isNotBlank(it) }
+                .collect { listElementParser.parse(it?.trim(), context?.listElementParserContext) }
+                .findAll { it != null }
+    }
+
+    /**
+     * Converts the given Collection to a List.
+     */
+    private List<T> parseCollection(Collection toParse, ListParserContext<T> context=null) {
+        if (!toParse) {
+            return getDefaultValue(context)
+        }
+
+        // Filters out blank and invalid elements. For example, if given [, , x,  y , ,, ] it will output [x, y]
+        return toParse.collect { listElementParser.parse(it, context?.listElementParserContext) }
+                .findAll { it != null }
+    }
+
+    /**
+     * Converts the given object into a singleton List of the parsed type.
+     */
+    private List<T> parseSingleElement(Object toParse, ListParserContext<T> context) {
+        T result = listElementParser.parse(toParse, context.listElementParserContext)
+        return result == null ? getDefaultValue(context) : [result]
+    }
+
+    @Override
+    List<T> parseImpl(Object toParse, ListParserContext<T> context) {
+        switch (toParse) {
+            case String:
+                return parseString(toParse as String, context)
+            case Collection:
+                return parseCollection(toParse, context)
+            default:
+                return parseSingleElement(toParse, context)
+        }
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/parser/ListParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/ListParser.groovy
@@ -13,9 +13,6 @@ abstract class ListParser<T> extends Parser<List<T>, ListParserContext<T>> {
     protected abstract Parser<T, ParserContext> getListElementParser()
 
     private List<T> getDefaultValue(ListParserContext<T> context) {
-        if (context?.defaultValue == null) {
-            return null
-        }
         return context?.defaultValue as List<T>
     }
 

--- a/src/main/groovy/org/pih/warehouse/core/parser/ListParserContext.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/ListParserContext.groovy
@@ -1,0 +1,19 @@
+package org.pih.warehouse.core.parser
+
+import org.pih.warehouse.core.Constants
+
+/**
+ * Context object for use when parsing lists.
+ */
+class ListParserContext<T> extends ParserContext<List<T>> {
+
+    /**
+     * The character(s) that separate the elements of the list.
+     */
+    String delimiter = Constants.DEFAULT_COLUMN_SEPARATOR
+
+    /**
+     * The context object to use when parsing the individual list entries.
+     */
+    ParserContext<T> listElementParserContext
+}

--- a/src/main/groovy/org/pih/warehouse/core/parser/Parser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/Parser.groovy
@@ -1,0 +1,78 @@
+package org.pih.warehouse.core.parser
+
+import org.springframework.core.GenericTypeResolver
+
+/**
+ * For converting input objects to a certain type.
+ */
+abstract class Parser<Type, Context extends ParserContext<Type>> {
+
+    /**
+     * Contains the actual logic for converting the given object to the type associated with the parser.
+     * Does not need to handle errors or default values. This will be done automatically.
+     */
+    abstract protected Type parseImpl(Object toParse, Context context)
+
+    /**
+     * Returns true if we should default to using this parser when converting to the given output type.
+     *
+     * Any default parser must override this method to return true. Only one parser is allowed to be the default
+     * for each type. Defining multiple will cause a startup error.
+     *
+     * It should generally be quite clear what the default parser should be for any type, because it will typically
+     * be named as such. For example, StringParser is the default parser for Strings.
+     *
+     * This functionality is what allows the DefaultTypeParser to function. For it to work, the DefaultTypeParser
+     * needs to be able to associate each output type with a single parser, but there can exist multiple
+     * parsers that output to the same type. For example, StringParser and EmailParser both output Strings.
+     * Because of this, we define one (and *only* one) parser as the default parser for each output type. That way,
+     * if we call DefaultTypeParser.parse(obj, String), it'll know to use StringParser, and not EmailParser.
+     */
+    boolean isDefaultParserForType() {
+        return false
+    }
+
+    /**
+     * Returns the type that the parser converts the input into.
+     */
+    Class<Type> getTargetType() {
+        return (Class<Type>) GenericTypeResolver.resolveTypeArguments(getClass(), Parser.class)[0]
+    }
+
+    /**
+     * Returns the type of the context object that we will use when parsing.
+     */
+    Class<Context> getContextType() {
+        return (Class<Context>) GenericTypeResolver.resolveTypeArguments(getClass(), Parser.class)[1]
+    }
+
+    /**
+     * Constructs a context object containing all default values.
+     * For use primarily when no context is specified for the parse.
+     */
+    private Context getDefaultContext() {
+        return getContextType().newInstance() as Context
+    }
+
+    /**
+     * Converts the given object to the type associated with the parser.
+     */
+    Type parse(Object toParse, Context context=null) {
+        Context contextToUse = context ?: getDefaultContext()
+
+        if (toParse == null) {
+            return contextToUse.defaultValue
+        }
+
+        try {
+            Type parsedValue = parseImpl(toParse, contextToUse)
+            // If the parsing returns null, we assume toParse is null-like, and so return the default value
+            return parsedValue == null ? contextToUse.defaultValue : parsedValue
+        } catch (Exception e) {
+            if (contextToUse.errorOnParseFailure) {
+                throw (e)
+            }
+            return null
+        }
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/parser/ParserContext.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/ParserContext.groovy
@@ -15,4 +15,15 @@ class ParserContext<T> {
      * True if we should throw an error if parsing fails. Otherwise will return null.
      */
     Boolean errorOnParseFailure = true
+
+    /**
+     * The class type that the parser outputs. Needed in certain scenarios due to Java type erasure.
+     *
+     * This field is only required if the parser has a non-concrete generic type. For example, in EnumParser<T>,
+     * even if you define new EnumParser<SomeType>(), the type of "SomeType" cannot be determined at runtime.
+     *
+     * However, in the case of StringParser extends Parser<String, ParserContext<String>>, because String parser
+     * concretely defines T to always be String, the type can be resolved automagically (see Parser.getTargetType()).
+     */
+    Class<T> typeToParseTo
 }

--- a/src/main/groovy/org/pih/warehouse/core/parser/ParserContext.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/ParserContext.groovy
@@ -1,0 +1,18 @@
+package org.pih.warehouse.core.parser
+
+/**
+ * Base context object containing any contextual information required when parsing fields.
+ * A majority of cases require only the default parser behaviour so this context object will often not be required.
+ */
+class ParserContext<T> {
+
+    /**
+     * The default value to return if the object being parsed is null.
+     */
+    T defaultValue = null
+
+    /**
+     * True if we should throw an error if parsing fails. Otherwise will return null.
+     */
+    Boolean errorOnParseFailure = true
+}

--- a/src/main/groovy/org/pih/warehouse/core/parser/StringParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/StringParser.groovy
@@ -24,7 +24,7 @@ class StringParser extends Parser<String, ParserContext<String>> {
      */
     static String parseString(String toParse, ParserContext<String> context=null) {
         if (StringUtils.isBlank(toParse)) {
-            return context?.defaultValue == null ? null : context.defaultValue
+            return context?.defaultValue
         }
 
         return toParse.trim()

--- a/src/main/groovy/org/pih/warehouse/core/parser/StringParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/StringParser.groovy
@@ -1,0 +1,42 @@
+package org.pih.warehouse.core.parser
+
+import org.apache.commons.lang.StringUtils
+import org.springframework.stereotype.Component
+
+/**
+ * For converting objects into String types.
+ */
+@Component
+class StringParser extends Parser<String, ParserContext<String>> {
+
+    @Override
+    boolean isDefaultParserForType() {
+        return true
+    }
+
+    /**
+     * Sanitizes the given String.
+     *
+     * Prefer the parse(Object) method when possible as it is much more flexible to variable input.
+     *
+     * @param toParse the String to convert
+     * @param context The context object containing information about how to parse the string
+     */
+    static String parse(String toParse, ParserContext<String> context=null) {
+        if (StringUtils.isBlank(toParse)) {
+            return context?.defaultValue == null ? null : context.defaultValue
+        }
+
+        return toParse.trim()
+    }
+
+    @Override
+    protected String parseImpl(Object toParse, ParserContext context) {
+        switch (toParse) {
+            case String:
+                return parse(toParse as String)
+            default:
+                return toParse.toString()
+        }
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/parser/StringParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/StringParser.groovy
@@ -22,7 +22,7 @@ class StringParser extends Parser<String, ParserContext<String>> {
      * @param toParse the String to convert
      * @param context The context object containing information about how to parse the string
      */
-    static String parse(String toParse, ParserContext<String> context=null) {
+    static String parseString(String toParse, ParserContext<String> context=null) {
         if (StringUtils.isBlank(toParse)) {
             return context?.defaultValue == null ? null : context.defaultValue
         }
@@ -34,7 +34,7 @@ class StringParser extends Parser<String, ParserContext<String>> {
     protected String parseImpl(Object toParse, ParserContext context) {
         switch (toParse) {
             case String:
-                return parse(toParse as String, context)
+                return parseString(toParse as String, context)
             default:
                 return toParse.toString()
         }

--- a/src/main/groovy/org/pih/warehouse/core/parser/StringParser.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/parser/StringParser.groovy
@@ -34,7 +34,7 @@ class StringParser extends Parser<String, ParserContext<String>> {
     protected String parseImpl(Object toParse, ParserContext context) {
         switch (toParse) {
             case String:
-                return parse(toParse as String)
+                return parse(toParse as String, context)
             default:
                 return toParse.toString()
         }

--- a/src/test/groovy/org/pih/warehouse/core/date/InstantParserSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/core/date/InstantParserSpec.groovy
@@ -2,6 +2,7 @@ package org.pih.warehouse.core.date
 
 import java.text.SimpleDateFormat
 import java.time.DateTimeException
+import java.time.Instant
 import java.time.LocalDate
 import java.time.ZonedDateTime
 import java.time.format.DateTimeParseException
@@ -164,7 +165,7 @@ class InstantParserSpec extends Specification {
         sessionManagerStub.timezone >> TimeZone.getTimeZone(timezoneOfDate)
 
         and: 'no workbook (which defaults to the windows 1900 based date system)'
-        DateParserContext context = new DateParserContext(excelWorkbook: null)
+        DateParserContext<Instant> context = new DateParserContext(excelWorkbook: null)
 
         expect:
         assert instantParser.parse(givenDate, context).toString() == expectedConvertedDate

--- a/src/test/groovy/org/pih/warehouse/core/parser/BigDecimalParserSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/core/parser/BigDecimalParserSpec.groovy
@@ -1,0 +1,61 @@
+package org.pih.warehouse.core.parser
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class BigDecimalParserSpec extends Specification {
+
+    @Shared
+    BigDecimalParser parser
+
+    void setup() {
+        parser = new BigDecimalParser()
+    }
+
+    void "parse should return #expectedResult when given #toParse and a defaultValue of #defaultValue"() {
+        given:
+        ParserContext<BigDecimal> context = new ParserContext(
+                defaultValue: defaultValue,
+                errorOnParseFailure: false,
+        )
+
+        expect:
+        assert parser.parse(toParse, context) == expectedResult
+
+        where:
+        toParse | defaultValue || expectedResult
+        null    | null         || null
+        null    | 0.0          || 0.0
+        1.1     | null         || 1.1
+        1.1d    | null         || 1.1
+        1       | null         || 1.0
+        1l      | null         || 1.0
+        "1"     | null         || 1
+        "1.1"   | null         || 1.1
+        "-1.1"  | null         || -1.1
+        ""      | null         || null
+        "bad"   | null         || null
+        "bad"   | 0.0          || null
+    }
+
+    void "parse should error when errorOnParseFailure==true and given #toParse and a defaultValue of #defaultValue"() {
+        given:
+        ParserContext<BigDecimal> context = new ParserContext(
+                defaultValue: defaultValue,
+                errorOnParseFailure: true,
+        )
+
+        when:
+        parser.parse(toParse, context)
+
+        then:
+        thrown(expectedException)
+
+        where:
+        toParse | defaultValue || expectedException
+        "bad"   | null         || NumberFormatException
+        "bad"   | 0.0          || NumberFormatException
+    }
+}

--- a/src/test/groovy/org/pih/warehouse/core/parser/BooleanParserSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/core/parser/BooleanParserSpec.groovy
@@ -1,0 +1,61 @@
+package org.pih.warehouse.core.parser
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class BooleanParserSpec extends Specification {
+
+    @Shared
+    BooleanParser parser
+
+    void setup() {
+        parser = new BooleanParser()
+    }
+
+    void "parse should return #expectedResult when given #toParse and a defaultValue of #defaultValue"() {
+        given:
+        ParserContext<Boolean> context = new ParserContext(
+                defaultValue: defaultValue,
+                errorOnParseFailure: false,
+        )
+
+        expect:
+        assert parser.parse(toParse, context) == expectedResult
+
+        where:
+        toParse | defaultValue || expectedResult
+        null    | null         || null
+        null    | false        || false
+        true    | null         || true
+        1       | null         || true
+        "true"  | null         || true
+        "t"     | null         || true
+        "1"     | null         || true
+        "y"     | null         || true
+        "yes"   | null         || true
+        ""      | null         || null
+        "bad"   | null         || null
+        "bad"   | false        || null
+    }
+
+    void "parse should error when errorOnParseFailure==true and given #toParse and a defaultValue of #defaultValue"() {
+        given:
+        ParserContext<Boolean> context = new ParserContext(
+                defaultValue: defaultValue,
+                errorOnParseFailure: true,
+        )
+
+        when:
+        parser.parse(toParse, context)
+
+        then:
+        thrown(expectedException)
+
+        where:
+        toParse | defaultValue || expectedException
+        "bad"   | null         || IllegalArgumentException
+        "bad"   | false        || IllegalArgumentException
+    }
+}

--- a/src/test/groovy/org/pih/warehouse/core/parser/DefaultTypeParserSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/core/parser/DefaultTypeParserSpec.groovy
@@ -1,0 +1,51 @@
+package org.pih.warehouse.core.parser
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class DefaultTypeParserSpec extends Specification {
+
+    @Shared
+    DefaultTypeParser parser
+
+    void setup() {
+        parser = new DefaultTypeParser([
+                // We're testing the DefaultTypeParser, not the individual parsers, so we only need to add
+                // enough parsers for us to be able to test a few edge cases
+                new IntegerParser(),
+                new StringParser(),
+        ])
+    }
+
+    void "parse should return #expectedResult when given #toParse and a defaultValue of #defaultValue"() {
+        given:
+        ParserContext context = new ParserContext(
+                defaultValue: defaultValue,
+                errorOnParseFailure: true,
+        )
+
+        expect:
+        assert parser.parse(toParse, typeToParseTo, context) == expectedResult
+
+        where:
+        toParse | typeToParseTo | defaultValue || expectedResult
+        null    | Integer       | null         || null
+        null    | Integer       | 0            || 0
+        null    | String        | null         || null
+        null    | String        | ""           || ""
+        1       | Integer       | null         || 1
+        "1"     | Integer       | null         || 1
+        "hi"    | String        | null         || "hi"
+        1       | String        | null         || "1"
+    }
+
+    void "parse should error when parsing a type that does not have a default"() {
+        when: "given a type that the DefaultTypeParser doesn't know about"
+        parser.parse("1.0", Double)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+}

--- a/src/test/groovy/org/pih/warehouse/core/parser/DoubleParserSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/core/parser/DoubleParserSpec.groovy
@@ -1,0 +1,61 @@
+package org.pih.warehouse.core.parser
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class DoubleParserSpec extends Specification {
+
+    @Shared
+    DoubleParser parser
+
+    void setup() {
+        parser = new DoubleParser()
+    }
+
+    void "parse should return #expectedResult when given #toParse and a defaultValue of #defaultValue"() {
+        given:
+        ParserContext<Double> context = new ParserContext(
+                defaultValue: defaultValue,
+                errorOnParseFailure: false,
+        )
+
+        expect:
+        assert parser.parse(toParse, context) == expectedResult
+
+        where:
+        toParse | defaultValue || expectedResult
+        null    | null         || null
+        null    | 0.0d         || 0.0d
+        1.1     | null         || 1.1d
+        1.1d    | null         || 1.1d
+        1       | null         || 1.0d
+        1l      | null         || 1.0d
+        "1"     | null         || 1.0d
+        "1.1"   | null         || 1.1d
+        "-1.1"  | null         || -1.1d
+        ""      | null         || null
+        "bad"   | null         || null
+        "bad"   | 0.0d         || null
+    }
+
+    void "parse should error when errorOnParseFailure==true and given #toParse and a defaultValue of #defaultValue"() {
+        given:
+        ParserContext<Double> context = new ParserContext(
+                defaultValue: defaultValue,
+                errorOnParseFailure: true,
+        )
+
+        when:
+        parser.parse(toParse, context)
+
+        then:
+        thrown(expectedException)
+
+        where:
+        toParse | defaultValue || expectedException
+        "bad"   | null         || NumberFormatException
+        "bad"   | 0.0d         || NumberFormatException
+    }
+}

--- a/src/test/groovy/org/pih/warehouse/core/parser/EnumParserSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/core/parser/EnumParserSpec.groovy
@@ -1,0 +1,68 @@
+package org.pih.warehouse.core.parser
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import org.pih.warehouse.api.PutawayStatus
+
+@Unroll
+class EnumParserSpec extends Specification {
+
+    @Shared
+    EnumParser parser
+
+    void setup() {
+        parser = new EnumParser<PutawayStatus>()
+    }
+
+    void "parse should return #expectedResult when given #toParse and a defaultValue of #defaultValue"() {
+        expect:
+        assert parser.parse(toParse, PutawayStatus) == expectedResult
+
+        where:
+        toParse || expectedResult
+        null    || null
+        ""      || null
+        " "     || null
+        "READY" || PutawayStatus.READY
+        "rEaDy" || PutawayStatus.READY
+    }
+
+    void "parse should return #expectedResult when given #toParse and a defaultValue of #defaultValue"() {
+        given:
+        ParserContext<PutawayStatus> context = new ParserContext(
+                defaultValue: defaultValue,
+                errorOnParseFailure: false,
+        )
+
+        expect:
+        assert parser.parse(toParse, context) == expectedResult
+
+        where:
+        toParse | defaultValue        || expectedResult
+        null    | null                || null
+        null    | PutawayStatus.READY || PutawayStatus.READY
+        1       | null                || null
+        1       | PutawayStatus.READY || null
+    }
+
+    void "parse should error when errorOnParseFailure==true and given #toParse and a defaultValue of #defaultValue"() {
+        given:
+        ParserContext<PutawayStatus> context = new ParserContext(
+                defaultValue: defaultValue,
+                errorOnParseFailure: true,
+        )
+
+        when:
+        parser.parse(toParse, context)
+
+        then:
+        thrown(expectedException)
+
+        where:
+        toParse | defaultValue        || expectedException
+        1       | null                || IllegalArgumentException
+        1       | PutawayStatus.READY || IllegalArgumentException
+    }
+}

--- a/src/test/groovy/org/pih/warehouse/core/parser/EnumParserSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/core/parser/EnumParserSpec.groovy
@@ -10,15 +10,15 @@ import org.pih.warehouse.api.PutawayStatus
 class EnumParserSpec extends Specification {
 
     @Shared
-    EnumParser parser
+    EnumParser<PutawayStatus> parser
 
     void setup() {
         parser = new EnumParser<PutawayStatus>()
     }
 
-    void "parse should return #expectedResult when given #toParse and a defaultValue of #defaultValue"() {
+    void "parseString should return #expectedResult when given #toParse and a defaultValue of #defaultValue"() {
         expect:
-        assert parser.parse(toParse, PutawayStatus) == expectedResult
+        assert parser.parseString(toParse, PutawayStatus) == expectedResult
 
         where:
         toParse || expectedResult
@@ -34,17 +34,24 @@ class EnumParserSpec extends Specification {
         ParserContext<PutawayStatus> context = new ParserContext(
                 defaultValue: defaultValue,
                 errorOnParseFailure: false,
+                typeToParseTo: PutawayStatus,
         )
 
         expect:
         assert parser.parse(toParse, context) == expectedResult
 
         where:
-        toParse | defaultValue        || expectedResult
-        null    | null                || null
-        null    | PutawayStatus.READY || PutawayStatus.READY
-        1       | null                || null
-        1       | PutawayStatus.READY || null
+        toParse   | defaultValue        || expectedResult
+        null      | null                || null
+        null      | PutawayStatus.READY || PutawayStatus.READY
+        1         | null                || null
+        1         | PutawayStatus.READY || null  // invalid values always return null
+        ""        | null                || null
+        ""        | PutawayStatus.READY || PutawayStatus.READY
+        " "       | null                || null
+        " "       | PutawayStatus.READY || PutawayStatus.READY
+        " rEaDy " | null                || PutawayStatus.READY
+        "READY"   | null                || PutawayStatus.READY
     }
 
     void "parse should error when errorOnParseFailure==true and given #toParse and a defaultValue of #defaultValue"() {
@@ -52,6 +59,7 @@ class EnumParserSpec extends Specification {
         ParserContext<PutawayStatus> context = new ParserContext(
                 defaultValue: defaultValue,
                 errorOnParseFailure: true,
+                typeToParseTo: PutawayStatus,
         )
 
         when:
@@ -64,5 +72,20 @@ class EnumParserSpec extends Specification {
         toParse | defaultValue        || expectedException
         1       | null                || IllegalArgumentException
         1       | PutawayStatus.READY || IllegalArgumentException
+    }
+
+    void "parse should error when errorOnParseFailure==true and typeToParseTo is not specified"() {
+        given:
+        ParserContext<PutawayStatus> context = new ParserContext(
+                defaultValue: null,
+                errorOnParseFailure: true,
+                typeToParseTo: null,  // We need to specify this when parsing enums
+        )
+
+        when:
+        parser.parse("READY", context)
+
+        then:
+        thrown(IllegalArgumentException)
     }
 }

--- a/src/test/groovy/org/pih/warehouse/core/parser/IntegerParserSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/core/parser/IntegerParserSpec.groovy
@@ -1,0 +1,61 @@
+package org.pih.warehouse.core.parser
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class IntegerParserSpec extends Specification {
+
+    @Shared
+    IntegerParser parser
+
+    void setup() {
+        parser = new IntegerParser()
+    }
+
+    void "parse should return #expectedResult when given #toParse and a defaultValue of #defaultValue"() {
+        given:
+        ParserContext<Integer> context = new ParserContext(
+                defaultValue: defaultValue,
+                errorOnParseFailure: false,
+        )
+
+        expect:
+        assert parser.parse(toParse, context) == expectedResult
+
+        where:
+        toParse | defaultValue || expectedResult
+        null    | null         || null
+        null    | 0            || 0
+        1.1     | null         || 1
+        1.1d    | null         || 1
+        1       | null         || 1
+        1l      | null         || 1
+        "1"     | null         || 1
+        "-1"    | null         || -1
+        "1.1"   | null         || 1
+        ""      | null         || null
+        "bad"   | null         || null
+        "bad"   | 0            || null
+    }
+
+    void "parse should error when errorOnParseFailure==true and given #toParse and a defaultValue of #defaultValue"() {
+        given:
+        ParserContext<Integer> context = new ParserContext(
+                defaultValue: defaultValue,
+                errorOnParseFailure: true,
+        )
+
+        when:
+        parser.parse(toParse, context)
+
+        then:
+        thrown(expectedException)
+
+        where:
+        toParse | defaultValue || expectedException
+        "bad"   | null         || NumberFormatException
+        "bad"   | 0            || NumberFormatException
+    }
+}

--- a/src/test/groovy/org/pih/warehouse/core/parser/ListOfIntegerParserSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/core/parser/ListOfIntegerParserSpec.groovy
@@ -1,0 +1,82 @@
+package org.pih.warehouse.core.parser
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class ListOfIntegerParserSpec extends Specification {
+
+    @Shared
+    ListOfIntegerParser parser
+
+    void setup() {
+        parser = new ListOfIntegerParser(new IntegerParser())
+    }
+
+    void "parse should return #expectedResult when given #toParse and a defaultValue of #defaultValue"() {
+        given:
+        ListParserContext<Integer> context = new ListParserContext(
+                defaultValue: defaultValue,
+                errorOnParseFailure: false,
+                listElementParserContext: new ParserContext<Integer>(
+                        defaultValue: null,
+                        errorOnParseFailure: false,
+                ),
+        )
+
+        expect:
+        assert parser.parse(toParse, context) == expectedResult
+
+        where:
+        toParse      | defaultValue || expectedResult
+        null         | null         || null
+        null         | []           || []
+        1.1          | null         || [1]
+        1.1d         | null         || [1]
+        1            | null         || [1]
+        1l           | null         || [1]
+        "1"          | null         || [1]
+        "1.1"        | null         || [1]
+        "1,2"        | null         || [1, 2]
+        " ,1 ,, 2,"  | null         || [1, 2]
+        [1, 2]       | null         || [1, 2]
+        ["1", "2"]   | null         || [1, 2]
+        ["1", 2]     | null         || [1, 2]
+        ""           | null         || null
+        ""           | []           || []
+        ","          | null         || []
+        ","          | []           || []
+        " "          | null         || null
+        " "          | []           || []
+        "bad"        | null         || []
+        "bad"        | []           || []
+        ["bad"]      | null         || []
+        ["bad"]      | []           || []
+    }
+
+    void "parse should error when errorOnParseFailure==true and given #toParse and a defaultValue of #defaultValue"() {
+        given:
+        ListParserContext<Integer> context = new ListParserContext(
+                defaultValue: defaultValue,
+                errorOnParseFailure: true,
+                listElementParserContext: new ParserContext<Integer>(
+                        defaultValue: null,
+                        errorOnParseFailure: true,
+                ),
+        )
+
+        when:
+        parser.parse(toParse, context)
+
+        then:
+        thrown(expectedException)
+
+        where:
+        toParse | defaultValue || expectedException
+        "bad"   | null         || NumberFormatException
+        "bad"   | []           || NumberFormatException
+        ["bad"] | null         || NumberFormatException
+        ["bad"] | []           || NumberFormatException
+    }
+}

--- a/src/test/groovy/org/pih/warehouse/core/parser/ListOfStringParserSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/core/parser/ListOfStringParserSpec.groovy
@@ -1,0 +1,56 @@
+package org.pih.warehouse.core.parser
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class ListOfStringParserSpec extends Specification {
+
+    @Shared
+    ListOfStringParser parser
+
+    void setup() {
+        parser = new ListOfStringParser(new StringParser())
+    }
+
+    void "parse should return #expectedResult when given #toParse and a defaultValue of #defaultValue"() {
+        given:
+        ListParserContext<String> context = new ListParserContext(
+                defaultValue: defaultValue,
+                errorOnParseFailure: false,
+                listElementParserContext: new ParserContext<String>(
+                        defaultValue: null,
+                        errorOnParseFailure: false,
+                ),
+        )
+
+        expect:
+        assert parser.parse(toParse, context) == expectedResult
+
+        where:
+        toParse      | defaultValue || expectedResult
+        null         | null         || null
+        null         | []           || []
+        1.1          | null         || ["1.1"]
+        1.1d         | null         || ["1.1"]
+        1            | null         || ["1"]
+        1l           | null         || ["1"]
+        "1"          | null         || ["1"]
+        "1.1"        | null         || ["1.1"]
+        "1,2"        | null         || ["1", "2"]
+        " ,1 ,, 2,"  | null         || ["1", "2"]
+        [1, 2]       | null         || ["1", "2"]
+        ["1", "2"]   | null         || ["1", "2"]
+        ["1", 2]     | null         || ["1", "2"]
+        ""           | null         || null
+        ""           | []           || []
+        ","          | null         || []
+        " "          | null         || null
+        " "          | []           || []
+        "aa"         | null         || ["aa"]
+        "aa,bb,11"   | null         || ["aa", "bb", "11"]
+        " aa , bb "  | null         || ["aa", "bb"]
+        "你,好"       | null         || ["你", "好"]
+    }
+}

--- a/src/test/groovy/org/pih/warehouse/core/parser/StringParserSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/core/parser/StringParserSpec.groovy
@@ -1,0 +1,42 @@
+package org.pih.warehouse.core.parser
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class StringParserSpec extends Specification {
+
+    @Shared
+    StringParser parser
+
+    void setup() {
+        parser = new StringParser()
+    }
+
+    void "parse should return #expectedResult when given #toParse and a defaultValue of #defaultValue"() {
+        given:
+        ParserContext<String> context = new ParserContext(
+                defaultValue: defaultValue,
+                errorOnParseFailure: true,
+        )
+
+        expect:
+        assert parser.parse(toParse, context) == expectedResult
+
+        where:
+        toParse | defaultValue || expectedResult
+        null    | null         || null
+        null    | ""           || ""
+        ""      | null         || null
+        ""      | ""           || ""
+        "hi hi" | null         || "hi hi"
+        1.1     | null         || "1.1"
+        1.1d    | null         || "1.1"
+        1       | null         || "1"
+        1l      | null         || "1"
+        "1"     | null         || "1"
+        "1.1"   | null         || "1.1"
+        "你好"   | null         || "你好"
+    }
+}


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7773

**Description:** Adds a bunch of new parsers that can be used to convert objects to a specific type. For example, IntegerParser takes in any object and outputs an Integer.

These parsers will be used as a part of the importer refactor, but can also be used anywhere that we need to convert from one type to another. The static `X.parseString(String)` methods will likely be useful for the simple data type conversions that we do all over the app.

The main goal is to standardize our approach to parsing so that we can have consistent behaviour everywhere across the app.

![image](https://github.com/user-attachments/assets/38a4e532-4348-472f-b7e5-f0089602d2ae)


For more details, see: https://pihemr.atlassian.net/wiki/spaces/OB/pages/4174905356/OBPIH-7748+Migrating+to+Apache+POI+for+imports#Parsers