### PR TITLE
OBPIH-7223 don't look up orgs by location number when creating locations

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/core/LocationController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/core/LocationController.groovy
@@ -99,8 +99,9 @@ class LocationController {
 
             if (!locationInstance.id && !locationInstance.organization) {
                 if (locationInstance?.locationType?.locationTypeCode == LocationTypeCode.SUPPLIER) {
+                    // When creating new suppliers we also create an org with the same name (unless one already exists)
                     locationInstance.organization =
-                            organizationService.findOrCreateSupplierOrganization(locationInstance.name, locationInstance.locationNumber)
+                            organizationService.findOrCreateSupplierOrganization(locationInstance.name)
                 }
             }
 


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7223

**Description:** When creating new supplier locations, we incorrectly were matching the location number to the org code of the location. This change makes it so that we only search for orgs with the same name as the location


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

https://www.loom.com/share/7a9db0b5a17b4139b35f46a4606b6dc4