### PR TITLE
OBPIH-6803 show most recent event on stock movement view

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/inventory/StockMovementController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/inventory/StockMovementController.groovy
@@ -154,18 +154,18 @@ class StockMovementController {
 
     def show() {
         Location currentLocation = Location.get(session?.warehouse?.id)
-        HistoryItem newestHistoryItem = null
+        HistoryItem latestHistoryItem = null
 
         // Pull Outbound Stock movement (Requisition based) or Outbound or Inbound Return (Order based)
         def stockMovement = outboundStockMovementService.getStockMovement(params.id)
         if (stockMovement) {
-            newestHistoryItem = outboundStockMovementService.getNewestHistoryItem(stockMovement)
+            latestHistoryItem = outboundStockMovementService.getLatestHistoryItem(stockMovement)
         }
 
         // For inbound stockMovement only
         if (!stockMovement) {
             stockMovement =  stockMovementService.getStockMovement(params.id)
-            newestHistoryItem = stockMovementService.getNewestHistoryItem(stockMovement)
+            latestHistoryItem = stockMovementService.getLatestHistoryItem(stockMovement)
         }
         stockMovement.documents = stockMovementService.getDocuments(stockMovement)
 
@@ -175,7 +175,7 @@ class StockMovementController {
             render(view: "show", model: [
                     stockMovement: stockMovement,
                     currentLocation: currentLocation,
-                    newestHistoryItem: newestHistoryItem,
+                    latestHistoryItem: latestHistoryItem,
             ])
         }
     }

--- a/grails-app/controllers/org/pih/warehouse/inventory/StockMovementController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/inventory/StockMovementController.groovy
@@ -154,18 +154,29 @@ class StockMovementController {
 
     def show() {
         Location currentLocation = Location.get(session?.warehouse?.id)
+        HistoryItem newestHistoryItem = null
+
         // Pull Outbound Stock movement (Requisition based) or Outbound or Inbound Return (Order based)
         def stockMovement = outboundStockMovementService.getStockMovement(params.id)
+        if (stockMovement) {
+            newestHistoryItem = outboundStockMovementService.getNewestHistoryItem(stockMovement)
+        }
+
         // For inbound stockMovement only
         if (!stockMovement) {
             stockMovement =  stockMovementService.getStockMovement(params.id)
+            newestHistoryItem = stockMovementService.getNewestHistoryItem(stockMovement)
         }
         stockMovement.documents = stockMovementService.getDocuments(stockMovement)
 
         if (stockMovement?.order) {
             render(view: "/returns/show", model: [stockMovement: stockMovement, currentLocation: currentLocation])
         } else {
-            render(view: "show", model: [stockMovement: stockMovement, currentLocation: currentLocation])
+            render(view: "show", model: [
+                    stockMovement: stockMovement,
+                    currentLocation: currentLocation,
+                    newestHistoryItem: newestHistoryItem,
+            ])
         }
     }
 

--- a/grails-app/domain/org/pih/warehouse/core/EventType.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/EventType.groovy
@@ -32,22 +32,22 @@ class EventType implements Comparable<EventType>, Serializable {
     EventCode eventCode
 
     /**
-     * True if the event type is supported by the application instance.
+     * True if the event type is enabled by the application instance.
      *
      * We add this field so that implementations can disable the event type while still being able to see it
-     * in event type list views. This is especially useful for non-custom event types, which will be created
+     * in event type list views. This is especially useful for system event types, which will be created
      * and enabled by default.
      */
-    boolean supported = true
+    boolean active = true
 
     static transients = ["optionValue"]
     static constraints = {
         name(nullable: false, maxSize: 255)
         description(nullable: true, maxSize: 255)
         sortOrder(nullable: true)
-        eventCode(nullable: false, validator: {
-            if (!it.customEvent && countByEventCode(it) > 0) {
-                return ["invalid.notUnique", it]
+        eventCode(nullable: false, validator: { EventCode eventCode, EventType eventType ->
+            if (eventType.isDirty("eventCode") && !eventCode.customEvent && countByEventCode(eventCode) > 0) {
+                return ["invalid.notUnique", eventCode]
             }
             return true
         })
@@ -76,7 +76,7 @@ class EventType implements Comparable<EventType>, Serializable {
     static List<EventType> listCustomEventTypes() {
         return createCriteria().list {
             'in'('eventCode', EventCode.listCustomEventTypeCodes())
-            eq("supported", true)
+            eq("active", true)
         }
     }
 }

--- a/grails-app/domain/org/pih/warehouse/core/EventType.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/EventType.groovy
@@ -9,13 +9,16 @@
  **/
 package org.pih.warehouse.core
 
-
 /**
- * Represents the type of an Event
+ * Represents the subset of {@link EventCode} that are supported by the specific application instance.
  *
- * This is distinct from ShipmentStatus in that status is meant to reflect the overall
- * status of a Shipment from Supplier to final destination, whereas ShipmentEvent is
- * meant to represent a particular Event which occurs during the course of Shipment.
+ * This is useful because it allows implementations to:
+ * 1) exclude some event codes. For example, an implementation doesn't distinguish between PICKED vs PACKED.
+ * 2) create their own custom event types (via the CUSTOM event code).
+ * 3) define their own custom sort order for event types.
+ *
+ * As such, EventType can be seen as a wrapper on EventCode. EventType should have a one-to-one mapping
+ * to EventCode, *except* for the CUSTOM event code, which can have multiple event types.
  */
 class EventType implements Comparable<EventType>, Serializable {
 
@@ -26,14 +29,28 @@ class EventType implements Comparable<EventType>, Serializable {
     Date dateCreated
     Date lastUpdated
 
-    EventCode eventCode        // CREATED, SHIPPED or RECEIVED
+    EventCode eventCode
+
+    /**
+     * True if the event type is supported by the application instance.
+     *
+     * We add this field so that implementations can disable the event type while still being able to see it
+     * in event type list views. This is especially useful for non-custom event types, which will be created
+     * and enabled by default.
+     */
+    boolean supported = true
 
     static transients = ["optionValue"]
     static constraints = {
         name(nullable: false, maxSize: 255)
         description(nullable: true, maxSize: 255)
         sortOrder(nullable: true)
-        eventCode(nullable: false)
+        eventCode(nullable: false, validator: {
+            if (!it.customEvent && countByEventCode(it) > 0) {
+                return ["invalid.notUnique", it]
+            }
+            return true
+        })
         dateCreated(display: false)
         lastUpdated(display: false)
         optionValue(display: false)
@@ -59,13 +76,7 @@ class EventType implements Comparable<EventType>, Serializable {
     static List<EventType> listCustomEventTypes() {
         return createCriteria().list {
             'in'('eventCode', EventCode.listCustomEventTypeCodes())
+            eq("supported", true)
         }
-    }
-
-    EventTypeDto toDto() {
-        return new EventTypeDto(
-                name: name,
-                eventCode: eventCode,
-        )
     }
 }

--- a/grails-app/domain/org/pih/warehouse/core/EventType.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/EventType.groovy
@@ -46,7 +46,10 @@ class EventType implements Comparable<EventType>, Serializable {
         description(nullable: true, maxSize: 255)
         sortOrder(nullable: true)
         eventCode(nullable: false, validator: { EventCode eventCode, EventType eventType ->
-            if (eventType.isDirty("eventCode") && !eventCode.customEvent && countByEventCode(eventCode) > 0) {
+            // System event codes should have a 1-to-1 mapping to EventType. Only validate if the code is being changed.
+            // Otherwise we can get in a scenario where we count ourselves when checking for types with the given code.
+            boolean codeIsDirty = eventType.id == null || eventType.isDirty("eventCode")
+            if (codeIsDirty && eventCode.isSystemEvent && EventType.countByEventCode(eventCode) > 0) {
                 return ["invalid.notUnique", eventCode]
             }
             return true

--- a/grails-app/domain/org/pih/warehouse/core/EventTypeDto.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/EventTypeDto.groovy
@@ -3,6 +3,9 @@ package org.pih.warehouse.core
 class EventTypeDto {
 
     String name
-
     EventCode eventCode
+
+    String toString() {
+        return name
+    }
 }

--- a/grails-app/domain/org/pih/warehouse/inventory/OutboundStockMovement.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/OutboundStockMovement.groovy
@@ -6,8 +6,10 @@ import org.pih.warehouse.api.StockMovementType
 import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.Person
+import org.pih.warehouse.core.ReferenceDocument
 import org.pih.warehouse.core.RoleType
 import org.pih.warehouse.core.User
+import org.pih.warehouse.core.history.Historizable
 import org.pih.warehouse.order.Order
 import org.pih.warehouse.order.OrderItemStatusCode
 import org.pih.warehouse.requisition.Requisition
@@ -22,7 +24,7 @@ import org.pih.warehouse.shipping.ShipmentType
 import org.pih.warehouse.api.StockMovementStatusContext
 import util.StockMovementStatusResolver
 
-class OutboundStockMovement implements Serializable, Validateable {
+class OutboundStockMovement implements Serializable, Validateable, Historizable {
 
     String id
     String name
@@ -132,6 +134,7 @@ class OutboundStockMovement implements Serializable, Validateable {
         statusCode(nullable: true)
 
         statusSortOrder(nullable: true)
+        referenceDocument(nullable: true)
     }
 
 
@@ -343,5 +346,13 @@ class OutboundStockMovement implements Serializable, Validateable {
     // This has to be named with the get prefix to align with the StockMovement DTO
     boolean getIsReturn() {
         return shipment?.isFromReturnOrder
+    }
+
+    @Override
+    ReferenceDocument getReferenceDocument() {
+        // The stock movement itself is not a concrete entity, and so does not have a reference document. The event
+        // history of a stock movement is built from the event history of its sub-components (Shipment, Order),
+        // so the stock movement itself is "referenceable" only in that its sub-components are referenceable.
+        return null
     }
 }

--- a/grails-app/domain/org/pih/warehouse/order/Order.groovy
+++ b/grails-app/domain/org/pih/warehouse/order/Order.groovy
@@ -21,7 +21,7 @@ import org.pih.warehouse.picklist.Picklist
 import org.pih.warehouse.shipping.Shipment
 import org.pih.warehouse.shipping.ShipmentStatusCode
 
-class Order implements Serializable, Historizable<OrderHistoryProvider> {
+class Order implements Serializable, Historizable {
 
     def beforeInsert() {
         createdBy = AuthService.currentUser
@@ -612,5 +612,17 @@ class Order implements Serializable, Historizable<OrderHistoryProvider> {
             default:
                 return toJson()
         }
+    }
+
+    @Override
+    ReferenceDocument getReferenceDocument() {
+        return new ReferenceDocument(
+                label: orderNumber,
+                url: "/openboxes/order/show/${id}",
+                id: id,
+                identifier: orderNumber,
+                description: description,
+                name: name,
+        )
     }
 }

--- a/grails-app/domain/org/pih/warehouse/shipping/Shipment.groovy
+++ b/grails-app/domain/org/pih/warehouse/shipping/Shipment.groovy
@@ -24,7 +24,7 @@ import org.pih.warehouse.order.RefreshOrderSummaryEvent
 import org.pih.warehouse.receiving.Receipt
 import org.pih.warehouse.requisition.Requisition
 
-class Shipment implements Comparable, Serializable, Historizable<ShipmentHistoryProvider> {
+class Shipment implements Comparable, Serializable, Historizable {
 
     def publishRefreshEvent() {
         Holders.grailsApplication.mainContext.publishEvent(new RefreshOrderSummaryEvent(this))
@@ -718,5 +718,17 @@ class Shipment implements Comparable, Serializable, Historizable<ShipmentHistory
     void resynchronizeEventAndStatus() {
         currentStatus = getStatus().code
         currentEvent = getMostRecentSystemEvent()
+    }
+
+    @Override
+    ReferenceDocument getReferenceDocument() {
+        return new ReferenceDocument(
+                label: shipmentNumber,
+                url: "/openboxes/stockMovement/show/${requisition?.id ?: id}",
+                id: id,
+                identifier: shipmentNumber,
+                description: description,
+                name: name,
+        )
     }
 }

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -1089,7 +1089,7 @@ event.dateLogged.label=Date Logged
 event.identifier.label=Event Identifier
 # Event type messages
 eventType.label=Event type
-eventType.eventCode.invalid.notUnique="A non-custom event type already exists with code {3}"
+eventType.eventCode.invalid.notUnique=A non-custom event type already exists with code {3}
 eventTypes.label=Event types
 # Fast movers report
 fastMovers.label=Fast movers

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -803,6 +803,7 @@ enum.EventCode.REJECTED=Rejected
 enum.EventCode.SUBMITTED=Submitted
 enum.EventCode.PUTAWAY=Putaway
 enum.EventCode.PARTIALLY_PUTAWAY=Partial Putaway
+enum.EventCode.CUSTOM=Custom
 enum.EventLogCode.EVENT_OCCURRED=Event occurred
 enum.EventLogCode.EVENT_ROLLBACK_OCCURRED=Event rolled back
 enum.InventoryStatus.INACTIVE=Inactive
@@ -1088,6 +1089,7 @@ event.dateLogged.label=Date Logged
 event.identifier.label=Event Identifier
 # Event type messages
 eventType.label=Event type
+eventType.eventCode.invalid.notUnique="A non-custom event type already exists with code {3}"
 eventTypes.label=Event types
 # Fast movers report
 fastMovers.label=Fast movers
@@ -3276,6 +3278,7 @@ stockMovement.requestType.label=Request type
 stockMovement.desiredDateOfDelivery=Desired date of delivery
 stockMovement.dateRequested.label=Date Requested
 stockMovement.status.label=Status
+stockMovement.mostRecentEvent.label=Most recent event
 stockMovement.identifier.label=Identifier
 stockMovement.trackingNumber.label=Tracking Number
 stockMovement.driverName.label=Driver Name

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -1089,7 +1089,7 @@ event.dateLogged.label=Date Logged
 event.identifier.label=Event Identifier
 # Event type messages
 eventType.label=Event type
-eventType.eventCode.invalid.notUnique=A non-custom event type already exists with code {3}
+eventType.eventCode.invalid.notUnique=A system event type already exists with code {3}
 eventTypes.label=Event types
 # Fast movers report
 fastMovers.label=Fast movers

--- a/grails-app/migrations/0.9.x/changelog-2026-04-29-0000-add-active-to-event-type.xml
+++ b/grails-app/migrations/0.9.x/changelog-2026-04-29-0000-add-active-to-event-type.xml
@@ -6,11 +6,11 @@
     <changeSet author="ewaterman" id="260420260000-0">
         <preConditions onFail="MARK_RAN">
             <not>
-                <columnExists tableName="event_type" columnName="supported"/>
+                <columnExists tableName="event_type" columnName="active"/>
             </not>
         </preConditions>
         <addColumn tableName="event_type">
-            <column name="supported" type="BIT" defaultValueBoolean="true">
+            <column name="active" type="BIT" defaultValueBoolean="true">
                 <constraints nullable="false" />
             </column>
         </addColumn>

--- a/grails-app/migrations/0.9.x/changelog-2026-04-29-0000-add-supported-to-event-type.xml
+++ b/grails-app/migrations/0.9.x/changelog-2026-04-29-0000-add-supported-to-event-type.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+
+    <changeSet author="ewaterman" id="260420260000-0">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="event_type" columnName="supported"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="event_type">
+            <column name="supported" type="BIT" defaultValueBoolean="true">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/grails-app/migrations/0.9.x/changelog.xml
+++ b/grails-app/migrations/0.9.x/changelog.xml
@@ -43,5 +43,5 @@
     <include file="0.9.x/changelog-2026-02-10-1200-create-table-shipment-event-log.xml" />
     <include file="0.9.x/changelog-2026-03-30-0000-create-table-order-event-log.xml" />
     <include file="0.9.x/changelog-2026-04-01-1500-add-unique-constraint-party-code.xml" />
-    <include file="0.9.x/changelog-2026-04-29-0000-add-supported-to-event-type.xml" />
+    <include file="0.9.x/changelog-2026-04-29-0000-add-active-to-event-type.xml" />
 </databaseChangeLog>

--- a/grails-app/migrations/0.9.x/changelog.xml
+++ b/grails-app/migrations/0.9.x/changelog.xml
@@ -43,4 +43,5 @@
     <include file="0.9.x/changelog-2026-02-10-1200-create-table-shipment-event-log.xml" />
     <include file="0.9.x/changelog-2026-03-30-0000-create-table-order-event-log.xml" />
     <include file="0.9.x/changelog-2026-04-01-1500-add-unique-constraint-party-code.xml" />
+    <include file="0.9.x/changelog-2026-04-29-0000-add-supported-to-event-type.xml" />
 </databaseChangeLog>

--- a/grails-app/services/org/pih/warehouse/inventory/OutboundStockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/OutboundStockMovementService.groovy
@@ -234,13 +234,14 @@ class OutboundStockMovementService {
     }
 
     /**
-     * Returns the most recently added non-rolled back event that occurred on an outbound stock movement.
+     * Returns the most recently added event that occurred on an outbound stock movement.
      */
-    HistoryItem getNewestHistoryItem(OutboundStockMovement stockMovement) {
+    HistoryItem getLatestHistoryItem(OutboundStockMovement stockMovement) {
         HistoryContext context = new HistoryContext(
-                includeRolledBackEvents: false,
+                includeRolledBackEvents: true,  // Noting that we *do* want to count rollbacks here
                 limit: 1,
         )
-        return outboundHistoryProvider.getHistory(stockMovement, context)?.first()
+        List<HistoryItem> historyItems = outboundHistoryProvider.getHistory(stockMovement, context)
+        return historyItems ? historyItems[0] : null
     }
 }

--- a/grails-app/services/org/pih/warehouse/inventory/OutboundStockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/OutboundStockMovementService.groovy
@@ -10,11 +10,13 @@
 package org.pih.warehouse.inventory
 
 import grails.gorm.transactions.Transactional
-import org.hibernate.ObjectNotFoundException
 import org.pih.warehouse.core.Constants
 import org.hibernate.criterion.CriteriaSpecification
 import org.hibernate.sql.JoinType
 import org.pih.warehouse.api.StockMovement
+import org.pih.warehouse.core.history.HistoryContext
+import org.pih.warehouse.core.history.HistoryItem
+import org.pih.warehouse.outbound.OutboundHistoryProvider
 import org.pih.warehouse.requisition.RequisitionSourceType
 import org.pih.warehouse.requisition.RequisitionStatus
 import org.pih.warehouse.shipping.ShipmentType
@@ -22,7 +24,9 @@ import org.pih.warehouse.shipping.ShipmentType
 @Transactional
 class OutboundStockMovementService {
 
-    def getStockMovement(String id) {
+    OutboundHistoryProvider outboundHistoryProvider
+
+    OutboundStockMovement getStockMovement(String id) {
         OutboundStockMovement outboundStockMovement = OutboundStockMovement.get(id)
 
         // Temporary returning outboundStockMovement even if not found.
@@ -216,5 +220,27 @@ class OutboundStockMovementService {
         }
 
         return stockMovements
+    }
+
+    /**
+     * Returns a chronological history of the events that have occurred on an outbound stock movement.
+     */
+    List<HistoryItem> getHistory(OutboundStockMovement stockMovement) {
+        HistoryContext context = new HistoryContext(
+                includeRolledBackEvents: true,
+                limit: null, // Fetch the full history
+        )
+        return outboundHistoryProvider.getHistory(stockMovement, context)
+    }
+
+    /**
+     * Returns the most recently added non-rolled back event that occurred on an outbound stock movement.
+     */
+    HistoryItem getNewestHistoryItem(OutboundStockMovement stockMovement) {
+        HistoryContext context = new HistoryContext(
+                includeRolledBackEvents: false,
+                limit: 1,
+        )
+        return outboundHistoryProvider.getHistory(stockMovement, context)?.first()
     }
 }

--- a/grails-app/services/org/pih/warehouse/inventory/OutboundStockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/OutboundStockMovementService.groovy
@@ -223,12 +223,11 @@ class OutboundStockMovementService {
     }
 
     /**
-     * Returns a chronological history of the events that have occurred on an outbound stock movement.
+     * Returns the full, chronological history of the events that have occurred on an outbound stock movement.
      */
     List<HistoryItem> getHistory(OutboundStockMovement stockMovement) {
         HistoryContext context = new HistoryContext(
                 includeRolledBackEvents: true,
-                limit: null, // Fetch the full history
         )
         return outboundHistoryProvider.getHistory(stockMovement, context)
     }

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -1632,14 +1632,15 @@ class StockMovementService {
     }
 
     /**
-     * Returns the most recently added non-rolled back event that occurred on a stock movement.
+     * Returns the most recently added event that occurred on a stock movement.
      */
-    HistoryItem getNewestHistoryItem(StockMovement stockMovement) {
+    HistoryItem getLatestHistoryItem(StockMovement stockMovement) {
         HistoryContext context = new HistoryContext(
-                includeRolledBackEvents: false,
+                includeRolledBackEvents: true,  // Noting that we *do* want to count rollbacks here
                 limit: 1,
         )
-        return stockMovementHistoryProvider.getHistory(stockMovement, context)?.first()
+        List<HistoryItem> historyItems = stockMovementHistoryProvider.getHistory(stockMovement, context)
+        return historyItems ? historyItems[0] : null
     }
 
     List<ReceiptItem> getRequisitionBasedStockMovementReceiptItems(def stockMovement) {

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -33,7 +33,6 @@ import org.pih.warehouse.api.SuggestedItem
 import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.Comment
-import org.pih.warehouse.core.ConfigService
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.Document
 import org.pih.warehouse.core.DocumentCode
@@ -48,6 +47,7 @@ import org.pih.warehouse.core.StockMovementItemParamsCommand
 import org.pih.warehouse.core.StockMovementItemsParamsCommand
 import org.pih.warehouse.core.User
 import org.pih.warehouse.core.UserService
+import org.pih.warehouse.core.history.HistoryContext
 import org.pih.warehouse.core.history.HistoryItem
 import org.pih.warehouse.data.DataService
 import org.pih.warehouse.forecasting.ForecastingService
@@ -63,8 +63,6 @@ import org.pih.warehouse.picklist.PicklistItem
 import org.pih.warehouse.product.Product
 import org.pih.warehouse.product.ProductAssociationTypeCode
 import org.pih.warehouse.product.ProductService
-import org.pih.warehouse.putaway.PutawayService
-import org.pih.warehouse.receiving.Receipt
 import org.pih.warehouse.receiving.ReceiptItem
 import org.pih.warehouse.requisition.ReplenishmentTypeCode
 import org.pih.warehouse.requisition.Requisition
@@ -108,7 +106,7 @@ class StockMovementService {
     UserService userService
     RequisitionDataService requisitionDataService
     GrailsApplication grailsApplication
-    PutawayService putawayService
+    StockMovementHistoryProvider stockMovementHistoryProvider
 
     def createStockMovement(StockMovement stockMovement) {
         if (!stockMovement.validate()) {
@@ -1623,16 +1621,25 @@ class StockMovementService {
     }
 
     /**
-     * Returns a chronological history of the events that have occurred on a stock movement. Stock movement
-     * history is built by combining the history from a number of different sources, including shipment and order.
+     * Returns a chronological history of the events that have occurred on a stock movement.
      */
     List<HistoryItem> getHistory(StockMovement stockMovement) {
-        List<HistoryItem> history = stockMovement?.shipment?.getHistory() ?: []
+        HistoryContext context = new HistoryContext(
+                includeRolledBackEvents: true,
+                limit: null, // Fetch the full history
+        )
+        return stockMovementHistoryProvider.getHistory(stockMovement, context)
+    }
 
-        // Currently the only orders that have event history are putaway orders.
-        history.addAll(putawayService.getPutawayOrders(stockMovement?.shipment).collectMany { it.getHistory() })
-
-        return history.sort()
+    /**
+     * Returns the most recently added non-rolled back event that occurred on a stock movement.
+     */
+    HistoryItem getNewestHistoryItem(StockMovement stockMovement) {
+        HistoryContext context = new HistoryContext(
+                includeRolledBackEvents: false,
+                limit: 1,
+        )
+        return stockMovementHistoryProvider.getHistory(stockMovement, context)?.first()
     }
 
     List<ReceiptItem> getRequisitionBasedStockMovementReceiptItems(def stockMovement) {

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -1783,12 +1783,11 @@ class StockMovementService {
     }
 
     /**
-     * Returns a chronological history of the events that have occurred on a stock movement.
+     * Returns the full, chronological history of the events that have occurred on a stock movement.
      */
     List<HistoryItem> getHistory(StockMovement stockMovement) {
         HistoryContext context = new HistoryContext(
                 includeRolledBackEvents: true,
-                limit: null, // Fetch the full history
         )
         return stockMovementHistoryProvider.getHistory(stockMovement, context)
     }

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -108,7 +108,6 @@ class StockMovementService {
     RequisitionDataService requisitionDataService
     GrailsApplication grailsApplication
     StockMovementHistoryProvider stockMovementHistoryProvider
-    PutawayService putawayService
     MessageLocalizer messageLocalizer
 
     def createStockMovement(StockMovement stockMovement) {

--- a/grails-app/services/org/pih/warehouse/putaway/PutawayService.groovy
+++ b/grails-app/services/org/pih/warehouse/putaway/PutawayService.groovy
@@ -14,18 +14,20 @@ import grails.gorm.transactions.Transactional
 import org.apache.commons.beanutils.BeanUtils
 import org.hibernate.criterion.CriteriaSpecification
 import org.hibernate.sql.JoinType
+import org.springframework.beans.factory.annotation.Value
+
 import org.pih.warehouse.api.Putaway
 import org.pih.warehouse.api.PutawayItem
 import org.pih.warehouse.api.PutawayStatus
 import org.pih.warehouse.core.ActivityCode
-import org.pih.warehouse.core.ConfigService
 import org.pih.warehouse.core.Constants
+import org.pih.warehouse.core.EventCode
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.inventory.InventoryItem
 import org.pih.warehouse.inventory.InventoryService
 import org.pih.warehouse.inventory.TransferStockCommand
 import org.pih.warehouse.order.Order
-import org.pih.warehouse.order.OrderEventLogger
+import org.pih.warehouse.order.OrderEventManager
 import org.pih.warehouse.order.OrderItem
 import org.pih.warehouse.order.OrderItemStatusCode
 import org.pih.warehouse.order.OrderStatus
@@ -37,11 +39,13 @@ import org.pih.warehouse.shipping.Shipment
 @Transactional
 class PutawayService {
 
-    ConfigService configService
     InventoryService inventoryService
     def productAvailabilityService
     GrailsApplication grailsApplication
-    OrderEventLogger orderEventLogger
+    OrderEventManager orderEventManager
+
+    @Value('${openboxes.receiving.createReceivingLocation.enabled}')
+    Boolean dynamicReceivingBinsEnabled
 
     def getPutawayCandidates(Location location) {
         List binLocationEntries = productAvailabilityService.getAvailableQuantityOnHandByBinLocation(location)
@@ -124,8 +128,6 @@ class PutawayService {
 
         // Because we don't have a formal relationship between putaway order and receipt, if we are not creating
         // designated receiving/putaway bins, we can't establish a unique mapping between the receipt and its putaway.
-        Boolean dynamicReceivingBinsEnabled = configService.getProperty(
-                "openboxes.receiving.createReceivingLocation.enabled", Boolean)
         if (!dynamicReceivingBinsEnabled) {
             return []
         }
@@ -149,7 +151,7 @@ class PutawayService {
         for (ReceiptItem receiptItem in receipt.receiptItems) {
             // If the item was directly received to a non-receiving bin, there won't be any putaway orders.
             Location receiptBinLocation = receiptItem.binLocation
-            if (!receiptBinLocation.supports(ActivityCode.PUTAWAY_STOCK)) {
+            if (!receiptBinLocation?.supports(ActivityCode.PUTAWAY_STOCK)) {
                 continue
             }
 
@@ -230,7 +232,7 @@ class PutawayService {
             inventoryService.transferStock(command)
         }
 
-        logPutaway(order, putaway)
+        createPutawayEvent(order, putaway)
 
         grailsApplication.mainContext.publishEvent(new PutawayCompletedEvent(putaway))
 
@@ -238,17 +240,14 @@ class PutawayService {
     }
 
     /**
-     * Logs a putaway event, adding it to the collection of event logs for the putaway order.
+     * Create a putaway event and log its occurrence.
      */
-    private void logPutaway(Order order, Putaway putaway) {
-        Boolean dynamicReceivingBinsEnabled =
-                configService.getStaticProperty("openboxes.receiving.createReceivingLocation.enabled", Boolean)
+    private void createPutawayEvent(Order order, Putaway putaway) {
+        EventCode eventCode = !dynamicReceivingBinsEnabled || isFinalPutaway(order, putaway) ?
+                EventCode.PUTAWAY :
+                EventCode.PARTIALLY_PUTAWAY
 
-        if (!dynamicReceivingBinsEnabled || isFinalPutaway(order, putaway)) {
-            orderEventLogger.logPutaway(order, putaway)
-            return
-        }
-        orderEventLogger.logPartialPutaway(order, putaway)
+        orderEventManager.createPutawayEvent(order, putaway, eventCode)
     }
 
     /**

--- a/grails-app/services/org/pih/warehouse/putaway/PutawayService.groovy
+++ b/grails-app/services/org/pih/warehouse/putaway/PutawayService.groovy
@@ -44,7 +44,7 @@ class PutawayService {
     GrailsApplication grailsApplication
     OrderEventManager orderEventManager
 
-    @Value('${openboxes.receiving.createReceivingLocation.enabled}')
+    @Value('${openboxes.receiving.createReceivingLocation.enabled:true}')
     Boolean dynamicReceivingBinsEnabled
 
     def getPutawayCandidates(Location location) {

--- a/grails-app/views/stockMovement/show.gsp
+++ b/grails-app/views/stockMovement/show.gsp
@@ -248,6 +248,14 @@
                                 ${stockMovement?.displayStatus?.label}
                             </td>
                         </tr>
+                        <tr class="prop">
+                            <td class="name">
+                                <g:message code="stockMovement.mostRecentEvent.label"/>
+                            </td>
+                            <td class="value">
+                                ${newestHistoryItem?.eventType?.name}
+                            </td>
+                        </tr>
                         <g:if test="${stockMovement?.shipment?.isFromPurchaseOrder}">
                             <tr class="prop">
                                 <td class="name">

--- a/grails-app/views/stockMovement/show.gsp
+++ b/grails-app/views/stockMovement/show.gsp
@@ -253,7 +253,15 @@
                                 <g:message code="stockMovement.mostRecentEvent.label"/>
                             </td>
                             <td class="value">
-                                ${newestHistoryItem?.eventType?.name}
+                                %{-- Shipment events link to the SM but we're already on that page so hide those links --}%
+                                <g:if test="${latestHistoryItem?.eventType?.eventCode?.isPutawayEvent()}">
+                                    <a href="${latestHistoryItem?.referenceDocument?.url}">
+                                        ${latestHistoryItem?.eventType?.name} ${latestHistoryItem?.referenceDocument?.identifier}
+                                    </a>
+                                </g:if>
+                                <g:else>
+                                    ${latestHistoryItem?.eventType?.name}
+                                </g:else>
                             </td>
                         </tr>
                         <g:if test="${stockMovement?.shipment?.isFromPurchaseOrder}">

--- a/src/main/groovy/org/pih/warehouse/api/StockMovement.groovy
+++ b/src/main/groovy/org/pih/warehouse/api/StockMovement.groovy
@@ -8,8 +8,10 @@ import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.Person
+import org.pih.warehouse.core.ReferenceDocument
 import org.pih.warehouse.core.RoleType
 import org.pih.warehouse.core.User
+import org.pih.warehouse.core.history.Historizable
 import org.pih.warehouse.inventory.StockMovementStatusCode
 import org.pih.warehouse.order.Order
 import org.pih.warehouse.order.OrderItemStatusCode
@@ -27,8 +29,7 @@ import org.pih.warehouse.auth.AuthService
 import util.ConfigHelper
 import util.StockMovementStatusResolver
 
-
-class StockMovement implements Validateable{
+class StockMovement implements Validateable, Historizable {
 
     String id
     String name
@@ -126,6 +127,7 @@ class StockMovement implements Validateable{
         lastUpdated(nullable: true)
         requestType(nullable: true)
         sourceType(nullable: true)
+        referenceDocument(nullable: true)
     }
 
     Map toJson() {
@@ -521,5 +523,13 @@ class StockMovement implements Validateable{
                 requisition?.status == RequisitionStatus.PENDING_APPROVAL &&
                 (isLocationDestination || isLocationOrigin)) ||
                 (requisition?.status == RequisitionStatus.APPROVED && isLocationOrigin)
+    }
+
+    @Override
+    ReferenceDocument getReferenceDocument() {
+        // The stock movement itself is not a concrete entity, and so does not have a reference document. The event
+        // history of a stock movement is built from the event history of its sub-components (Shipment, Order),
+        // so the stock movement itself is "referenceable" only in that its sub-components are referenceable.
+        return null
     }
 }

--- a/src/main/groovy/org/pih/warehouse/core/EventCode.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/EventCode.groovy
@@ -10,10 +10,12 @@
 package org.pih.warehouse.core
 
 /**
- * Represents a particular category of {@link Event} that can occur during the course of a state-changing operation.
+ * Enumerates the specific, discrete types of {@link Event} that can be triggered via interactions with
+ * the application (even if those events don't end up altering state or status).
  *
- * EventCodes should be broad, categorical, and general purpose. Custom, feature-specific types of events should be
- * created as an {@Link EventType} so that the system remains flexible to a dynamic range of use cases.
+ * Custom, implementation-specific events should be defined by adding an {@link EventType} with the CUSTOM code.
+ *
+ * Avoid working directly with EventCode. Anything that references an EventCode should do so via it's EventType(s).
  */
 enum EventCode {
 
@@ -37,11 +39,23 @@ enum EventCode {
     REJECTED(true),
     SUBMITTED(true),
     PUTAWAY(false),
-    PARTIALLY_PUTAWAY(false)
+    PARTIALLY_PUTAWAY(false),
 
     /**
-     * Returns true if the event code represents a system event, meaning there is internal functionality built
-     * into the app relating to it. As such, triggering this event likely changes state in the app.
+     * Custom, implementation-specific events that are not triggered by application logic. Custom events
+     * can only be triggered manually by users, likely via some create event API call.
+     *
+     * By default, the system will contain no custom events. Custom events need to be configured by adding
+     * an {@link EventType} to the database with the CUSTOM code.
+     */
+    CUSTOM(false)
+
+    /**
+     * Returns true if the event code represents an event that is core to the system, meaning it is directly
+     * tied to state-altering application logic.
+     *
+     * Note that an event can be a non-system event and also not be a custom event. This represents events that
+     * are triggered via application logic but don't have any actual impact on state.
      */
     boolean isSystemEvent
 
@@ -54,7 +68,9 @@ enum EventCode {
      * around it. The event is purely a label representing some state change that is managed outside of the app.
      */
     boolean isCustomEvent() {
-        return !isSystemEvent
+        // This check on isSystemEvent is to support legacy behaviour from before we added the CUSTOM event.
+        // Going forward, custom events should only represent the events that use the CUSTOM code.
+        return !isSystemEvent || this == CUSTOM
     }
 
     static List<EventCode> listCustomEventTypeCodes() {

--- a/src/main/groovy/org/pih/warehouse/core/EventCode.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/EventCode.groovy
@@ -13,7 +13,8 @@ package org.pih.warehouse.core
  * Enumerates the specific, discrete types of {@link Event} that can be triggered via interactions with
  * the application (even if those events don't end up altering state or status).
  *
- * Custom, implementation-specific events should be defined by adding an {@link EventType} with the CUSTOM code.
+ * Custom, implementation-specific events that are not triggered via application logic should be defined
+ * by adding an {@link EventType} with the CUSTOM code.
  *
  * Avoid working directly with EventCode. Anything that references an EventCode should do so via it's EventType(s).
  */
@@ -51,11 +52,11 @@ enum EventCode {
     CUSTOM(false)
 
     /**
-     * Returns true if the event code represents an event that is core to the system, meaning it is directly
-     * tied to state-altering application logic.
+     * Returns true if the event code represents an event that is core to the system, meaning it is triggered
+     * by application logic.
      *
-     * Note that an event can be a non-system event and also not be a custom event. This represents events that
-     * are triggered via application logic but don't have any actual impact on state.
+     * This field only exists for backwards compatability reasons from before we had the CUSTOM code. Going forward,
+     * every event code that is not CUSTOM should be a system event.
      */
     boolean isSystemEvent
 
@@ -65,7 +66,7 @@ enum EventCode {
 
     /**
      * Returns true if the event code represents a custom event, meaning there is no in-app functionality built
-     * around it. The event is purely a label representing some state change that is managed outside of the app.
+     * around it. Custom events are purely labels representing some state change that is managed outside of the app.
      */
     boolean isCustomEvent() {
         // This check on isSystemEvent is to support legacy behaviour from before we added the CUSTOM event.

--- a/src/main/groovy/org/pih/warehouse/core/EventCode.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/EventCode.groovy
@@ -39,8 +39,8 @@ enum EventCode {
     APPROVED(true),
     REJECTED(true),
     SUBMITTED(true),
-    PUTAWAY(false),
-    PARTIALLY_PUTAWAY(false),
+    PUTAWAY(true),
+    PARTIALLY_PUTAWAY(true),
 
     /**
      * Custom, implementation-specific events that are not triggered by application logic. Custom events

--- a/src/main/groovy/org/pih/warehouse/core/EventCode.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/EventCode.groovy
@@ -16,7 +16,7 @@ package org.pih.warehouse.core
  * Custom, implementation-specific events that are not triggered via application logic should be defined
  * by adding an {@link EventType} with the CUSTOM code.
  *
- * Avoid working directly with EventCode. Anything that references an EventCode should do so via it's EventType(s).
+ * Avoid working directly with EventCode. Anything that references an EventCode should do so via its EventType(s).
  */
 enum EventCode {
 

--- a/src/main/groovy/org/pih/warehouse/core/event/EventManager.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/event/EventManager.groovy
@@ -19,7 +19,7 @@ abstract class EventManager {
             throw new RuntimeException("Event code is not a unique identifier for custom events. Fetch by id instead.")
         }
 
-        // Non-custom event types are expected to have a one-to-one mapping to event code
+        // System event types are expected to have a one-to-one mapping to event code
         EventType eventType = EventType.findByEventCode(eventCode)
         if (eventType) {
             return eventType
@@ -28,8 +28,8 @@ abstract class EventManager {
         /*
          * We create the event type if one does not exist for the given code purely for the sake of convenience.
          * It saves us from needing to also create an event type via migration when we add a new event code to
-         * the system. This is only safe to do because non-custom event types have a one-to-one mapping to code.
-         * Implementations will still be able to disable these event types by setting supported to false.
+         * the system. This is only safe to do because system event types have a one-to-one mapping to code.
+         * Implementations will still be able to disable these event types by setting enabled to false.
          */
         return new EventType(
                 name: eventCode.toString(),

--- a/src/main/groovy/org/pih/warehouse/core/event/EventManager.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/event/EventManager.groovy
@@ -1,0 +1,39 @@
+package org.pih.warehouse.core.event
+
+import org.pih.warehouse.core.Event
+import org.pih.warehouse.core.EventCode
+import org.pih.warehouse.core.EventType
+
+/**
+ * Manages the lifecycle (creating and rolling back) of an {@link Event}.
+ */
+abstract class EventManager {
+
+    /**
+     * Fetches the event type associated with the given code, creating one if it does not exist yet.
+     *
+     * Not to be used for the CUSTOM event code since there can be more than one custom event type.
+     */
+    EventType getOrCreateEventType(EventCode eventCode) {
+        if (eventCode == EventCode.CUSTOM) {
+            throw new RuntimeException("Event code is not a unique identifier for custom events. Fetch by id instead.")
+        }
+
+        // Non-custom event types are expected to have a one-to-one mapping to event code
+        EventType eventType = EventType.findByEventCode(eventCode)
+        if (eventType) {
+            return eventType
+        }
+
+        /*
+         * We create the event type if one does not exist for the given code purely for the sake of convenience.
+         * It saves us from needing to also create an event type via migration when we add a new event code to
+         * the system. This is only safe to do because non-custom event types have a one-to-one mapping to code.
+         * Implementations will still be able to disable these event types by setting supported to false.
+         */
+        return new EventType(
+                name: eventCode.toString(),
+                eventCode: eventCode,
+        ).save(failOnError: true)
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/event/EventTypeManager.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/event/EventTypeManager.groovy
@@ -1,13 +1,15 @@
 package org.pih.warehouse.core.event
 
-import org.pih.warehouse.core.Event
+import org.springframework.stereotype.Component
+
 import org.pih.warehouse.core.EventCode
 import org.pih.warehouse.core.EventType
 
 /**
- * Manages the lifecycle (creating and rolling back) of an {@link Event}.
+ * Manages the lifecycle (creating and rolling back) of an {@link EventType}.
  */
-abstract class EventManager {
+@Component
+class EventTypeManager {
 
     /**
      * Fetches the event type associated with the given code, creating one if it does not exist yet.

--- a/src/main/groovy/org/pih/warehouse/core/history/EventLogHistoryProvider.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/history/EventLogHistoryProvider.groovy
@@ -5,9 +5,9 @@ import org.springframework.beans.factory.annotation.Autowired
 
 import org.pih.warehouse.core.Comment
 import org.pih.warehouse.core.Event
+import org.pih.warehouse.core.EventCode
 import org.pih.warehouse.core.EventType
 import org.pih.warehouse.core.EventTypeDto
-import org.pih.warehouse.core.Referenceable
 import org.pih.warehouse.core.date.JavaUtilDateParser
 import org.pih.warehouse.core.localization.MessageLocalizer
 
@@ -15,7 +15,7 @@ import org.pih.warehouse.core.localization.MessageLocalizer
  * A convenience base class for any HistoryProvider that operates on entities whose history is based off
  * of a collection of {@link EventLog}.
  */
-abstract class EventLogHistoryProvider<T extends Referenceable> implements HistoryProvider<T> {
+abstract class EventLogHistoryProvider<T extends Historizable> extends HistoryProvider<T> {
 
     @Autowired
     MessageLocalizer messageLocalizer
@@ -26,15 +26,19 @@ abstract class EventLogHistoryProvider<T extends Referenceable> implements Histo
     abstract Collection<EventLog> getEventLogs(T source)
 
     @Override
-    List<HistoryItem> getHistory(T source) {
+    List<HistoryItem> doGetHistory(T source, HistoryContext context=new HistoryContext()) {
         // The default behaviour assumes the event logs contain all the information that we need to build the history.
         Collection<EventLog> eventLogs = getEventLogs(source)
         List<HistoryItem> historyItems = []
         for (EventLog eventLog in eventLogs) {
+            if (!context.includeRolledBackEvents && isRollbackOrRolledBack(eventLog)) {
+                continue
+            }
+
             HistoryItem historyItem = getHistoryItem(source, eventLog)
             historyItems.add(historyItem)
         }
-        return historyItems.sort()
+        return historyItems
     }
 
     /**
@@ -62,14 +66,32 @@ abstract class EventLogHistoryProvider<T extends Referenceable> implements Histo
                 dateLogged: event.dateCreated,
                 date: event.eventDate,
                 location: event.eventLocation,
-                eventType: new EventTypeDto(
-                        name: eventType ? messageLocalizer.localizeEnumValue(eventType.eventCode) : null,
-                        eventCode: eventType?.eventCode,
-                ),
+                eventType: eventTypeToDto(eventType),
                 comment: event.comment,
                 createdBy: event.createdBy,
-                referenceDocument: getReferenceDocument(source),
+                referenceDocument: source.getReferenceDocument(),
         )
+    }
+
+    private EventTypeDto eventTypeToDto(EventType eventType) {
+        if (!eventType) {
+            return new EventTypeDto()
+        }
+
+        EventCode eventCode = eventType.eventCode
+
+        // Custom event types are dynamic and so won't have a localizable name. Simply use the name from the database.
+        String name = eventCode == EventCode.CUSTOM ? eventType.name : messageLocalizer.localizeEnumValue(eventCode)
+
+        return new EventTypeDto(
+                name: name,
+                eventCode: eventCode,
+        )
+    }
+
+    private boolean isRollbackOrRolledBack(EventLog eventLog) {
+        return eventLog.eventLogCode == EventLogCode.EVENT_ROLLBACK_OCCURRED ||
+                (eventLog.eventLogCode == EventLogCode.EVENT_OCCURRED && eventLog.event == null)
     }
 
     private HistoryItem getHistoryItem(T source, EventLog eventLog) {
@@ -98,7 +120,7 @@ abstract class EventLogHistoryProvider<T extends Referenceable> implements Histo
                 ),
                 comment: StringUtils.isBlank(eventLog.message) ? null : new Comment(comment: eventLog.message),
                 createdBy: eventLog.createdBy,
-                referenceDocument: getReferenceDocument(source),
+                referenceDocument: source.getReferenceDocument(),
         )
     }
 }

--- a/src/main/groovy/org/pih/warehouse/core/history/EventLogHistoryProvider.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/history/EventLogHistoryProvider.groovy
@@ -69,7 +69,7 @@ abstract class EventLogHistoryProvider<T extends Historizable> extends HistoryPr
                 eventType: eventTypeToDto(eventType),
                 comment: event.comment,
                 createdBy: event.createdBy,
-                referenceDocument: source.getReferenceDocument(),
+                referenceDocument: source.referenceDocument,
         )
     }
 
@@ -120,7 +120,7 @@ abstract class EventLogHistoryProvider<T extends Historizable> extends HistoryPr
                 ),
                 comment: StringUtils.isBlank(eventLog.message) ? null : new Comment(comment: eventLog.message),
                 createdBy: eventLog.createdBy,
-                referenceDocument: source.getReferenceDocument(),
+                referenceDocument: source.referenceDocument,
         )
     }
 }

--- a/src/main/groovy/org/pih/warehouse/core/history/Historizable.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/history/Historizable.groovy
@@ -1,37 +1,14 @@
 package org.pih.warehouse.core.history
 
-import org.springframework.core.GenericTypeResolver
-
-import org.pih.warehouse.core.AppUtil
-import org.pih.warehouse.core.ReferenceDocument
 import org.pih.warehouse.core.Referenceable
 
 /**
- * The ability for some entity to produce one or more entries of a report on historical data.
+ * The ability for some entity to be transformed into one or more entries of a report on historical data.
  *
- * While not strictly required, this trait will often be used by entities in conjunction with
- * a List of {@link EventLog} to maintain an event/audit log of all relevant changes.
+ * While not strictly required, Historizable entities will often have a hasMany relationship to {@link EventLog}
+ * because that is the easiest way to maintain an event/audit log of all relevant changes.
  */
-trait Historizable<T extends HistoryProvider> implements Referenceable {
-
-    T getHistoryProvider() {
-        // Determines (statically but at runtime) the class type of the HistoryProvider and uses that to fetch the bean.
-        return AppUtil.getBean((Class<T>) GenericTypeResolver.resolveTypeArgument(getClass(), Historizable.class))
-    }
-
-    /**
-     * Returns a List of HistoryItem representing some historical data on the entity. Typically this will be some
-     * kind of event/audit log built from a List of {@link EventLog} on the entity, but it is up to the implementing
-     * HistoryProvider to determine what qualifies as a history item.
-     *
-     * Returns a list to allow for a single historizable object to produce multiple history records if needed.
-     */
-    List<HistoryItem> getHistory() {
-        return historyProvider.getHistory(this)
-    }
-
-    @Override
-    ReferenceDocument getReferenceDocument() {
-        return historyProvider.getReferenceDocument(this)
-    }
+interface Historizable extends Referenceable {
+    // Currently this interface is simply a label. We expect the actual logic for generating the event
+    // history to be defined in a *HistoryProvider component.
 }

--- a/src/main/groovy/org/pih/warehouse/core/history/HistoryContext.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/history/HistoryContext.groovy
@@ -1,0 +1,14 @@
+package org.pih.warehouse.core.history
+
+class HistoryContext {
+    /**
+     * The number of history items to return. Setting a value of null will return the full history.
+     */
+    Integer limit
+
+    /**
+     * True if the history should include rollback events and events that have been rolled back.
+     * False if they should be filtered out.
+     */
+    Boolean includeRolledBackEvents = true
+}

--- a/src/main/groovy/org/pih/warehouse/core/history/HistoryProvider.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/history/HistoryProvider.groovy
@@ -6,7 +6,7 @@ package org.pih.warehouse.core.history
 abstract class HistoryProvider<T extends Historizable> {
 
     /**
-     * Contains the feature-specific logic for building the history fir a given historizable object.
+     * Contains the feature-specific logic for building the history for a given historizable object.
      */
     abstract List<HistoryItem> doGetHistory(T source, HistoryContext context)
 

--- a/src/main/groovy/org/pih/warehouse/core/history/HistoryProvider.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/history/HistoryProvider.groovy
@@ -1,17 +1,14 @@
 package org.pih.warehouse.core.history
 
-import org.pih.warehouse.core.ReferenceDocument
-import org.pih.warehouse.core.Referenceable
-
 /**
- * Constructs a history of actions for some Referenceable (and possibly Historizable) entity.
+ * Constructs a history of actions for some historizable entity.
  */
-interface HistoryProvider<T extends Referenceable> {
+abstract class HistoryProvider<T extends Historizable> {
 
     /**
-     * @return A reference (in a standardized format) to the object being historized.
+     * Contains the feature-specific logic for building the history fir a given historizable object.
      */
-    ReferenceDocument getReferenceDocument(T source)
+    abstract List<HistoryItem> doGetHistory(T source, HistoryContext context)
 
     /**
      * Returns a List of HistoryItem representing some historical data on the object being historized. Typically this
@@ -20,5 +17,13 @@ interface HistoryProvider<T extends Referenceable> {
      *
      * Returns a list to allow for a single historizable object to produce multiple history records if needed.
      */
-    List<HistoryItem> getHistory(T source)
+    List<HistoryItem> getHistory(T source, HistoryContext context) {
+        List<HistoryItem> historyItems = doGetHistory(source, context).sort()
+        return limitHistory(historyItems, context)
+    }
+
+    private List<HistoryItem> limitHistory(List<HistoryItem> historyItems, HistoryContext context) {
+        // Assumes the history items have been sorted oldest to newest.
+        return context.limit ? historyItems.takeRight(context.limit) : historyItems
+    }
 }

--- a/src/main/groovy/org/pih/warehouse/core/history/HistoryProvider.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/history/HistoryProvider.groovy
@@ -24,6 +24,6 @@ abstract class HistoryProvider<T extends Historizable> {
 
     private List<HistoryItem> limitHistory(List<HistoryItem> historyItems, HistoryContext context) {
         // Assumes the history items have been sorted oldest to newest.
-        return context.limit ? historyItems.takeRight(context.limit) : historyItems
+        return context.limit != null && context.limit >= 0 ? historyItems.takeRight(context.limit) : historyItems
     }
 }

--- a/src/main/groovy/org/pih/warehouse/inventory/StockMovementHistoryProvider.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/StockMovementHistoryProvider.groovy
@@ -1,0 +1,52 @@
+package org.pih.warehouse.inventory
+
+import org.springframework.stereotype.Component
+
+import org.pih.warehouse.api.StockMovement
+import org.pih.warehouse.core.history.HistoryContext
+import org.pih.warehouse.core.history.HistoryItem
+import org.pih.warehouse.core.history.HistoryProvider
+import org.pih.warehouse.order.Order
+import org.pih.warehouse.order.OrderHistoryProvider
+import org.pih.warehouse.putaway.PutawayService
+import org.pih.warehouse.shipping.ShipmentHistoryProvider
+
+/**
+ * Constructs a history of actions performed on a stock movement.
+ *
+ * Stock movement history is built by combining the history from a number of different sources, including
+ * shipment and order.
+ */
+@Component
+class StockMovementHistoryProvider extends HistoryProvider<StockMovement> {
+
+    final OrderHistoryProvider orderHistoryProvider
+    final ShipmentHistoryProvider shipmentHistoryProvider
+    final PutawayService putawayService
+
+    StockMovementHistoryProvider(final OrderHistoryProvider orderHistoryProvider,
+                                 final ShipmentHistoryProvider shipmentHistoryProvider,
+                                 final PutawayService putawayService) {
+        this.orderHistoryProvider = orderHistoryProvider
+        this.shipmentHistoryProvider = shipmentHistoryProvider
+        this.putawayService = putawayService
+    }
+
+    @Override
+    List<HistoryItem> doGetHistory(StockMovement source, HistoryContext context) {
+        List<HistoryItem> historyItems = []
+        if (!source?.shipment) {
+            return historyItems
+        }
+
+        historyItems.addAll(shipmentHistoryProvider.getHistory(source.shipment, context))
+
+        // The only orders that have event history are putaway orders so don't bother fetching anything else.
+        Collection<Order> orders = putawayService.getPutawayOrders(source?.shipment)
+        for (Order order in orders) {
+            historyItems.addAll(orderHistoryProvider.getHistory(order, context))
+        }
+
+        return historyItems
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/order/OrderEventLogger.groovy
+++ b/src/main/groovy/org/pih/warehouse/order/OrderEventLogger.groovy
@@ -4,8 +4,7 @@ import grails.validation.ValidationException
 import java.time.Instant
 import org.springframework.stereotype.Component
 
-import org.pih.warehouse.api.Putaway
-import org.pih.warehouse.core.EventCode
+import org.pih.warehouse.core.Event
 import org.pih.warehouse.core.date.InstantParser
 import org.pih.warehouse.core.history.EventLog
 import org.pih.warehouse.core.history.EventLogCode
@@ -26,34 +25,17 @@ class OrderEventLogger {
     }
 
     /**
-     * Logs the occurrence of a putaway order being completed.
+     * Log the occurrence of an order event.
      */
-    EventLog logPutaway(Order order, Putaway putaway) {
+    EventLog logEvent(Order order, Event event) {
 
         EventLog eventLog = new EventLog(
-                event: null,  // A putaway is not Event based
-                eventCode: EventCode.PUTAWAY,
-                eventDate: putaway.putawayDate ? InstantParser.asInstant(putaway.putawayDate) : Instant.now(),
+                event: event,
+                eventCode: event.eventType?.eventCode,
+                eventDate: event.eventDate ? InstantParser.asInstant(event.eventDate) : Instant.now(),
                 eventLogCode: EventLogCode.EVENT_OCCURRED,
-                message: order.description,
-                location: putaway.destination,
-        )
-
-        return createEventLog(order, eventLog)
-    }
-
-    /**
-     * Logs the occurrence of a putaway order being partially completed.
-     */
-    EventLog logPartialPutaway(Order order, Putaway putaway) {
-
-        EventLog eventLog = new EventLog(
-                event: null,  // A putaway is not Event based
-                eventCode: EventCode.PARTIALLY_PUTAWAY,
-                eventDate: putaway.putawayDate ? InstantParser.asInstant(putaway.putawayDate) : Instant.now(),
-                eventLogCode: EventLogCode.EVENT_OCCURRED,
-                message: order.description,
-                location: putaway.destination,
+                message: event.comment?.comment ?: order.description,
+                location: event.eventLocation,
         )
 
         return createEventLog(order, eventLog)

--- a/src/main/groovy/org/pih/warehouse/order/OrderEventManager.groovy
+++ b/src/main/groovy/org/pih/warehouse/order/OrderEventManager.groovy
@@ -1,0 +1,50 @@
+package org.pih.warehouse.order
+
+import grails.validation.ValidationException
+import org.springframework.stereotype.Component
+
+import org.pih.warehouse.api.Putaway
+import org.pih.warehouse.auth.AuthService
+import org.pih.warehouse.core.Event
+import org.pih.warehouse.core.EventCode
+import org.pih.warehouse.core.EventType
+import org.pih.warehouse.core.event.EventManager
+
+/**
+ * Manages the lifecycle (creating and rolling back) of an Order related {@link Event}.
+ */
+@Component
+class OrderEventManager extends EventManager {
+
+    final OrderEventLogger orderEventLogger
+
+    OrderEventManager(final OrderEventLogger orderEventLogger) {
+        this.orderEventLogger = orderEventLogger
+    }
+
+    private Event createEvent(Order order, Event event) {
+        if (!event.save()) {
+            throw new ValidationException("Unable to create order event", event.errors)
+        }
+        order.addToEvents(event)
+
+        orderEventLogger.logEvent(order, event)
+
+        return event
+    }
+
+    /**
+     * Create a new event representing the putaway of an order, then logs the action.
+     */
+    Event createPutawayEvent(Order order, Putaway putaway, EventCode eventCode) {
+        EventType eventType = getOrCreateEventType(eventCode)
+        Event event = new Event(
+                eventDate: putaway.putawayDate ?: new Date(),
+                eventType: eventType,
+                eventLocation: putaway.destination,
+                createdBy: AuthService.currentUser,
+        )
+
+        return createEvent(order, event)
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/order/OrderEventManager.groovy
+++ b/src/main/groovy/org/pih/warehouse/order/OrderEventManager.groovy
@@ -8,18 +8,21 @@ import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.Event
 import org.pih.warehouse.core.EventCode
 import org.pih.warehouse.core.EventType
-import org.pih.warehouse.core.event.EventManager
+import org.pih.warehouse.core.event.EventTypeManager
 
 /**
  * Manages the lifecycle (creating and rolling back) of an Order related {@link Event}.
  */
 @Component
-class OrderEventManager extends EventManager {
+class OrderEventManager {
 
     final OrderEventLogger orderEventLogger
+    final EventTypeManager eventTypeManager
 
-    OrderEventManager(final OrderEventLogger orderEventLogger) {
+    OrderEventManager(final OrderEventLogger orderEventLogger,
+                      final EventTypeManager eventTypeManager) {
         this.orderEventLogger = orderEventLogger
+        this.eventTypeManager = eventTypeManager
     }
 
     private Event createEvent(Order order, Event event) {
@@ -37,7 +40,7 @@ class OrderEventManager extends EventManager {
      * Create a new event representing the putaway of an order, then logs the action.
      */
     Event createPutawayEvent(Order order, Putaway putaway, EventCode eventCode) {
-        EventType eventType = getOrCreateEventType(eventCode)
+        EventType eventType = eventTypeManager.getOrCreateEventType(eventCode)
         Event event = new Event(
                 eventDate: putaway.putawayDate ?: new Date(),
                 eventType: eventType,

--- a/src/main/groovy/org/pih/warehouse/order/OrderHistoryProvider.groovy
+++ b/src/main/groovy/org/pih/warehouse/order/OrderHistoryProvider.groovy
@@ -10,18 +10,6 @@ import org.pih.warehouse.core.history.EventLogHistoryProvider
 class OrderHistoryProvider extends EventLogHistoryProvider<Order> {
 
     @Override
-    ReferenceDocument getReferenceDocument(Order source) {
-        return new ReferenceDocument(
-                label: source.orderNumber,
-                url: "/openboxes/order/show/${source.id}",
-                id: source.id,
-                identifier: source.orderNumber,
-                description: source.description,
-                name: source.name,
-        )
-    }
-
-    @Override
     Collection<EventLog> getEventLogs(Order source) {
         return source.eventLogs
     }

--- a/src/main/groovy/org/pih/warehouse/outbound/OutboundHistoryProvider.groovy
+++ b/src/main/groovy/org/pih/warehouse/outbound/OutboundHistoryProvider.groovy
@@ -1,0 +1,56 @@
+package org.pih.warehouse.outbound
+
+import org.springframework.stereotype.Component
+
+import org.pih.warehouse.core.history.HistoryContext
+import org.pih.warehouse.core.history.HistoryItem
+import org.pih.warehouse.core.history.HistoryProvider
+import org.pih.warehouse.inventory.OutboundStockMovement
+import org.pih.warehouse.order.Order
+import org.pih.warehouse.order.OrderHistoryProvider
+import org.pih.warehouse.putaway.PutawayService
+import org.pih.warehouse.shipping.ShipmentHistoryProvider
+
+/**
+ * Constructs a history of actions performed on an outbound stock movement.
+ *
+ * Stock movement history is built by combining the history from a number of different sources, including
+ * shipment and order.
+ */
+@Component
+class OutboundHistoryProvider extends HistoryProvider<OutboundStockMovement> {
+
+    final OrderHistoryProvider orderHistoryProvider
+    final ShipmentHistoryProvider shipmentHistoryProvider
+    final PutawayService putawayService
+
+    OutboundHistoryProvider(final OrderHistoryProvider orderHistoryProvider,
+                            final ShipmentHistoryProvider shipmentHistoryProvider,
+                            final PutawayService putawayService) {
+        this.orderHistoryProvider = orderHistoryProvider
+        this.shipmentHistoryProvider = shipmentHistoryProvider
+        this.putawayService = putawayService
+    }
+
+    @Override
+    List<HistoryItem> doGetHistory(OutboundStockMovement source, HistoryContext context) {
+        List<HistoryItem> historyItems = []
+        if (!source?.shipment) {
+            return historyItems
+        }
+
+        historyItems.addAll(shipmentHistoryProvider.getHistory(source.shipment, context))
+
+        // TODO: Putaways are specific to inbounds, but inbound SMs currently use the OutboundStockMovement entity on
+        //       SM view pages so we use the same history provider for both. Once we split out non-outbounds to their
+        //       own entity and have them use StockMovementHistoryProvider, we can remove the putaway logic here.
+
+        // The only orders that have event history are putaway orders so don't bother fetching anything else.
+        Collection<Order> orders = putawayService.getPutawayOrders(source?.shipment)
+        for (Order order in orders) {
+            historyItems.addAll(orderHistoryProvider.getHistory(order, context))
+        }
+
+        return historyItems
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/shipping/ShipmentEventManager.groovy
+++ b/src/main/groovy/org/pih/warehouse/shipping/ShipmentEventManager.groovy
@@ -9,12 +9,13 @@ import org.pih.warehouse.core.Event
 import org.pih.warehouse.core.EventCode
 import org.pih.warehouse.core.EventType
 import org.pih.warehouse.core.Location
+import org.pih.warehouse.core.event.EventManager
 
 /**
- * Manages the lifecycle (creating and rolling back) of Shipment related {@link Event}s.
+ * Manages the lifecycle (creating and rolling back) of a Shipment related {@link Event}.
  */
 @Component
-class ShipmentEventManager {
+class ShipmentEventManager extends EventManager {
 
     @Autowired
     ShipmentEventLogger shipmentEventLogger
@@ -37,11 +38,7 @@ class ShipmentEventManager {
      * Create a new Shipment Event representing some state change to the shipment, then logs the action.
      */
     Event createEvent(Shipment shipment, Date eventDate, EventCode eventCode, Location location) {
-        EventType eventType = EventType.findByEventCode(eventCode)
-        if (!eventType) {
-            throw new RuntimeException("Unable to find event type for event code ${eventCode}")
-        }
-
+        EventType eventType = getOrCreateEventType(eventCode)
         Event event = new Event(
                 eventDate: eventDate,
                 eventType: eventType,

--- a/src/main/groovy/org/pih/warehouse/shipping/ShipmentEventManager.groovy
+++ b/src/main/groovy/org/pih/warehouse/shipping/ShipmentEventManager.groovy
@@ -1,7 +1,6 @@
 package org.pih.warehouse.shipping
 
 import grails.validation.ValidationException
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 import org.pih.warehouse.auth.AuthService
@@ -9,16 +8,22 @@ import org.pih.warehouse.core.Event
 import org.pih.warehouse.core.EventCode
 import org.pih.warehouse.core.EventType
 import org.pih.warehouse.core.Location
-import org.pih.warehouse.core.event.EventManager
+import org.pih.warehouse.core.event.EventTypeManager
 
 /**
  * Manages the lifecycle (creating and rolling back) of a Shipment related {@link Event}.
  */
 @Component
-class ShipmentEventManager extends EventManager {
+class ShipmentEventManager {
 
-    @Autowired
-    ShipmentEventLogger shipmentEventLogger
+    final ShipmentEventLogger shipmentEventLogger
+    final EventTypeManager eventTypeManager
+
+    ShipmentEventManager(final ShipmentEventLogger shipmentEventLogger,
+                         final EventTypeManager eventTypeManager) {
+        this.shipmentEventLogger = shipmentEventLogger
+        this.eventTypeManager = eventTypeManager
+    }
 
     /**
      * Create a new Shipment event representing some state change to the shipment, then logs the action.
@@ -38,7 +43,7 @@ class ShipmentEventManager extends EventManager {
      * Create a new Shipment Event representing some state change to the shipment, then logs the action.
      */
     Event createEvent(Shipment shipment, Date eventDate, EventCode eventCode, Location location) {
-        EventType eventType = getOrCreateEventType(eventCode)
+        EventType eventType = eventTypeManager.getOrCreateEventType(eventCode)
         Event event = new Event(
                 eventDate: eventDate,
                 eventType: eventType,

--- a/src/main/groovy/org/pih/warehouse/shipping/ShipmentHistoryProvider.groovy
+++ b/src/main/groovy/org/pih/warehouse/shipping/ShipmentHistoryProvider.groovy
@@ -4,8 +4,8 @@ import org.springframework.stereotype.Component
 
 import org.pih.warehouse.core.EventCode
 import org.pih.warehouse.core.EventTypeDto
+import org.pih.warehouse.core.history.HistoryContext
 import org.pih.warehouse.core.history.HistoryItem
-import org.pih.warehouse.core.ReferenceDocument
 import org.pih.warehouse.core.history.EventLog
 import org.pih.warehouse.core.history.EventLogHistoryProvider
 
@@ -13,48 +13,34 @@ import org.pih.warehouse.core.history.EventLogHistoryProvider
 class ShipmentHistoryProvider extends EventLogHistoryProvider<Shipment> {
 
     @Override
-    ReferenceDocument getReferenceDocument(Shipment source) {
-        return new ReferenceDocument(
-                label: source.shipmentNumber,
-                url: "/openboxes/stockMovement/show/${source.requisition?.id ?: source.id}",
-                id: source.id,
-                identifier: source.shipmentNumber,
-                description: source.description,
-                name: source.name,
-        )
-    }
-
-    @Override
     Collection<EventLog> getEventLogs(Shipment source) {
         return source.eventLogs
     }
 
     @Override
-    List<HistoryItem> getHistory(Shipment source) {
+    List<HistoryItem> doGetHistory(Shipment source, HistoryContext context=new HistoryContext()) {
         // A (temporary) backwards compatibility check. We don't want to generate a partial history for shipments that
         // were in progress when event logs were first introduced so we only rely on event logs if all of the shipment
         // events have been logged. We know that the SHIPPED event is the first logged event, so if the shipment has it,
-        // it's safe to rely on event logs.
-        if (source.eventLogs?.any { it.eventCode == EventCode.SHIPPED }) {
-            return getHistoryFromEventLogs(source)
-        }
-        // Gracefully handle fetching history for shipments from before we introduced event logs.
-        return getHistoryFromEvents(source)
+        // it's safe to rely on event logs. Otherwise, we'll rely on the events.
+        return source.eventLogs?.any { it.eventCode == EventCode.SHIPPED } ?
+                getHistoryFromEventLogs(source, context) :
+                getHistoryFromEvents(source)
     }
 
     /**
      * Build the history for the shipment using its EventLogs.
      */
-    private List<HistoryItem> getHistoryFromEventLogs(Shipment source) {
+    private List<HistoryItem> getHistoryFromEventLogs(Shipment source, HistoryContext context) {
         List<HistoryItem> historyItems = []
 
         // The entry for the initial CREATED event must be added manually. See the docstring for details.
         historyItems.add(getCreatedHistoryItem(source))
 
         // Then we can simply collect history of each of the EventLogs
-        historyItems.addAll(super.getHistory(source))
+        historyItems.addAll(super.doGetHistory(source, context))
 
-        return historyItems.sort()
+        return historyItems
     }
 
     /**
@@ -62,15 +48,16 @@ class ShipmentHistoryProvider extends EventLogHistoryProvider<Shipment> {
      * For use on shipments that were started before we introduced event logs.
      */
     private List<HistoryItem> getHistoryFromEvents(Shipment source) {
-        List<HistoryItem> histories = []
+        List<HistoryItem> historyItems = []
 
         // The entry for the initial CREATED event must be added manually. See the docstring for details.
-        histories.add(getCreatedHistoryItem(source))
+        historyItems.add(getCreatedHistoryItem(source))
 
-        // Then we can simply collect history of each of the Events
-        histories.addAll(getHistoryItemsFromEvents(source, source.events))
+        // Then we can simply collect history of each of the Events. We don't need to filter for rollbacks
+        // because Events are deleted when they're rolled back.
+        historyItems.addAll(getHistoryItemsFromEvents(source, source.events))
 
-        return histories.sort()
+        return historyItems
     }
 
     /**
@@ -89,7 +76,7 @@ class ShipmentHistoryProvider extends EventLogHistoryProvider<Shipment> {
                         name: messageLocalizer.localizeEnumValue(EventCode.CREATED),
                         eventCode: EventCode.CREATED,
                 ),
-                referenceDocument: getReferenceDocument(source),
+                referenceDocument: source.getReferenceDocument(),
                 createdBy: source.createdBy,
         )
     }

--- a/src/main/groovy/org/pih/warehouse/shipping/ShipmentHistoryProvider.groovy
+++ b/src/main/groovy/org/pih/warehouse/shipping/ShipmentHistoryProvider.groovy
@@ -76,7 +76,7 @@ class ShipmentHistoryProvider extends EventLogHistoryProvider<Shipment> {
                         name: messageLocalizer.localizeEnumValue(EventCode.CREATED),
                         eventCode: EventCode.CREATED,
                 ),
-                referenceDocument: source.getReferenceDocument(),
+                referenceDocument: source.referenceDocument,
                 createdBy: source.createdBy,
         )
     }

--- a/src/test/groovy/org/pih/warehouse/shipping/ShipmentHistoryProviderSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/shipping/ShipmentHistoryProviderSpec.groovy
@@ -8,6 +8,7 @@ import org.pih.warehouse.core.Comment
 import org.pih.warehouse.core.Event
 import org.pih.warehouse.core.EventCode
 import org.pih.warehouse.core.EventType
+import org.pih.warehouse.core.history.HistoryContext
 import org.pih.warehouse.core.history.HistoryItem
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.ReferenceDocument
@@ -155,7 +156,7 @@ class ShipmentHistoryProviderSpec extends Specification {
         shipment.eventLogs = new TreeSet<EventLog>([shippedEventLog, partialReceivedEventLog, receivedEventLog])
 
         when:
-        List<HistoryItem> historyItems = shipmentHistoryProvider.getHistory(shipment)
+        List<HistoryItem> historyItems = shipmentHistoryProvider.getHistory(shipment, new HistoryContext())
 
         then:
         assert historyItems.size() == 4
@@ -310,7 +311,7 @@ class ShipmentHistoryProviderSpec extends Specification {
         ])
 
         when:
-        List<HistoryItem> historyItems = shipmentHistoryProvider.getHistory(shipment)
+        List<HistoryItem> historyItems = shipmentHistoryProvider.getHistory(shipment, new HistoryContext())
 
         then:
         assert historyItems.size() == 7
@@ -463,7 +464,7 @@ class ShipmentHistoryProviderSpec extends Specification {
         )
 
         when:
-        List<HistoryItem> historyItems = shipmentHistoryProvider.getHistory(shipment)
+        List<HistoryItem> historyItems = shipmentHistoryProvider.getHistory(shipment, new HistoryContext())
 
         then:
         assert historyItems.size() == 4
@@ -502,6 +503,136 @@ class ShipmentHistoryProviderSpec extends Specification {
                 shipmentCreator,
                 EventCode.RECEIVED.name(),
                 EventCode.RECEIVED,
+                expectedReferenceDocument)
+    }
+
+    void "getHistory should work when using event log and rollbacks are ignored"() {
+        given: "A Shipment (which is rolled back)"
+        Date shipmentCreationDate = new Date()
+        Location origin = new Location()
+        User shipmentCreator = new User()
+        Shipment shipment = new Shipment(
+                origin: origin,
+                createdBy: shipmentCreator,
+                shipmentNumber: "ABC123",
+                name: "Name",
+                description: "Description",
+        )
+        shipment.id = "0"
+        shipment.dateCreated = shipmentCreationDate
+
+        and: "An expected reference document representing the shipment"
+        ReferenceDocument expectedReferenceDocument = new ReferenceDocument(
+                label: "ABC123",
+                url: "/openboxes/stockMovement/show/0",
+                id: 0,
+                identifier: "ABC123",
+                description: "Description",
+                name: "Name",
+        )
+
+        and: "EventLogs for each of the Events and their rollbacks"
+        Instant shipmentCreationLogDate = InstantParser.asInstant(shipmentCreationDate)
+        EventLog shippedEventLog = new EventLog(
+                event: null,  // rolled back so no longer exists
+                eventCode: EventCode.SHIPPED,
+                eventDate: shipmentCreationLogDate,
+                eventLogCode: EventLogCode.EVENT_OCCURRED,
+                message: "Event Log - Sending shipment",
+                location: origin,
+                createdBy: shipmentCreator,
+        )
+        shippedEventLog.dateCreated = shipmentCreationLogDate
+
+        Date partialReceiptDate = new Date(shipmentCreationDate.getTime() + 1000)
+        Instant partialReceiptLogDate = InstantParser.asInstant(partialReceiptDate)
+        EventLog partialReceivedEventLog = new EventLog(
+                event: null,  // rolled back so no longer exists
+                eventCode: EventCode.PARTIALLY_RECEIVED,
+                eventDate: partialReceiptLogDate,
+                eventLogCode: EventLogCode.EVENT_OCCURRED,
+                message: "Event Log - Partial receiving shipment",
+                location: origin,
+                createdBy: shipmentCreator,
+        )
+        partialReceivedEventLog.dateCreated = partialReceiptLogDate
+
+        Date finalReceiptDate = new Date(partialReceiptDate.getTime() + 1000)
+        Instant finalReceiptLogDate = InstantParser.asInstant(finalReceiptDate)
+        EventLog receivedEventLog = new EventLog(
+                event: null,  // rolled back so no longer exists
+                eventCode: EventCode.RECEIVED,
+                eventDate: finalReceiptLogDate,
+                eventLogCode: EventLogCode.EVENT_OCCURRED,
+                message: "Event Log - Final receiving shipment",
+                location: origin,
+                createdBy: shipmentCreator,
+        )
+        receivedEventLog.dateCreated = finalReceiptLogDate
+
+        Date finalReceiptRollbackDate = new Date(finalReceiptDate.getTime() + 1000)
+        Instant finalReceiptRollbackLogDate = InstantParser.asInstant(finalReceiptRollbackDate)
+        EventLog receivedRollbackEventLog = new EventLog(
+                event: null,  // rolled back so no longer exists
+                eventCode: EventCode.RECEIVED,
+                eventDate: finalReceiptRollbackLogDate,
+                eventLogCode: EventLogCode.EVENT_ROLLBACK_OCCURRED,
+                message: "Event Log - Rollback - Final receiving shipment",
+                location: origin,
+                createdBy: shipmentCreator,
+        )
+        receivedRollbackEventLog.dateCreated = finalReceiptRollbackLogDate
+
+        Date partialReceiptRollbackDate = new Date(finalReceiptRollbackDate.getTime() + 1000)
+        Instant partialReceiptRollbackLogDate = InstantParser.asInstant(partialReceiptRollbackDate)
+        EventLog partialReceivedRollbackEventLog = new EventLog(
+                event: null,  // rolled back so no longer exists
+                eventCode: EventCode.PARTIALLY_RECEIVED,
+                eventDate: partialReceiptRollbackLogDate,
+                eventLogCode: EventLogCode.EVENT_ROLLBACK_OCCURRED,
+                message: "Event Log - Rollback - Partial receiving shipment",
+                location: origin,
+                createdBy: shipmentCreator,
+        )
+        partialReceivedRollbackEventLog.dateCreated = partialReceiptRollbackLogDate
+
+        Date shipmentCreationRollbackDate = new Date(partialReceiptRollbackDate.getTime() + 1000)
+        Instant shipmentCreationRollbackLogDate = InstantParser.asInstant(shipmentCreationRollbackDate)
+        EventLog shippedRollbackEventLog = new EventLog(
+                event: null,  // rolled back so no longer exists
+                eventCode: EventCode.SHIPPED,
+                eventDate: shipmentCreationRollbackLogDate,
+                eventLogCode: EventLogCode.EVENT_ROLLBACK_OCCURRED,
+                message: "Event Log - Rollback - Sending shipment",
+                location: origin,
+                createdBy: shipmentCreator,
+        )
+        shippedRollbackEventLog.dateCreated = shipmentCreationRollbackLogDate
+
+        shipment.eventLogs = new TreeSet<EventLog>([
+                shippedEventLog,
+                partialReceivedEventLog,
+                receivedEventLog,
+                receivedRollbackEventLog,
+                partialReceivedRollbackEventLog,
+                shippedRollbackEventLog,
+        ])
+
+        when: "we fetch history, ignoring rollbacks"
+        List<HistoryItem> historyItems = shipmentHistoryProvider.getHistory(shipment, new HistoryContext(
+                includeRolledBackEvents: false,
+        ))
+
+        then: "all rolled back events are filtered out from the history"
+        assert historyItems.size() == 1
+
+        assertHistoryItem(historyItems[0],  // The created event - based on Shipment
+                shipmentCreationDate,
+                origin,
+                null,
+                shipmentCreator,
+                EventCode.CREATED.name(),
+                EventCode.CREATED,
                 expectedReferenceDocument)
     }
 


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-6803

**Description:** Add "most recent event" field on stock movement view that displays the most recent non-rolled back event for the stock movement

The SM view page has some weird temp logic in it. It actually uses the OutboundStockMovement POJO for all SMs, including inbounds. This made the logic a little weird. I'll leave a more specific comment in the code about it

I ended up modifying some of the event history structure to try and make things a little cleaner. I also added some new logic around event type so that the distinction between it and event code is clearer. I'll add more specific comments in line.

Here's the overall structure. Most of it is pre-existing:

<img width="1734" height="819" alt="Screenshot from 2026-04-30 09-11-28" src="https://github.com/user-attachments/assets/5a8c00fc-295b-45d4-8169-6c24b9930fdb" />


Sorry for the big PR. I can try to split the refactor out into it's own PR if that would be cleaner.

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

With event history:

<img width="1018" height="506" alt="Screenshot from 2026-04-29 15-41-56" src="https://github.com/user-attachments/assets/e0c7f23a-dba6-4908-a106-43b499f1b08a" />

After rollbacks:

<img width="1077" height="543" alt="Screenshot from 2026-04-29 15-43-41" src="https://github.com/user-attachments/assets/3bb67e3a-fda8-4df4-a063-567a69dbc205" />