### PR TITLE
OBPIH-6836 Include pending return orders on inbound stock movement list

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/api/StockMovementApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/StockMovementApiController.groovy
@@ -691,7 +691,7 @@ class StockMovementApiController {
                 sm.stocklist?.name ?: "",
                 sm.requestedBy ?: warehouse.message(code: 'default.none.label'),
                 sm.dateRequested.format("MM-dd-yyyy") ?: "",
-                sm.requisition?.dateCreated?.format("MM-dd-yyyy") ?: "",
+                sm.dateCreated?.format("MM-dd-yyyy") ?: "",
                 sm.shipment?.expectedShippingDate?.format("MM-dd-yyyy") ?: "",
             )
         }

--- a/grails-app/controllers/org/pih/warehouse/api/StockMovementApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/StockMovementApiController.groovy
@@ -691,7 +691,7 @@ class StockMovementApiController {
                 sm.stocklist?.name ?: "",
                 sm.requestedBy ?: warehouse.message(code: 'default.none.label'),
                 sm.dateRequested.format("MM-dd-yyyy") ?: "",
-                sm.dateCreated?.format("MM-dd-yyyy") ?: "",
+                sm.requisition?.dateCreated?.format("MM-dd-yyyy") ?: "",
                 sm.shipment?.expectedShippingDate?.format("MM-dd-yyyy") ?: "",
             )
         }

