### PR TITLE
OBPIH-6237 OB Returns View Page: Add downloadable Delivery Note 

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/UrlMappings.groovy
+++ b/grails-app/controllers/org/pih/warehouse/UrlMappings.groovy
@@ -384,6 +384,11 @@ class UrlMappings {
             action = [GET: "downloadPackingListTemplate"]
         }
 
+        "/api/stockMovements/$id/documents" {
+            controller = "stockMovementApi"
+            action = [GET: "getDocuments"]
+        }
+
         "/api/picklists/$id/items" {
             controller = "picklistApi"
             action = [DELETE: "clearPicklist"]

--- a/grails-app/controllers/org/pih/warehouse/api/StockMovementApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/StockMovementApiController.groovy
@@ -759,4 +759,9 @@ class StockMovementApiController {
             render status: 404
         }
     }
+
+    def getDocuments() {
+        List<Map> documents = stockMovementService.getDocuments(params.id)
+        render([data: documents] as JSON)
+    }
 }

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -3305,6 +3305,15 @@ class StockMovementService {
         return true
     }
 
+    List<Map> getDocuments(String stockMovementId) {
+        // First attempt to get outbound stock movement, because stock movement throws exception if it can't find a
+        // stock movement with the given ID, while outbound stock movement will return null if it can't find a match
+        def stockMovement = outboundStockMovementService.getStockMovement(stockMovementId) ?: getStockMovement(stockMovementId)
+        if (!stockMovement) {
+            throw new IllegalArgumentException("Could not find stock movement with ID ${stockMovementId}")
+        }
+        return getDocuments(stockMovement)
+    }
 
     List<Map> getDocuments(def stockMovement) {
         def g = grailsApplication.mainContext.getBean('org.grails.plugins.web.taglib.ApplicationTagLib')

--- a/src/js/api/services/StockMovementApi.js
+++ b/src/js/api/services/StockMovementApi.js
@@ -1,6 +1,7 @@
 import {
   STOCK_MOVEMENT_API,
   STOCK_MOVEMENT_BY_ID,
+  STOCK_MOVEMENT_DOCUMENTS,
   STOCK_MOVEMENT_ITEMS,
   STOCK_MOVEMENT_ROLLBACK_APPROVAL,
   STOCK_MOVEMENT_UPDATE_REQUISITION,
@@ -49,4 +50,5 @@ export default {
     apiClient.post(STOCK_MOVEMENT_URL.uploadDocuments(id), formData, {
       headers: { 'Content-Type': 'multipart/form-data' },
     }),
+  getDocuments: (id) => apiClient.get(STOCK_MOVEMENT_DOCUMENTS(id)),
 };

--- a/src/js/api/urls.js
+++ b/src/js/api/urls.js
@@ -31,6 +31,7 @@ export const PICKLIST_IMPORT = (id) => `${STOCK_MOVEMENT_API}/importPickListItem
 export const PACKING_LIST_TEMPLATE = `${STOCK_MOVEMENT_API}/packingList/template`;
 export const STOCK_MOVEMENT_UPDATE_SHIPMENT = (id) => `${STOCK_MOVEMENT_BY_ID(id)}/updateShipment`;
 export const STOCK_MOVEMENT_UPLOAD_DOCUMENTS = (id) => `${STOCK_MOVEMENT_BY_ID(id)}/uploadDocuments`;
+export const STOCK_MOVEMENT_DOCUMENTS = (id) => `${STOCK_MOVEMENT_BY_ID(id)}/documents`;
 
 // STOCK MOVEMENT ITEMS
 export const STOCK_MOVEMENT_ITEM_API = `${API}/stockMovementItems`;

--- a/src/js/components/returns/outbound/SendOutboundReturn.jsx
+++ b/src/js/components/returns/outbound/SendOutboundReturn.jsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
 import Alert from 'react-s-alert';
 
 import { hideSpinner, showSpinner } from 'actions';
+import stockMovementApi from 'api/services/StockMovementApi';
 import ArrayField from 'components/form-elements/ArrayField';
 import DateField from 'components/form-elements/DateField';
 import LabelField from 'components/form-elements/LabelField';
@@ -19,6 +20,7 @@ import TextField from 'components/form-elements/TextField';
 import { STOCK_MOVEMENT_URL } from 'consts/applicationUrls';
 import DateFormat from 'consts/dateFormat';
 import apiClient, { flattenRequest, parseResponse } from 'utils/apiClient';
+import DocumentsDropdown from 'utils/DocumentsDropdown';
 import { renderFormField } from 'utils/form-utils';
 import { formatProductDisplayName } from 'utils/form-values-utils';
 import Translate, { translateWithDefaultMessage } from 'utils/Translate';
@@ -204,6 +206,7 @@ class SendMovementPage extends Component {
     super(props);
     this.state = {
       shipmentTypes: [],
+      documents: [],
       values: { outboundReturn: { ...this.props.initialValues } },
     };
 
@@ -216,6 +219,7 @@ class SendMovementPage extends Component {
     if (this.props.outboundReturnsTranslationsFetched) {
       this.dataFetched = true;
       this.fetchOutboundReturn();
+      this.fetchDocuments();
     }
   }
 
@@ -223,6 +227,16 @@ class SendMovementPage extends Component {
     if (nextProps.outboundReturnsTranslationsFetched && !this.dataFetched) {
       this.dataFetched = true;
       this.fetchOutboundReturn();
+    }
+  }
+
+  async fetchDocuments() {
+    try {
+      const response = await stockMovementApi
+        .getDocuments(this.props.match.params.outboundReturnId);
+      this.setState({ documents: response.data.data || [] });
+    } catch (e) {
+      this.props.hideSpinner();
     }
   }
 
@@ -438,13 +452,14 @@ class SendMovementPage extends Component {
           <form onSubmit={handleSubmit}>
             <div className="classic-form classic-form-condensed">
               <span className="buttons-container classic-form-buttons">
+                <DocumentsDropdown documents={this.state.documents} />
                 { !(values && values.status === 'COMPLETED')
                   ? (
                     <span>
                       <button
                         type="button"
                         onClick={() => this.save(values)}
-                        className="btn btn-outline-secondary float-right btn-form btn-xs"
+                        className="btn btn-outline-secondary float-right btn-form btn-xs ml-1"
                         disabled={invalid}
                       >
                         <span>

--- a/src/js/utils/DocumentsDropdown.jsx
+++ b/src/js/utils/DocumentsDropdown.jsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+
+import PropTypes from 'prop-types';
+
+import DocumentButton from 'components/DocumentButton';
+import Translate from 'utils/Translate';
+
+const DocumentsDropdown = ({ documents }) => {
+  const [isDropdownVisible, setIsDropdownVisible] = useState(false);
+
+  const toggleDocumentDropdown = () => setIsDropdownVisible((prev) => !prev);
+
+  return (
+    <div className="dropdown">
+      <button
+        type="button"
+        onClick={toggleDocumentDropdown}
+        className="dropdown-button float-right mb-1 btn btn-outline-secondary align-self-end btn-xs mr-1"
+      >
+        <span>
+          <i className="fa fa-sign-out pr-2" />
+          <Translate id="react.default.button.download.label" defaultMessage="Download" />
+        </span>
+      </button>
+      <div className={`dropdown-content print-buttons-container col-md-3 flex-grow-1
+        ${isDropdownVisible ? 'visible' : ''}`}
+      >
+        {documents.length ? documents.map((document) => {
+          if (document.hidden) {
+            return null;
+          }
+          return (
+            <DocumentButton
+              link={document.uri}
+              buttonTitle={document.name}
+              {...document}
+              key={document.name}
+            />
+          );
+        }) : null}
+      </div>
+    </div>
+  );
+};
+
+export default DocumentsDropdown;
+
+DocumentsDropdown.propTypes = {
+  documents: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string,
+    uri: PropTypes.string,
+    hidden: PropTypes.bool,
+  })),
+};
+
+DocumentsDropdown.defaultProps = {
+  documents: [],
+};


### PR DESCRIPTION
Implementation for the reopened ticket (related to that question): Can we also add an option to download the document on the send page like we have for other types of shipments?