### PR TITLE
OBLS-744 Short-circuit product and internal location search below min…

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/api/InternalLocationApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/InternalLocationApiController.groovy
@@ -10,6 +10,7 @@
 package org.pih.warehouse.api
 
 import grails.converters.JSON
+import grails.core.GrailsApplication
 import grails.gorm.transactions.Transactional
 import org.hibernate.ObjectNotFoundException
 import org.pih.warehouse.core.ActivityCode
@@ -26,6 +27,7 @@ class InternalLocationApiController {
 
     LocationService locationService
     ZebraService zebraService
+    GrailsApplication grailsApplication
 
     def list(InternalLocationSearchCommand command) {
         command.location = getFacility(command)
@@ -35,6 +37,12 @@ class InternalLocationApiController {
     }
 
     def search() {
+        def minLength = grailsApplication.config.openboxes.typeahead.minLength
+        if (params?.searchTerm?.size() < minLength) {
+            render([data: [], totalCount: 0] as JSON)
+            return
+        }
+
         LocationTypeCode[] locationTypeCodes = params.locationTypeCode ? params.list("locationTypeCode") : [LocationTypeCode.INTERNAL, LocationTypeCode.BIN_LOCATION]
         List<Location> locations = locationService.searchInternalLocations(params, locationTypeCodes)
 

--- a/grails-app/controllers/org/pih/warehouse/api/MobileProductApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/MobileProductApiController.groovy
@@ -151,6 +151,13 @@ class MobileProductApiController extends BaseDomainApiController {
 
     def search() {
         JSONObject jsonObject = request.JSON
+
+        def minLength = grailsApplication.config.openboxes.typeahead.minLength
+        if (jsonObject?.value?.size() < minLength) {
+            render([data: []] as JSON)
+            return
+        }
+
         // Don't split scanned value - treat as single term for barcode/product code matching
         String[] terms = jsonObject.value ? [jsonObject.value] as String[] : null
         List products = productService.searchProducts(terms, [])


### PR DESCRIPTION
… char threshold

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket: https://openboxes.atlassian.net/browse/OBLS-744**

**Description:**
Mobile typeaheads currently fire product and internal-location queries from the first keystroke, which fetches the full unpaginated dataset (~13k products / ~5k locations on VVG) on every interaction. This PR adds a fast, no-DB-hit short-circuit on the BE so requests below the configured minimum length are rejected immediately.

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