--- a/grails-app/domain/org/pih/warehouse/inventory/InboundStockMovementListItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/InboundStockMovementListItem.groovy
@@ -39,43 +39,10 @@ class InboundStockMovementListItem implements Serializable, Validateable {
     ShipmentStatusCode currentStatus
     ShipmentType shipmentType
 
-    static transients = [
-        "fromReturnOrder",
-        "lineItemCount",
-        "displayStatus",
-        "status",
-        "received",
-        "partiallyReceived",
-        "pending",
-    ]
-
     static mapping = {
         version false
         cache usage: "read-only"
         table "inbound_stock_movement_list_item"
-
-        shipmentType column: "shipment_type_id"
-    }
-
-    static constraints = {
-        id(nullable: true)
-        name(nullable: true)
-        description(nullable: true)
-        identifier(nullable: true)
-        origin(nullable: false)
-        destination(nullable: false)
-        requestedBy(nullable: false)
-        createdBy(nullable: true)
-        updatedBy(nullable: true)
-        dateRequested(nullable: false)
-        dateCreated(nullable: true)
-        lastUpdated(nullable: true)
-        shipment(nullable: true)
-        requisition(nullable: true)
-        stocklist(nullable: true)
-        order(nullable: true)
-        currentStatus(nullable: true)
-        shipmentType(nullable: true)
     }
 
     String getStatus() {
@@ -135,7 +102,7 @@ class InboundStockMovementListItem implements Serializable, Validateable {
 
     Map toJson() {
         return [
-            id                  : requisition?.id ?: id,
+            id                  : id,
             name                : name,
             description         : description,
             shipmentType        : shipment?.shipmentType,

--- a/grails-app/domain/org/pih/warehouse/inventory/InboundStockMovementListItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/InboundStockMovementListItem.groovy
@@ -2,7 +2,6 @@ package org.pih.warehouse.inventory
 
 import grails.validation.Validateable
 import org.pih.warehouse.api.StockMovementStatusContext
-import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.Person
 import org.pih.warehouse.order.Order
@@ -79,7 +78,7 @@ class InboundStockMovementListItem implements Serializable, Validateable {
     }
 
     Boolean isReceived() {
-        return (shipment?.status?.code >= ShipmentStatusCode.RECEIVED)
+        return shipment?.currentStatus == ShipmentStatusCode.RECEIVED
     }
 
     Boolean isPartiallyReceived() {
@@ -120,8 +119,8 @@ class InboundStockMovementListItem implements Serializable, Validateable {
                 id: order?.id,
             ],
             stocklist           : stocklist,
-            dateCreated         : dateCreated?.format(Constants.MONTH_DAY_YEAR_DATE_FORMAT),
-            expectedDeliveryDate: shipment?.expectedDeliveryDate?.format(Constants.DELIVERY_DATE_FORMAT),
+            dateCreated         : dateCreated,
+            expectedDeliveryDate: shipment?.expectedDeliveryDate,
             requestedBy         : requestedBy,
             lineItemCount       : lineItemCount,
             isReturn            : fromReturnOrder,

--- a/grails-app/domain/org/pih/warehouse/inventory/InboundStockMovementListItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/InboundStockMovementListItem.groovy
@@ -1,0 +1,166 @@
+package org.pih.warehouse.inventory
+
+import grails.validation.Validateable
+import org.pih.warehouse.api.StockMovementStatusContext
+import org.pih.warehouse.core.Constants
+import org.pih.warehouse.core.Location
+import org.pih.warehouse.core.Person
+import org.pih.warehouse.order.Order
+import org.pih.warehouse.order.OrderItem
+import org.pih.warehouse.requisition.Requisition
+import org.pih.warehouse.shipping.Shipment
+import org.pih.warehouse.shipping.ShipmentStatusCode
+import org.pih.warehouse.shipping.ShipmentType
+import util.StockMovementStatusResolver
+
+class InboundStockMovementListItem implements Serializable, Validateable {
+
+    String id
+    String name
+    String identifier
+    String description
+
+    Location origin
+    Location destination
+
+    Person requestedBy
+    Person createdBy
+    Person updatedBy
+
+    Date dateCreated
+    Date lastUpdated
+    Date dateRequested
+
+    Shipment shipment
+    Requisition requisition
+    Requisition stocklist
+    Order order
+
+    ShipmentStatusCode currentStatus
+    ShipmentType shipmentType
+
+    static transients = [
+        "fromReturnOrder",
+        "lineItemCount",
+        "displayStatus",
+        "status",
+        "received",
+        "partiallyReceived",
+        "pending",
+    ]
+
+    static mapping = {
+        version false
+        cache usage: "read-only"
+        table "inbound_stock_movement_list_item"
+
+        shipmentType column: "shipment_type_id"
+    }
+
+    static constraints = {
+        id(nullable: true)
+        name(nullable: true)
+        description(nullable: true)
+        identifier(nullable: true)
+        origin(nullable: false)
+        destination(nullable: false)
+        requestedBy(nullable: false)
+        createdBy(nullable: true)
+        updatedBy(nullable: true)
+        dateRequested(nullable: false)
+        dateCreated(nullable: true)
+        lastUpdated(nullable: true)
+        shipment(nullable: true)
+        requisition(nullable: true)
+        stocklist(nullable: true)
+        order(nullable: true)
+        currentStatus(nullable: true)
+        shipmentType(nullable: true)
+    }
+
+    String getStatus() {
+        if (requisition) {
+            return requisition.status
+        }
+        if (shipment) {
+            return shipment.status?.code
+        }
+        if (order) {
+            return order.status
+        }
+        return null
+    }
+
+    Map getDisplayStatus() {
+        StockMovementStatusContext stockMovementContext = new StockMovementStatusContext(
+            order: order,
+            requisition: requisition,
+            shipment: shipment,
+            origin: origin,
+            destination: destination
+        )
+        Enum status = StockMovementStatusResolver.getListStatus(stockMovementContext)
+        return StockMovementStatusResolver.getStatusMetaData(status)
+    }
+
+    Boolean isFromReturnOrder() {
+        return order?.isReturnOrder ?: false
+    }
+
+    Boolean isPending() {
+        return shipment?.currentStatus == ShipmentStatusCode.PENDING
+    }
+
+    Boolean isReceived() {
+        return (shipment?.status?.code >= ShipmentStatusCode.RECEIVED)
+    }
+
+    Boolean isPartiallyReceived() {
+        return shipment?.currentStatus == ShipmentStatusCode.PARTIALLY_RECEIVED
+    }
+
+    Integer getLineItemCount() {
+        if (requisition) {
+            return requisition.requisitionItemCount ?: 0
+        }
+        if (shipment) {
+            return shipment.shipmentItemCount ?: 0
+        }
+        if (order) {
+            return OrderItem.countByOrder(order)
+        }
+
+        return 0
+    }
+
+    Map toJson() {
+        return [
+            id                  : requisition?.id ?: id,
+            name                : name,
+            description         : description,
+            shipmentType        : shipment?.shipmentType,
+            displayStatus       : displayStatus,
+            identifier          : identifier,
+            origin              : [
+                id     : origin?.id,
+                name   : origin?.name,
+                isDepot: origin?.isDepot(),
+            ],
+            destination         : [
+                id: destination?.id,
+            ],
+            order               : [
+                id: order?.id,
+            ],
+            stocklist           : stocklist,
+            dateCreated         : dateCreated?.format(Constants.MONTH_DAY_YEAR_DATE_FORMAT),
+            expectedDeliveryDate: shipment?.expectedDeliveryDate?.format(Constants.DELIVERY_DATE_FORMAT),
+            requestedBy         : requestedBy,
+            lineItemCount       : lineItemCount,
+            isReturn            : fromReturnOrder,
+            isReceived          : received,
+            isPartiallyReceived : partiallyReceived,
+            isPending           : pending,
+        ]
+    }
+}

--- a/grails-app/domain/org/pih/warehouse/inventory/OutboundStockMovementListItem.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/OutboundStockMovementListItem.groovy
@@ -15,6 +15,7 @@ import org.pih.warehouse.requisition.RequisitionStatus
 import org.pih.warehouse.requisition.RequisitionType
 import org.pih.warehouse.shipping.Shipment
 import org.pih.warehouse.shipping.ShipmentStatusCode
+import org.pih.warehouse.shipping.ShipmentType
 import org.pih.warehouse.api.StockMovementStatusContext
 import util.StockMovementStatusResolver
 
@@ -39,6 +40,7 @@ class OutboundStockMovementListItem implements Serializable, Validateable {
 
 
     ShipmentStatusCode shipmentStatus
+    ShipmentType shipmentType
 
     RequisitionStatus status
     Requisition stocklist
@@ -172,7 +174,7 @@ class OutboundStockMovementListItem implements Serializable, Validateable {
                 isReturn            : fromReturnOrder,
                 isElectronicType    : electronicType,
                 isApprovalRequired  : requisition?.approvalRequired,
-                shipmentType        : shipment?.shipmentType,
+                shipmentType        : shipmentType,
                 approvers           : requisition?.approvers?.toList()
         ]
     }

--- a/grails-app/init/org/pih/warehouse/BootStrap.groovy
+++ b/grails-app/init/org/pih/warehouse/BootStrap.groovy
@@ -69,6 +69,7 @@ import org.pih.warehouse.core.User
 import org.pih.warehouse.inventory.CycleCountCandidate
 import org.pih.warehouse.inventory.CycleCountRequest
 import org.pih.warehouse.inventory.InventoryItem
+import org.pih.warehouse.inventory.InboundStockMovementListItem
 import org.pih.warehouse.inventory.OutboundStockMovementListItem
 import org.pih.warehouse.invoice.InvoiceItem
 import org.pih.warehouse.invoice.InvoiceItemCandidate
@@ -678,6 +679,9 @@ class BootStrap {
 
         JSON.registerObjectMarshaller(InventoryTransactionsSummary) { InventoryTransactionsSummary inventoryTransactionsSummary ->
             return inventoryTransactionsSummary.toJson()
+        }
+        JSON.registerObjectMarshaller(InboundStockMovementListItem) { InboundStockMovementListItem inboundStockMovementListItem ->
+            return inboundStockMovementListItem.toJson()
         }
     }
 

--- a/grails-app/migrations/views/changelog.xml
+++ b/grails-app/migrations/views/changelog.xml
@@ -192,4 +192,7 @@
   <changeSet id="1748970410098-7" author="kchelstowski" runOnChange="true" runAlways="true" failOnError="true">
     <sqlFile path="views/inventory-counts.sql"/>
   </changeSet>
+  <changeSet id="1748970410098-8" author="slib" runOnChange="true" runAlways="true" failOnError="true">
+    <sqlFile path="views/inbound-stock-movement-list-item.sql"/>
+   </changeSet>
 </databaseChangeLog>

--- a/grails-app/migrations/views/drop-all-views.xml
+++ b/grails-app/migrations/views/drop-all-views.xml
@@ -14,6 +14,7 @@
       DROP VIEW IF EXISTS cycle_count_summary;
       DROP VIEW IF EXISTS edit_page_item;
       DROP VIEW IF EXISTS fill_rate;
+      DROP VIEW IF EXISTS inbound_stock_movement_list_item;
       DROP VIEW IF EXISTS inventory_audit_details;
       DROP VIEW IF EXISTS inventory_audit_rollup;
       DROP VIEW IF EXISTS inventory_audit_summary;

--- a/grails-app/migrations/views/inbound-stock-movement-list-item.sql
+++ b/grails-app/migrations/views/inbound-stock-movement-list-item.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE VIEW inbound_stock_movement_list_item AS
     -- Querying from shipment (not requisition) to include purchase orders (POs never have a requisition).
     -- Requisition data is preferred via COALESCE when available.
     SELECT
-        s.id,
+        COALESCE(r.id, s.id)                               AS id,
         COALESCE(r.name, s.name)                           AS name,
         COALESCE(r.request_number, s.shipment_number)      AS identifier,
         COALESCE(r.description, s.description)             AS description,

--- a/grails-app/migrations/views/inbound-stock-movement-list-item.sql
+++ b/grails-app/migrations/views/inbound-stock-movement-list-item.sql
@@ -11,7 +11,7 @@ CREATE OR REPLACE VIEW inbound_stock_movement_list_item AS
         COALESCE(r.date_created, s.date_created)           AS date_created,
         COALESCE(r.last_updated, s.last_updated)           AS last_updated,
         COALESCE(r.date_requested, s.date_created)         AS date_requested,
-        COALESCE(r.requested_by_id, s.created_by_id)       AS requested_by_id,
+        r.requested_by_id                                  AS requested_by_id,
         COALESCE(r.created_by_id, s.created_by_id)         AS created_by_id,
         COALESCE(r.updated_by_id, s.updated_by_id)         AS updated_by_id,
         s.id                                               AS shipment_id,

--- a/grails-app/migrations/views/inbound-stock-movement-list-item.sql
+++ b/grails-app/migrations/views/inbound-stock-movement-list-item.sql
@@ -1,0 +1,49 @@
+CREATE OR REPLACE VIEW inbound_stock_movement_list_item AS
+    -- Querying from shipment (not requisition) to include purchase orders (POs never have a requisition).
+    -- Requisition data is preferred via COALESCE when available.
+    SELECT
+        s.id,
+        COALESCE(r.name, s.name)                           AS name,
+        COALESCE(r.request_number, s.shipment_number)      AS identifier,
+        COALESCE(r.description, s.description)             AS description,
+        COALESCE(r.origin_id, s.origin_id)                 AS origin_id,
+        COALESCE(r.destination_id, s.destination_id)       AS destination_id,
+        COALESCE(r.date_created, s.date_created)           AS date_created,
+        COALESCE(r.last_updated, s.last_updated)           AS last_updated,
+        COALESCE(r.date_requested, s.date_created)         AS date_requested,
+        COALESCE(r.requested_by_id, s.created_by_id)       AS requested_by_id,
+        COALESCE(r.created_by_id, s.created_by_id)         AS created_by_id,
+        COALESCE(r.updated_by_id, s.updated_by_id)         AS updated_by_id,
+        s.id                                               AS shipment_id,
+        r.id                                               AS requisition_id,
+        NULL                                               AS order_id,
+        r.requisition_template_id                          AS stocklist_id,
+        s.current_status,
+        s.shipment_type_id
+    FROM shipment s
+    LEFT JOIN requisition r ON r.id = s.requisition_id
+
+    UNION ALL
+    -- Return orders with PENDING status do not have a shipment yet, so they would not be picked up by the query above, hence this separate query
+    SELECT
+        o.id,
+        o.name,
+        o.order_number                                     AS identifier,
+        o.description,
+        o.origin_id,
+        o.destination_id,
+        o.date_created,
+        o.last_updated,
+        o.date_ordered                                     AS date_requested,
+        o.ordered_by_id                                    AS requested_by_id,
+        o.created_by_id,
+        o.updated_by_id,
+        NULL                                               AS shipment_id,
+        NULL                                               AS requisition_id,
+        o.id                                               AS order_id,
+        NULL                                               AS stocklist_id,
+        o.status                                           AS current_status,
+        NULL                                               AS shipment_type_id
+    FROM `order` o
+    WHERE o.order_type_id = 'RETURN_ORDER'
+      AND o.status = 'PENDING';

--- a/grails-app/migrations/views/stock-movement-list-item.sql
+++ b/grails-app/migrations/views/stock-movement-list-item.sql
@@ -14,6 +14,7 @@ CREATE OR REPLACE VIEW stock_movement_list_item AS
         r.updated_by_id,
         s.id AS shipment_id,
         s.current_status AS shipment_status,
+        s.shipment_type_id,
         # Depreacted, could be removed in a cleanup ticket
         CASE
             WHEN r.status IS NULL THEN 'REQUESTING'
@@ -51,6 +52,7 @@ CREATE OR REPLACE VIEW stock_movement_list_item AS
         o.updated_by_id,
         s.id AS shipment_id,
         s.current_status AS shipment_status,
+        s.shipment_type_id,
         # At point of refactoring status below, (OBPIH-6368) the statusCode seems not to be used anywhere
         # It is marked as deprecated and would be removed soon in a cleanup ticket
         # This is the reason it differs from the status - there was no point to refactor it along with the status in OBPIH-6368

--- a/grails-app/services/org/pih/warehouse/inventory/OutboundStockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/OutboundStockMovementService.groovy
@@ -11,6 +11,7 @@ package org.pih.warehouse.inventory
 
 import grails.gorm.transactions.Transactional
 import org.hibernate.ObjectNotFoundException
+import org.pih.warehouse.core.Constants
 import org.hibernate.criterion.CriteriaSpecification
 import org.hibernate.sql.JoinType
 import org.pih.warehouse.api.StockMovement
@@ -164,8 +165,11 @@ class OutboundStockMovementService {
                 le("dateCreated", createdBefore)
             }
             if (shipmentTypes) {
-                shipment {
+                or {
                     'in'("shipmentType", shipmentTypes)
+                    if (shipmentTypes.any { it.id == Constants.DEFAULT_SHIPMENT_TYPE_ID }) {
+                        isNull("shipmentType")
+                    }
                 }
             }
         }

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -471,15 +471,7 @@ class StockMovementService {
                 eq("createdBy", criteria?.createdBy)
             }
             if (criteria.requestedBy) {
-                or {
-                    requisition(JoinType.LEFT_OUTER_JOIN.joinTypeValue) {
-                        eq("requestedBy", criteria?.requestedBy)
-                    }
-                    and {
-                        isNull("requisition")
-                        eq("createdBy", criteria?.requestedBy)
-                    }
-                }
+                eq("requestedBy", criteria?.requestedBy)
             }
             if (criteria.updatedBy) {
                 eq("updatedBy", criteria.updatedBy)
@@ -506,10 +498,8 @@ class StockMovementService {
                 } else if (params.sort == "dateRequested") {
                     order("dateRequested", params.order ?: "desc")
                 } else if (params.sort == "stocklist.name") {
-                    requisition(JoinType.LEFT_OUTER_JOIN.joinTypeValue)  {
-                        requisitionTemplate(JoinType.LEFT_OUTER_JOIN.joinTypeValue)  {
-                            order("name", params.order ?: "desc")
-                        }
+                    stocklist(JoinType.LEFT_OUTER_JOIN.joinTypeValue) {
+                        order("name", params.order ?: "desc")
                     }
                 } else if (params.sort == "identifier") {
                     order("identifier", params.order ?: "desc")

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -11,7 +11,7 @@ package org.pih.warehouse.inventory
 
 import grails.core.GrailsApplication
 import grails.gorm.transactions.Transactional
-import grails.orm.PagedResultList
+import grails.gorm.PagedResultList
 import grails.plugins.csv.CSVMapReader
 import grails.validation.ValidationException
 import org.grails.plugins.web.taglib.ApplicationTagLib
@@ -431,7 +431,7 @@ class StockMovementService {
         }
     }
 
-    def getInboundStockMovements(StockMovement criteria, Map params) {
+    PagedResultList<InboundStockMovementListItem> getInboundStockMovements(StockMovement criteria, Map params) {
         def max = params.max ? params.int("max") : null
         def offset = params.offset ? params.int("offset") : null
         Date createdAfter = params.createdAfter ? Date.parse("MM/dd/yyyy", params.createdAfter) : null
@@ -439,7 +439,7 @@ class StockMovementService {
         List<ShipmentType> shipmentTypes = params.list("shipmentType") ? params.list("shipmentType").collect{ ShipmentType.read(it) } : null
         Location currentLocation = AuthService.currentLocation
 
-        PagedResultList shipments = Shipment.createCriteria().list(max: max, offset: offset) {
+        PagedResultList<InboundStockMovementListItem> stockMovements = InboundStockMovementListItem.createCriteria().list(max: max, offset: offset) {
             // OBPIH-6403: We want to hide SMs with requisition of status REJECTED from the inbound list (only for the depot-depot case!!)
             // The "or" is needed, because otherwise, SMs without requisition were also filtered out from the list (e.g. shipment from PO)
             if (!currentLocation?.downstreamConsumer) {
@@ -454,7 +454,7 @@ class StockMovementService {
             if (criteria?.identifier || criteria.name || criteria?.description) {
                 or {
                     if (criteria?.identifier) {
-                        ilike("shipmentNumber", criteria.identifier)
+                        ilike("identifier", criteria.identifier)
                     }
                     if (criteria?.name) {
                         ilike("name", criteria.name)
@@ -504,9 +504,7 @@ class StockMovementService {
                         order("name", params.order ?: "desc")
                     }
                 } else if (params.sort == "dateRequested") {
-                    requisition {
-                        order("dateRequested", params.order ?: "desc")
-                    }
+                    order("dateRequested", params.order ?: "desc")
                 } else if (params.sort == "stocklist.name") {
                     requisition(JoinType.LEFT_OUTER_JOIN.joinTypeValue)  {
                         requisitionTemplate(JoinType.LEFT_OUTER_JOIN.joinTypeValue)  {
@@ -514,7 +512,7 @@ class StockMovementService {
                         }
                     }
                 } else if (params.sort == "identifier") {
-                    order("shipmentNumber", params.order ?: "desc")
+                    order("identifier", params.order ?: "desc")
                 } else {
                     order(params.sort, params.order ?: "desc")
                 }
@@ -522,14 +520,8 @@ class StockMovementService {
                 order("dateCreated", "desc")
             }
         }
-        List<StockMovement> stockMovements = shipments.collect { Shipment shipment ->
-            if (shipment.requisition) {
-                return StockMovement.createFromRequisition(shipment.requisition, params.includeStockMovementItems)
-            } else {
-                return StockMovement.createFromShipment(shipment, params.includeStockMovementItems)
-            }
-        }
-        return new PaginatedList<StockMovement>(stockMovements, shipments.totalCount)
+
+        return stockMovements
     }
 
     def getOutboundStockMovements(Integer maxResults, Integer offset) {

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -483,7 +483,12 @@ class StockMovementService {
                 le("dateCreated", createdBefore)
             }
             if (shipmentTypes) {
-                'in'("shipmentType", shipmentTypes)
+                or {
+                    'in'("shipmentType", shipmentTypes)
+                    if (shipmentTypes.any { it.id == Constants.DEFAULT_SHIPMENT_TYPE_ID }) {
+                        isNull("shipmentType")
+                    }
+                }
             }
 
             if (params.sort) {


### PR DESCRIPTION
### :sparkles: Description of Change
https://pihemr.atlassian.net/browse/OBPIH-6836

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:**

**Description:**
Inbound returns that were created but not yet submitted (i.e. the user did not reach the Send Shipment step) were not showing up on the inbound list page.
                                                                                                                                                                                                                                                                                                         
This happened because the inbound list was querying from the shipment table, and inbound returns in PENDING status do not have a shipment or a requisition yet, so they were simply not included in the results.                                                                                      
                                                                                                                                                                                                                                                                                                         
To fix this, I created the new view inbound_stock_movement_list_item. The view combines two queries: one for all shipment-based stock movements (existing behaviour), and one specifically for return orders with PENDING status that have no shipment yet.  

I tested my changes on several locations and everything looks fine. Everything is returned as before but now we
also see inbound returns and filtering works correctly. Below you can see that after my changes all statuses except PENDING return the same number of rows.                            
 
TESTING:
Note: I created only one inbound return during testing, which is why there is exactly one additional row visible in the PENDING status filter.
                  
before: 
video: https://github.com/user-attachments/assets/e6965a91-b0cf-403b-8936-188c96b538ae
                                                                                                                                                                                                                                                                             
<img width="2493" height="817" alt="Screenshot From 2026-04-14 13-19-12" src="https://github.com/user-attachments/assets/e366ded3-0cb2-49cd-b0ec-006b33face44" />
              
--------------------------------------------------------------
                                                                                                                                                                                                                                                                                           
after: 
video: https://github.com/user-attachments/assets/420db683-0e66-4568-9e3e-0a36b2086fd2

<img width="2493" height="817" alt="Screenshot From 2026-04-14 13-17-24" src="https://github.com/user-attachments/assets/147626f5-05f3-422c-b6b2-64943f131334" />
                                                                                                                                                                                                                                                                      



---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
