### PR TITLE
OBLS-292 Refresh product availability when inventory moves to Lost & …

### DIFF
--- a/grails-app/domain/org/pih/warehouse/core/Location.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Location.groovy
@@ -350,8 +350,12 @@ class Location implements Comparable<Location>, java.io.Serializable {
         return supports(ActivityCode.HOLD_STOCK)
     }
 
+    Boolean isLostAndFound() {
+        return supports(ActivityCode.LOST_AND_FOUND)
+    }
+
     Boolean isPickable() {
-        return !onHold
+        return !onHold && !lostAndFound
     }
 
     Boolean isDownstreamConsumer() {

--- a/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
@@ -886,7 +886,8 @@ class InventoryService implements ApplicationContextAware {
                                 inventoryItem    : inventoryItem,
                                 binLocation      : binLocation,
                                 quantity         : quantity,
-                                isOnHold         : binLocation?.isOnHold()
+                                isOnHold         : binLocation?.isOnHold(),
+                                isLostAndFound   : binLocation?.isLostAndFound()
                             ]))
                     }
                 }

--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -12,6 +12,7 @@ package org.pih.warehouse.inventory
 import grails.core.GrailsApplication
 import grails.gorm.PagedResultList
 import grails.gorm.transactions.Transactional
+import grails.plugin.cache.CacheEvict
 import grails.util.Holders
 import groovy.sql.BatchingStatementWrapper
 import groovy.sql.Sql
@@ -227,7 +228,7 @@ class ProductAvailabilityService {
      * Data is pulled from:
      *  1. Picklist items from pending requisitions (outbound stock movements) with origin being provided location
      *     that are *NOT* having RECALLED inventory item (inventoryItem.lotStatus) or bin location *WITHOUT*
-     *     HOLD_STOCK in the supported activity (location.supportedActivities).
+     *     HOLD_STOCK or LOST_AND_FOUND in the supported activity (location.supportedActivities).
      *  2. Picklist items from pending orders (outbound returns) with origin being provided location.
      *     (IMPORTANT: Outbound returns can have picked items with RECALLED lots and bins with HOLD_STOCK activity)
      * */
@@ -290,8 +291,8 @@ class ProductAvailabilityService {
                     ) lsa ON lsa.location_id = l.id
                 WHERE (r.origin_id = :locationId 
                     AND r.status IN (:pendingRequisitionStatuses))
-                  AND (ri.id IS NOT NULL AND (ii.lot_status IS NULL OR ii.lot_status != 'RECALLED') 
-                  AND (lsa.activities IS NULL OR lsa.activities NOT LIKE '%HOLD_STOCK%'))
+                  AND (ri.id IS NOT NULL AND (ii.lot_status IS NULL OR ii.lot_status != 'RECALLED')
+                  AND (lsa.activities IS NULL OR (lsa.activities NOT LIKE '%HOLD_STOCK%' AND lsa.activities NOT LIKE '%LOST_AND_FOUND%')))
                   AND (:productId = '' OR ri.product_id = :productId)
                   ${internalTransactionsWhereClause}
                 GROUP BY pli.bin_location_id, pli.inventory_item_id, pli.reason_code
@@ -334,6 +335,7 @@ class ProductAvailabilityService {
         }
     }
 
+    @CacheEvict(value = "dashboardCache", allEntries = true)
     boolean saveProductAvailability(Location location, Product product, List binLocations, Boolean forceRefresh) {
         log.info "Saving product availability for product=${product?.productCode}, location=${location}"
         def batchSize = Holders.config.openboxes.inventorySnapshot.batchSize ?: 1000
@@ -418,7 +420,7 @@ class ProductAvailabilityService {
                 quantityAllocated: pickedItems
                         ? (pickedItemsGrouped[[it.inventoryItem?.id, it.binLocation?.id]]?.sum{ AllocatedItem  val -> val.quantityAllocated } ?: 0)
                         : 0,
-                quantityOnHold   : it?.isOnHold || it?.inventoryItem?.lotStatus == LotStatusCode.RECALLED ? it.quantity : 0
+                quantityOnHold   : it?.isOnHold || it?.isLostAndFound || it?.inventoryItem?.lotStatus == LotStatusCode.RECALLED ? it.quantity : 0
             ]
         }
         log.debug("Collecting inside transformBinLocations took: " + (System.currentTimeMillis() - startTime) + " ms")

