### PR TITLE
OBLS-696 Fix missing preferred bin and assigned locations on st…

### DIFF
--- a/grails-app/domain/org/pih/warehouse/product/Product.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/Product.groovy
@@ -459,7 +459,7 @@ class Product implements Comparable, Serializable, Validatable<ProductValidator>
     InventoryLevel getInventoryLevel(String locationId) {
         if (id) {
             def location = Location.get(locationId)
-            return InventoryLevel.findByProductAndInventory(this, location.inventory)
+             return InventoryLevel.findByProductAndInventoryAndInternalLocationIsNull(this, location.inventory)
         }
     }
 

--- a/grails-app/domain/org/pih/warehouse/product/Product.groovy
+++ b/grails-app/domain/org/pih/warehouse/product/Product.groovy
@@ -459,7 +459,7 @@ class Product implements Comparable, Serializable, Validatable<ProductValidator>
     InventoryLevel getInventoryLevel(String locationId) {
         if (id) {
             def location = Location.get(locationId)
-             return InventoryLevel.findByProductAndInventoryAndInternalLocationIsNull(this, location.inventory)
+            return InventoryLevel.findByProductAndInventoryAndInternalLocationIsNull(this, location.inventory)
         }
     }
 


### PR DESCRIPTION
…ock card

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket: https://openboxes.atlassian.net/browse/OBLS-696**

**Description:**
The product stock card silently hid the "Preferred bin location" and "Assigned locations" rows for some products. Root cause was `Product.getInventoryLevel(locationId)` using `findByProductAndInventory(...)`, which has no `ORDER BY` and can return any `InventoryLevel` matching `(product, inventory)`. When a product had both a facility-scoped row and one or more location-scoped rows under the same facility, the system could return a location-scoped row - on which `preferredBinLocation` is null and `getAssignedLocations()` short-circuits to `[]`. The two `<g:if>` blocks in `_productDetails.gsp` then evaluated false and the rows disappeared from the card. The bug was data-dependent (UUID ordering), which is why only some products were affected on staging.

Fixed by tightening the dynamic finder so it always returns the facility-scoped row, which is the row that actually carries `preferredBinLocation` and seeds the assigned-locations list.

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
