### PR TITLE
OBLS-677 Fix picked greater than allocated bypass in edit pick modal

### DIFF
--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -2015,6 +2015,14 @@ class StockMovementService {
             throw new IllegalArgumentException("Total picked quantity (${totalPicked}) exceeds quantity required (${quantityRequired})")
         }
 
+        picklistItems?.each { picklistItemMap ->
+            Integer rowPicked = (picklistItemMap.quantityPicked ?: 0) as Integer
+            Integer rowAllocated = (picklistItemMap.quantityAllocated ?: 0) as Integer
+            if (rowPicked > rowAllocated) {
+                throw new IllegalArgumentException("Picked quantity (${rowPicked}) exceeds allocated quantity (${rowAllocated})")
+            }
+        }
+
         clearPicklist(requisitionItem)
 
         picklistItems.each { picklistItemMap ->

--- a/src/js/components/stock-movement-wizard/modals/EditPickModal.jsx
+++ b/src/js/components/stock-movement-wizard/modals/EditPickModal.jsx
@@ -157,19 +157,24 @@ function validate(values) {
   errors.availableItems = [];
   _.forEach(values.availableItems, (item, key) => {
     errors.availableItems[key] = errors.availableItems[key] || {};
-    if ((item.quantityPicked || 0) > (item.quantityAvailable || 0)) {
+
+    const picked = _.toInteger(item.quantityPicked);
+    const allocated = _.toInteger(item.quantityAllocated);
+    const available = _.toInteger(item.quantityAvailable);
+
+    if (picked > available) {
       errors.availableItems[key].quantityPicked = 'react.stockMovement.errors.higherTyPicked.label';
     }
-    if ((item.quantityPicked || 0) < 0) {
+    if (picked < 0) {
       errors.availableItems[key].quantityPicked = 'react.stockMovement.errors.negativeQtyPicked.label';
     }
-    if ((item.quantityAllocated || 0) < 0) {
+    if (allocated < 0) {
       errors.availableItems[key].quantityAllocated = 'react.stockMovement.errors.negativeQtyAllocated.label';
     }
-    if ((item.quantityAllocated || 0) > (item.quantityAvailable || 0)) {
+    if (allocated > available) {
       errors.availableItems[key].quantityAllocated = 'react.stockMovement.errors.higherThanAvailable.label';
     }
-    if ((item.quantityPicked || 0) > (item.quantityAllocated || 0)) {
+    if (picked > allocated) {
       errors.availableItems[key].quantityPicked = 'react.stockMovement.errors.pickedHigherThanAllocated.label';
     }
   });


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket: https://openboxes.atlassian.net/browse/OBLS-677**

**Description:**
- Added a per-row server-side safeguard in `StockMovementService.updatePicklistItem` that rejects payloads where `quantityPicked > quantityAllocated`, mirroring the existing total-vs-required guards. Throws `IllegalArgumentException("Picked quantity (X) exceeds allocated quantity (Y)")`.
- Coerced qty allocated, qty available, qty picked to integers via `_.toInteger` (Per-row check).

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
