### PR TITLE
OBPIH-7765 fix1. fix location import with multiple orgs same name dif…

### DIFF
--- a/grails-app/services/org/pih/warehouse/core/OrganizationService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/OrganizationService.groovy
@@ -42,24 +42,30 @@ class OrganizationService {
         }
     }
 
-    Organization findOrganization(String name, String code) {
-        // First, search by code if one was provided
-        Organization organization = StringUtils.isBlank(code) ? null : Organization.createCriteria().get {
-            eq("code", code)
-            ne("code", StringUtils.EMPTY)
-            isNotNull("code")
-        } as Organization
-
-        // Then search by name, which is not strictly unique so in case multiple are found, return the newest one
-        if (!organization) {
-            organization = Organization.createCriteria().list(max: 1) {
-                eq("name", name)
-                ne("name", StringUtils.EMPTY)
-                isNotNull("name")
-                order("dateCreated", "asc")
-            }[0]
+    /**
+     * Returns the organization matching the given code, or if none exist for the given code, returns all
+     * organizations that match the given name.
+     */
+    List<Organization> findOrganizations(String name, String code) {
+        List<Organization> organizations = []
+        if (!StringUtils.isBlank(code)) {
+            Organization organization = Organization.findByCode(code)
+            if (organization) {
+                return [organization]
+            }
         }
-        return organization
+        if (!StringUtils.isBlank(name)) {
+            organizations = Organization.findAllByName(name, [sort: "dateCreated", order: "asc"])
+        }
+        return organizations
+    }
+
+    /**
+     * Returns the organization matching the given code, or if none exist for the given code, returns
+     * the newest organization that matches the given name.
+     */
+    Organization findOrganization(String name, String code) {
+        return findOrganizations(name, code)?.find()
     }
 
     private Organization createOrUpdateOrganization(String name, String code, List<RoleType> roleTypes) {

--- a/grails-app/services/org/pih/warehouse/importer/LocationImportDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/importer/LocationImportDataService.groovy
@@ -40,7 +40,10 @@ class LocationImportDataService implements ImportDataService {
             LocationType locationType = LocationType
                     .findAllByNameLike(locationTypeName + "%")
                     .find{ LocalizationUtil.getDefaultString(it.name) == locationTypeName}
-            List<Organization> organizations = params.organization ? Organization.findAllByCodeOrName(params.organization, params.organization) : null
+
+            // The user can specify either the organization name or code, so make sure to look up by either
+            String identifier = params.organization
+            List<Organization> organizations = organizationService.findOrganizations(identifier, identifier)
 
             if (params.id && !location) {
                 command.errors.reject("Row ${index + 1}: Id '${params.id}' do not exists in the system.")


### PR DESCRIPTION
…ferent code

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7765

**Description:** original PR https://github.com/openboxes/openboxes/pull/5863

This bug wasn't caused by my change but it's closely related so I'm fixing it under the same ticket.

When importing locations, if you assign a location an org code but two orgs exist in the system with the same name as the specified code, it errors. The fix is to first search orgs by code, and then only if no orgs are found then search by name.

<img width="1953" height="310" alt="image" src="https://github.com/user-attachments/assets/b44508ab-0c2e-47ea-a9f2-980006a0ef65" />

See Kuba's video for details: https://jam.dev/c/b886c65b-c6ac-43ec-82e4-3562eaea4568