### PR TITLE
OBLS-677 Prevent picked quantity from exceeding allocated quantity in…

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -3785,6 +3785,7 @@ react.stockMovement.errors.errorInLine.label=Error occurred in line
 react.stockMovement.errors.followingRowsContainValidationError.label=Following rows contain validation errors: Row 
 react.stockMovement.errors.negativeQtyAllocated.label=Allocated quantity must not be negative
 react.stockMovement.errors.higherThanAvailable.label=Allocated quantity exceeds available stock
+react.stockMovement.errors.pickedHigherThanAllocated.label=Picked quantity exceeds allocated quantity
 react.stockMovement.errors.allocatedHigherThanRequired.label=Total allocated quantity exceeds quantity required
 react.stockMovement.message.confirmChange.label=Confirm change
 react.stockMovement.confirmChange.message=Do you want to change stock movement data? Changing origin, destination or stock list can cause loss of your current work

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -1941,6 +1941,8 @@ class StockMovementService {
             requisitionItem.addToPicklistItems(picklistItem)
             picklistItem.inventoryItem = inventoryItem
             picklistItem.binLocation = binLocation
+            // Safeguard: Ensure allocated quantity is never less than picked quantity.
+            // The frontend validates that picked <= allocated, but this protects against API misuse.
             picklistItem.quantity = quantityPicked ?: quantityToPick
             picklistItem.quantityPicked = quantityPicked ?: 0
             picklistItem.reasonCode = reasonCode ?: null

--- a/src/js/components/stock-movement-wizard/modals/EditPickModal.jsx
+++ b/src/js/components/stock-movement-wizard/modals/EditPickModal.jsx
@@ -169,6 +169,9 @@ function validate(values) {
     if (item.quantityAllocated > item.quantityAvailable) {
       errors.availableItems[key].quantityAllocated = 'react.stockMovement.errors.higherThanAvailable.label';
     }
+    if (item.quantityPicked > item.quantityAllocated) {
+      errors.availableItems[key].quantityPicked = 'react.stockMovement.errors.pickedHigherThanAllocated.label';
+    }
   });
 
   const allocatedSum = _.reduce(


### PR DESCRIPTION
… edit pick modal

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket: https://openboxes.atlassian.net/browse/OBLS-677**

**Description:**
  - Added frontend validation in the edit pick modal that prevents picked quantity from    
  exceeding allocated quantity per row, mirroring the existing validation that prevents
  allocated from exceeding available                                                       
  - Added a server-side comment clarifying the quantityPicked ?: quantityToPick logic as a
  safeguard against API misuse                                                             
  - Added pickedHigherThanAllocated message key to messages.properties
