### PR TITLE
OBLS-677 Prevent allocated/picked qty from exceeding required qty in …

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -3786,6 +3786,7 @@ react.stockMovement.errors.followingRowsContainValidationError.label=Following r
 react.stockMovement.errors.negativeQtyAllocated.label=Allocated quantity must not be negative
 react.stockMovement.errors.higherThanAvailable.label=Allocated quantity exceeds available stock
 react.stockMovement.errors.pickedHigherThanAllocated.label=Picked quantity exceeds allocated quantity
+react.stockMovement.errors.pickedHigherThanRequired.label=Total picked quantity exceeds quantity required
 react.stockMovement.errors.allocatedHigherThanRequired.label=Total allocated quantity exceeds quantity required
 react.stockMovement.message.confirmChange.label=Confirm change
 react.stockMovement.confirmChange.message=Do you want to change stock movement data? Changing origin, destination or stock list can cause loss of your current work

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -2005,16 +2005,9 @@ class StockMovementService {
         Integer quantityRequired = requisitionItem.calculateQuantityRequired() ?: 0
 
         // Server-side safeguard: total allocated and total picked must not exceed quantity required
-        Integer totalAllocated = 0
-        Integer totalPicked = 0
-        picklistItems.each { picklistItemMap ->
-            Integer qty = (picklistItemMap.quantityAllocated != null && picklistItemMap.quantityAllocated != "") ?
-                    picklistItemMap.quantityAllocated as Integer : null
-            Integer picked = (picklistItemMap.quantityPicked != null && picklistItemMap.quantityPicked != "") ?
-                    picklistItemMap.quantityPicked as Integer : null
-            totalAllocated += qty ?: 0
-            totalPicked += picked ?: 0
-        }
+        Integer totalAllocated = picklistItems?.sum { (it.quantityAllocated ?: 0) as Integer } ?: 0
+        Integer totalPicked = picklistItems?.sum { (it.quantityPicked ?: 0) as Integer } ?: 0
+        
         if (totalAllocated > quantityRequired) {
             throw new IllegalArgumentException("Total allocated quantity (${totalAllocated}) exceeds quantity required (${quantityRequired})")
         }

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -2008,12 +2008,12 @@ class StockMovementService {
         Integer totalAllocated = 0
         Integer totalPicked = 0
         picklistItems.each { picklistItemMap ->
-            BigDecimal qty = (picklistItemMap.quantityAllocated != null && picklistItemMap.quantityAllocated != "") ?
-                    new BigDecimal(picklistItemMap.quantityAllocated) : null
-            BigDecimal picked = (picklistItemMap.quantityPicked != null && picklistItemMap.quantityPicked != "") ?
-                    new BigDecimal(picklistItemMap.quantityPicked) : null
-            totalAllocated += qty?.intValueExact() ?: 0
-            totalPicked += picked?.intValueExact() ?: 0
+            Integer qty = (picklistItemMap.quantityAllocated != null && picklistItemMap.quantityAllocated != "") ?
+                    picklistItemMap.quantityAllocated as Integer : null
+            Integer picked = (picklistItemMap.quantityPicked != null && picklistItemMap.quantityPicked != "") ?
+                    picklistItemMap.quantityPicked as Integer : null
+            totalAllocated += qty ?: 0
+            totalPicked += picked ?: 0
         }
         if (totalAllocated > quantityRequired) {
             throw new IllegalArgumentException("Total allocated quantity (${totalAllocated}) exceeds quantity required (${quantityRequired})")
@@ -2035,13 +2035,11 @@ class StockMovementService {
             Location binLocation = picklistItemMap.binLocation?.id ?
                     Location.get(picklistItemMap.binLocation?.id) : null
 
-            BigDecimal quantityPicked = (picklistItemMap.quantityPicked != null && picklistItemMap.quantityPicked != "") ?
-                    new BigDecimal(picklistItemMap.quantityPicked) : null
+            Integer quantityPicked = (picklistItemMap.quantityPicked != null && picklistItemMap.quantityPicked != "") ?
+                    picklistItemMap.quantityPicked as Integer : null
 
-            BigDecimal quantityAllocated = (picklistItemMap.quantityAllocated != null && picklistItemMap.quantityAllocated != "") ?
-                    new BigDecimal(picklistItemMap.quantityAllocated) : null
-
-            Integer quantityToPick = quantityAllocated?.intValueExact()
+            Integer quantityToPick = (picklistItemMap.quantityAllocated != null && picklistItemMap.quantityAllocated != "") ?
+                    picklistItemMap.quantityAllocated as Integer : null
 
             if (quantityPicked == null && quantityToPick == null) {
                 return
@@ -2050,7 +2048,7 @@ class StockMovementService {
             String comment = picklistItemMap.comment
 
             createOrUpdatePicklistItem(requisitionItem, picklistItem, inventoryItem, binLocation,
-                    quantityPicked?.intValueExact(), reasonCode, comment, isAutoAllocated, quantityToPick)
+                    quantityPicked, reasonCode, comment, isAutoAllocated, quantityToPick)
         }
     }
 

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -1941,9 +1941,7 @@ class StockMovementService {
             requisitionItem.addToPicklistItems(picklistItem)
             picklistItem.inventoryItem = inventoryItem
             picklistItem.binLocation = binLocation
-            // Safeguard: Ensure allocated quantity is never less than picked quantity.
-            // The frontend validates that picked <= allocated, but this protects against API misuse.
-            picklistItem.quantity = quantityPicked ?: quantityToPick
+            picklistItem.quantity = quantityToPick != null ? quantityToPick : (quantityPicked ?: 0)
             picklistItem.quantityPicked = quantityPicked ?: 0
             picklistItem.reasonCode = reasonCode ?: null
             picklistItem.comment = comment
@@ -2004,6 +2002,25 @@ class StockMovementService {
     void updatePicklistItem(StockMovementItem stockMovementItem, List picklistItems, String reasonCode) {
         RequisitionItem requisitionItem = RequisitionItem.get(stockMovementItem.id)
         Boolean isAutoAllocated = requisitionItem.autoAllocated ?: false
+        Integer quantityRequired = requisitionItem.calculateQuantityRequired() ?: 0
+
+        // Server-side safeguard: total allocated and total picked must not exceed quantity required
+        Integer totalAllocated = 0
+        Integer totalPicked = 0
+        picklistItems.each { picklistItemMap ->
+            BigDecimal qty = (picklistItemMap.quantityAllocated != null && picklistItemMap.quantityAllocated != "") ?
+                    new BigDecimal(picklistItemMap.quantityAllocated) : null
+            BigDecimal picked = (picklistItemMap.quantityPicked != null && picklistItemMap.quantityPicked != "") ?
+                    new BigDecimal(picklistItemMap.quantityPicked) : null
+            totalAllocated += qty?.intValueExact() ?: 0
+            totalPicked += picked?.intValueExact() ?: 0
+        }
+        if (totalAllocated > quantityRequired) {
+            throw new IllegalArgumentException("Total allocated quantity (${totalAllocated}) exceeds quantity required (${quantityRequired})")
+        }
+        if (totalPicked > quantityRequired) {
+            throw new IllegalArgumentException("Total picked quantity (${totalPicked}) exceeds quantity required (${quantityRequired})")
+        }
 
         clearPicklist(requisitionItem)
 

--- a/src/js/components/stock-movement-wizard/modals/EditPickModal.jsx
+++ b/src/js/components/stock-movement-wizard/modals/EditPickModal.jsx
@@ -157,19 +157,19 @@ function validate(values) {
   errors.availableItems = [];
   _.forEach(values.availableItems, (item, key) => {
     errors.availableItems[key] = errors.availableItems[key] || {};
-    if (item.quantityPicked > item.quantityAvailable) {
+    if ((item.quantityPicked || 0) > (item.quantityAvailable || 0)) {
       errors.availableItems[key].quantityPicked = 'react.stockMovement.errors.higherTyPicked.label';
     }
-    if (item.quantityPicked < 0) {
+    if ((item.quantityPicked || 0) < 0) {
       errors.availableItems[key].quantityPicked = 'react.stockMovement.errors.negativeQtyPicked.label';
     }
-    if (item.quantityAllocated < 0) {
+    if ((item.quantityAllocated || 0) < 0) {
       errors.availableItems[key].quantityAllocated = 'react.stockMovement.errors.negativeQtyAllocated.label';
     }
-    if (item.quantityAllocated > item.quantityAvailable) {
+    if ((item.quantityAllocated || 0) > (item.quantityAvailable || 0)) {
       errors.availableItems[key].quantityAllocated = 'react.stockMovement.errors.higherThanAvailable.label';
     }
-    if (item.quantityPicked > item.quantityAllocated) {
+    if ((item.quantityPicked || 0) > (item.quantityAllocated || 0)) {
       errors.availableItems[key].quantityPicked = 'react.stockMovement.errors.pickedHigherThanAllocated.label';
     }
   });
@@ -194,6 +194,15 @@ function validate(values) {
       (sum + (val.quantityPicked ? _.toInteger(val.quantityPicked) : 0)),
     0,
   );
+
+  if (pickedSum > values.quantityRequired) {
+    _.forEach(values.availableItems, (item, key) => {
+      if (item.quantityPicked > 0) {
+        errors.availableItems[key] = errors.availableItems[key] || {};
+        errors.availableItems[key].quantityPicked = 'react.stockMovement.errors.pickedHigherThanRequired.label';
+      }
+    });
+  }
 
   if (_.some(values.availableItems, (val) => !_.isNil(val.quantityPicked))
     && !values.reasonCode && pickedSum !== values.quantityRequired) {

--- a/src/js/components/stock-movement-wizard/outbound/PickPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/PickPage.jsx
@@ -826,7 +826,9 @@ class PickPage extends Component {
         values: ({
           ...prevState.values,
           pickPageItems: picklistItems
-            .map((item) => ({ ...item, picklistItems: [], quantityPicked: 0 })),
+            .map((item) => ({
+              ...item, picklistItems: [], quantityPicked: 0, quantityAllocated: 0,
+            })),
         }),
       }));
     } finally {


### PR DESCRIPTION
…edit pick modal

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket: https://openboxes.atlassian.net/browse/OBLS-677**

**Description:**
  - Fixed a bug where allocated quantity could exceed required and picked quantities after 
  saving in the edit pick modal                                                            
  - Added frontend validation preventing total picked quantity from exceeding quantity     
  required                                                                                 
  - Fixed all per-row validations in the edit pick modal to default to 0 for undefined/null
   values, preventing silent validation bypasses (e.g. 5 > undefined → false in JS)        
  - Fixed backend createOrUpdatePicklistItem to respect the explicit allocated quantity    
  from the frontend instead of silently overwriting it with picked quantity                
  - Added server-side safeguard in updatePicklistItem rejecting requests where total
  allocated or total picked exceeds quantity required                                      
  - Fixed "Clear pick" on the pick page to also reset quantityAllocated in the table, not
  just quantityPicked

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