--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -12,7 +12,6 @@ package org.pih.warehouse.inventory
 import grails.core.GrailsApplication
 import grails.gorm.PagedResultList
 import grails.gorm.transactions.Transactional
-import grails.plugin.cache.CacheEvict
 import grails.util.Holders
 import groovy.sql.BatchingStatementWrapper
 import groovy.sql.Sql
@@ -335,7 +334,6 @@ class ProductAvailabilityService {
         }
     }
 
-    @CacheEvict(value = "dashboardCache", allEntries = true)
     boolean saveProductAvailability(Location location, Product product, List binLocations, Boolean forceRefresh) {
         log.info "Saving product availability for product=${product?.productCode}, location=${location}"
         def batchSize = Holders.config.openboxes.inventorySnapshot.batchSize ?: 1000

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -1509,8 +1509,8 @@ class StockMovementService {
             log.info " - Available item " + it.toJson()
         }
 
-        // filter out hold locations
-        availableItems = availableItems.findAll { !it.isOnHold() }
+        // filter out hold and lost-and-found locations
+        availableItems = availableItems.findAll { !it.isOnHold() && !it.binLocation?.lostAndFound }
 
         // If there's only one pickable location, it should either be a default location or
         if (availableItems.count { it.pickable } == 1) {

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -1509,8 +1509,8 @@ class StockMovementService {
             log.info " - Available item " + it.toJson()
         }
 
-        // filter out hold and lost-and-found locations
-        availableItems = availableItems.findAll { !it.isOnHold() && !it.binLocation?.lostAndFound }
+        // filter out non-pickable bins (hold / lost-and-found)
+        availableItems = availableItems.findAll { !it.binLocation || it.binLocation.pickable }
 
         // If there's only one pickable location, it should either be a default location or
         if (availableItems.count { it.pickable } == 1) {

--- a/grails-app/services/org/pih/warehouse/putaway/PutawayTaskCompletedEventService.groovy
+++ b/grails-app/services/org/pih/warehouse/putaway/PutawayTaskCompletedEventService.groovy
@@ -9,17 +9,31 @@
  **/
 package org.pih.warehouse.putaway
 
-import grails.gorm.transactions.Transactional
 import org.springframework.context.ApplicationListener
+import org.springframework.transaction.support.TransactionSynchronizationAdapter
+import org.springframework.transaction.support.TransactionSynchronizationManager
 
-@Transactional
 class PutawayTaskCompletedEventService implements ApplicationListener<PutawayTaskCompletedEvent> {
 
     def productAvailabilityService
 
     void onApplicationEvent(PutawayTaskCompletedEvent event) {
-        PutawayTask task = (PutawayTask) event.source;
-        log.info "Putaway ${task.id} into ${task.facility}:${task.destination} completed by ${task.completedBy} at ${task.dateCompleted} "
-        productAvailabilityService.triggerRefreshProductAvailability(task?.facility?.id, [task.product.id], event?.forceRefresh)
+        PutawayTask task = (PutawayTask) event.source
+        String facilityId = task?.facility?.id
+        String productId = task?.product?.id
+        Boolean forceRefresh = event?.forceRefresh
+        log.info "Putaway ${task?.id} completed; scheduling product-availability refresh for facility=${facilityId}, product=${productId}"
+
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            // Defer until commit so transferStock's two Transaction inserts are both flushed before the refresh reads transaction_entry.
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter() {
+                @Override
+                void afterCommit() {
+                    productAvailabilityService.refreshProductsAvailability(facilityId, [productId], forceRefresh)
+                }
+            })
+        } else {
+            productAvailabilityService.refreshProductsAvailability(facilityId, [productId], forceRefresh)
+        }
     }
 }

--- a/grails-app/services/org/pih/warehouse/putaway/PutawayTaskCompletedEventService.groovy
+++ b/grails-app/services/org/pih/warehouse/putaway/PutawayTaskCompletedEventService.groovy
@@ -9,31 +9,17 @@
  **/
 package org.pih.warehouse.putaway
 
-import org.springframework.context.ApplicationListener
-import org.springframework.transaction.support.TransactionSynchronizationAdapter
-import org.springframework.transaction.support.TransactionSynchronizationManager
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
 
-class PutawayTaskCompletedEventService implements ApplicationListener<PutawayTaskCompletedEvent> {
+class PutawayTaskCompletedEventService {
 
     def productAvailabilityService
 
-    void onApplicationEvent(PutawayTaskCompletedEvent event) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    void onPutawayTaskCompleted(PutawayTaskCompletedEvent event) {
         PutawayTask task = (PutawayTask) event.source
-        String facilityId = task?.facility?.id
-        String productId = task?.product?.id
-        Boolean forceRefresh = event?.forceRefresh
-        log.info "Putaway ${task?.id} completed; scheduling product-availability refresh for facility=${facilityId}, product=${productId}"
-
-        if (TransactionSynchronizationManager.isSynchronizationActive()) {
-            // Defer until commit so transferStock's two Transaction inserts are both flushed before the refresh reads transaction_entry.
-            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter() {
-                @Override
-                void afterCommit() {
-                    productAvailabilityService.refreshProductsAvailability(facilityId, [productId], forceRefresh)
-                }
-            })
-        } else {
-            productAvailabilityService.refreshProductsAvailability(facilityId, [productId], forceRefresh)
-        }
+        log.info "Putaway ${task?.id} completed; refreshing PA for facility=${task?.facility?.id}, product=${task?.product?.id}"
+        productAvailabilityService.triggerRefreshProductAvailability(task?.facility?.id, [task?.product?.id], event?.forceRefresh)
     }
 }

--- a/src/main/groovy/org/pih/warehouse/api/StockMovementItem.groovy
+++ b/src/main/groovy/org/pih/warehouse/api/StockMovementItem.groovy
@@ -399,7 +399,7 @@ class AvailableItem {
         if (recalled) {
             return AvailableItemStatus.RECALLED
         }
-        if (onHold) {
+        if (binLocation && !binLocation.pickable) {
             return AvailableItemStatus.HOLD
         }
         if (available && quantityAvailable < quantityOnHand) {

--- a/src/main/groovy/org/pih/warehouse/inventory/BinLocationItem.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/BinLocationItem.groovy
@@ -23,6 +23,8 @@ class BinLocationItem implements Comparable<BinLocationItem> {
 
     Boolean isOnHold
 
+    Boolean isLostAndFound
+
     @Override
     int compareTo(BinLocationItem obj) {
         inventoryItem?.expirationDate <=> obj?.inventoryItem?.expirationDate


### PR DESCRIPTION
…Found

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket: https://openboxes.atlassian.net/browse/OBLS-292**

**Description:**
 Three coupled fixes for the staleness that forced users to click "Refresh Caches" after putaway with cancel-remaining:
- **Lost & Found is unallocatable.** Bins supporting `ActivityCode.LOST_AND_FOUND` are now treated like `HOLD_STOCK`: their quantity lands in `quantityOnHold` (ATP=0), the picklist-allocation SQL excludes them, and the stock-movement allocation rules filter them out as pick sources.
- **Dashboard cache invalidation.** `@CacheEvict(value = "dashboardCache", allEntries = true)` on `ProductAvailabilityService.saveProductAvailability` - previously the cache was only ever cleared by the manual "Refresh caches" button, so PA-backed tiles (Lost & Found count, …) served stale data indefinitely.
- **Deferred refresh after commit.** `PutawayTaskCompletedEventService` now registers a `TransactionSynchronization.afterCommit` callback instead of triggering a 5-second-delayed Quartz job.

### :camera: Screenshots & Recordings (optional)
https://github.com/user-attachments/assets/95f979ab-6fef-4ace-aaab-1fc191a592f9

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
