### PR TITLE
OBLS-583 Restore Edit action for outbound returns in Picking status

### DIFF
--- a/src/js/utils/permissionUtils.js
+++ b/src/js/utils/permissionUtils.js
@@ -8,7 +8,7 @@ const canEditRequest = (currentUser, request, location) => {
     ActivityCode.REQUIRE_MOBILE_PICKING,
   );
 
-  if (hasMobilePicking) {
+  if (hasMobilePicking && !request?.isReturn) {
     const blockEditingStatuses = [
       StockMovementStatus.PICKING,
       StockMovementStatus.PICKED,


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket: https://openboxes.atlassian.net/browse/OBLS-583**

**Description:**
Edit action button for outbound return was hidden whenever the origin location had REQUIRE_MOBILE_PICKING enabled. Outbound returns should not be affected by that gate.

---
### :camera: Screenshots & Recordings (optional)
<img width="637" height="200" alt="image" src="https://github.com/user-attachments/assets/35dcbd09-35a1-4a03-b24a-8282787e6c34" />


[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
