### PR TITLE
Automate preview environment for new PRs 

### DIFF
--- a/.github/workflows/preview-image.yml
+++ b/.github/workflows/preview-image.yml
@@ -1,0 +1,248 @@
+name: Preview Environment
+
+# Builds a per-PR image and pushes it to ttl.sh (anonymous, auto-expiring registry). This image
+# is the artifact a preview host runs. Separate from docker-image.yml (releases -> GHCR).
+#
+# NOTE: The Uffizzi render/deploy/teardown jobs below are RETAINED BUT DISABLED (if: false).
+# Uffizzi Cloud was shut down in 2024; the jobs are kept for reference / a possible self-hosted
+# Uffizzi Enterprise install. The active preview host is being migrated (Preevy / a PaaS).
+#
+# Preview policy (cost control):
+#   - "claude/*" branches get a preview automatically (no label needed).
+#   - Any other PR can opt in by adding the "preview" label.
+#   - workflow_dispatch builds the image only.
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, closed]
+  workflow_dispatch:
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # ttl.sh image lifetime. Accepts values like 10m, 1h, 24h.
+  PREVIEW_TTL: 1h
+
+jobs:
+  build:
+    name: Build preview image
+    # Gate: never on close; manual runs always; PRs only for claude/* branches or "preview" label.
+    if: >-
+      github.event.action != 'closed' &&
+      ( github.event_name == 'workflow_dispatch' ||
+        startsWith(github.head_ref, 'claude/') ||
+        contains(github.event.pull_request.labels.*.name, 'preview') )
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.vars.outputs.image }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Compute ephemeral image reference
+        id: vars
+        # Untrusted values (branch names) are passed via env, never interpolated into the script.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            slug="pr-${PR_NUMBER}"
+          else
+            slug="branch-${REF_NAME//\//-}"
+          fi
+          echo "image=ttl.sh/openboxes-preview-${slug}-${SHA::7}:${PREVIEW_TTL}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 8
+          distribution: temurin
+          cache: gradle
+
+      - name: Build dependencies, project and prepare files for Docker build
+        run: ./gradlew prepareDocker -Dgrails.env=prod --console=plain
+
+      - name: Build and push preview image to ttl.sh
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: build/docker/
+          file: build/docker/Dockerfile
+          push: true
+          tags: ${{ steps.vars.outputs.image }}
+
+  render-compose-file:
+    name: Render Uffizzi compose file
+    needs: build
+    if: false  # disabled: Uffizzi path (Uffizzi Cloud shut down 2024)
+    runs-on: ubuntu-latest
+    outputs:
+      compose-file-cache-key: ${{ steps.hash.outputs.hash }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Render docker-compose.uffizzi.yml with the built image
+        env:
+          OB_IMAGE: ${{ needs.build.outputs.image }}
+        run: |
+          export OB_IMAGE
+          # Only substitute $OB_IMAGE; leave any other shell-like tokens untouched.
+          envsubst '$OB_IMAGE' < docker/docker-compose.uffizzi.yml > docker-compose.rendered.yml
+          echo "Rendered compose file:"
+          cat docker-compose.rendered.yml
+
+      - name: Hash rendered compose file
+        id: hash
+        run: echo "hash=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache rendered compose file
+        uses: actions/cache@v4
+        with:
+          path: docker-compose.rendered.yml
+          key: ${{ steps.hash.outputs.hash }}
+
+  deploy-uffizzi-preview:
+    name: Deploy preview to Uffizzi
+    needs: render-compose-file
+    if: false  # disabled: Uffizzi Cloud shut down 2024 (kept for Uffizzi Enterprise/self-hosted)
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v3
+    with:
+      compose-file-cache-key: ${{ needs.render-compose-file.outputs.compose-file-cache-key }}
+      compose-file-cache-path: docker-compose.rendered.yml
+      server: https://app.uffizzi.com
+      healthcheck-url-path: /openboxes/health
+    secrets: inherit
+
+  delete-uffizzi-preview:
+    name: Delete Uffizzi preview
+    if: false  # disabled: Uffizzi Cloud shut down 2024
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v3
+    with:
+      compose-file-cache-key: ""
+      compose-file-cache-path: docker-compose.rendered.yml
+      server: https://app.uffizzi.com
+    secrets: inherit
+
+  # ---- Active preview host: per-PR deploy to a VPS, routed via Traefik with HTTPS ----
+  deploy-vps-preview:
+    name: Deploy preview to VPS
+    needs: build
+    if: >-
+      github.event_name == 'pull_request' && github.event.action != 'closed' &&
+      ( startsWith(github.head_ref, 'claude/') ||
+        contains(github.event.pull_request.labels.*.name, 'preview') )
+    runs-on: ubuntu-latest
+    environment: preview
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure SSH
+        env:
+          SSH_KEY: ${{ secrets.PREVIEW_SSH_KEY }}
+          SSH_HOST: ${{ vars.PREVIEW_SSH_HOST }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Deploy preview stack
+        env:
+          SSH_HOST: ${{ vars.PREVIEW_SSH_HOST }}
+          SSH_USER: ${{ vars.PREVIEW_SSH_USER }}
+          OB_IMAGE: ${{ needs.build.outputs.image }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_DOMAIN: ${{ vars.PREVIEW_BASE_DOMAIN }}
+          ACME_EMAIL: ${{ vars.PREVIEW_ACME_EMAIL }}
+          MAX_CONCURRENT: ${{ vars.PREVIEW_MAX_CONCURRENT }}
+        run: |
+          project="pr-${PR_NUMBER}"
+          host="pr-${PR_NUMBER}.${BASE_DOMAIN}"
+          target="$SSH_USER@$SSH_HOST"
+          ssh -i ~/.ssh/deploy_key "$target" "mkdir -p ~/openboxes-preview"
+          scp -i ~/.ssh/deploy_key \
+            docker/docker-compose.preview.yml \
+            docker/docker-compose.traefik.yml \
+            docker/preview-deploy.sh \
+            "$target:~/openboxes-preview/"
+          ssh -i ~/.ssh/deploy_key "$target" \
+            "chmod +x ~/openboxes-preview/preview-deploy.sh && PREVIEW_ACME_EMAIL='$ACME_EMAIL' PREVIEW_MAX_CONCURRENT='${MAX_CONCURRENT:-3}' ~/openboxes-preview/preview-deploy.sh '$project' '$host' '$OB_IMAGE'"
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        env:
+          BASE_DOMAIN: ${{ vars.PREVIEW_BASE_DOMAIN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          script: |
+            const marker = '<!-- vps-preview -->';
+            const host = `pr-${process.env.PR_NUMBER}.${process.env.BASE_DOMAIN}`;
+            const url = `https://${host}/openboxes`;
+            const body = [
+              marker,
+              '### Preview environment deployed',
+              '',
+              `URL: ${url}`,
+              '',
+              '_Per-PR preview on the VPS, routed through Traefik with HTTPS. Tears down when this PR closes. First boot runs Liquibase migrations, so give it a minute (and the TLS cert a few seconds to issue)._',
+            ].join('\n');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body,
+              });
+            }
+
+  teardown-vps-preview:
+    name: Teardown VPS preview
+    if: >-
+      github.event_name == 'pull_request' && github.event.action == 'closed' &&
+      ( startsWith(github.head_ref, 'claude/') ||
+        contains(github.event.pull_request.labels.*.name, 'preview') )
+    runs-on: ubuntu-latest
+    environment: preview
+    permissions:
+      contents: read
+    steps:
+      - name: Configure SSH
+        env:
+          SSH_KEY: ${{ secrets.PREVIEW_SSH_KEY }}
+          SSH_HOST: ${{ vars.PREVIEW_SSH_HOST }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Tear down preview stack
+        env:
+          SSH_HOST: ${{ vars.PREVIEW_SSH_HOST }}
+          SSH_USER: ${{ vars.PREVIEW_SSH_USER }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          project="pr-${PR_NUMBER}"
+          ssh -i ~/.ssh/deploy_key "$SSH_USER@$SSH_HOST" \
+            "docker compose -p '$project' -f ~/openboxes-preview/docker-compose.preview.yml down --remove-orphans || true"

--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -1,6 +1,6 @@
 services:
     app:
-      image: ${OB_IMAGE_REPOSITORY-ghcr.io/}openboxes/openboxes:${OB_VERSION:-latest}
+      image: ${OB_IMAGE:-${OB_IMAGE_REPOSITORY-ghcr.io/}openboxes/openboxes:${OB_VERSION:-latest}}
       container_name: openboxes-app
       expose:
         - "8080"

--- a/docker/docker-compose.preview.yml
+++ b/docker/docker-compose.preview.yml
@@ -1,0 +1,47 @@
+# Per-PR preview stack: app (from OB_IMAGE) + its own MariaDB, isolated per compose project
+# (deployed as `docker compose -p pr-<n>`). Traefik routes ${PREVIEW_HOST} to the app over the
+# shared external "traefik" network and terminates HTTPS; the db stays on the project-private
+# default network. No host ports are published, so many PRs run side by side without collisions.
+#
+# Required env at deploy time: OB_IMAGE, PREVIEW_PROJECT (e.g. pr-123), PREVIEW_HOST.
+services:
+  app:
+    image: "${OB_IMAGE:-ghcr.io/openboxes/openboxes:latest}"
+    # Preview hosts don't honor compose depends_on health gating, so block until the db is up.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - 'until (echo > /dev/tcp/db/3306) 2>/dev/null; do echo "waiting for db:3306..."; sleep 2; done; exec java -Dgrails.env=prod -jar /app/openboxes.war'
+    restart: on-failure
+    environment:
+      DATASOURCE_URL: "jdbc:mysql://db/openboxes?serverTimezone=UTC&useSSL=false"
+      DATASOURCE_USERNAME: openboxes
+      DATASOURCE_PASSWORD: openboxes
+      # Canonical URL behind the Traefik TLS terminator, so generated links use the preview host.
+      GRAILS_SERVER_URL: "https://${PREVIEW_HOST}/openboxes/"
+      JAVA_TOOL_OPTIONS: "-Xms512m -Xmx1536m -XX:+UseG1GC -Djava.awt.headless=true"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.${PREVIEW_PROJECT}.rule=Host(`${PREVIEW_HOST}`)"
+      - "traefik.http.routers.${PREVIEW_PROJECT}.entrypoints=websecure"
+      - "traefik.http.routers.${PREVIEW_PROJECT}.tls.certresolver=le"
+      - "traefik.http.services.${PREVIEW_PROJECT}.loadbalancer.server.port=8080"
+    networks:
+      - default
+      - traefik
+
+  db:
+    image: mariadb:10
+    restart: on-failure
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: openboxes
+      MYSQL_USER: openboxes
+      MYSQL_PASSWORD: openboxes
+    networks:
+      - default
+
+networks:
+  # Shared with the Traefik proxy; created once by preview-deploy.sh.
+  traefik:
+    external: true

--- a/docker/docker-compose.traefik.yml
+++ b/docker/docker-compose.traefik.yml
@@ -1,0 +1,41 @@
+# Long-running reverse proxy for per-PR previews. Brought up once (idempotently) by
+# preview-deploy.sh under the project name "preview-infra". It discovers each PR's app container
+# via Docker labels, routes pr-<n>.<base-domain> to it, and obtains a Let's Encrypt certificate
+# per host via the HTTP-01 challenge (so no DNS-provider API credentials are required).
+#
+# Requires: the external "traefik" network to exist, ports 80/443 free on the host (remove Apache),
+# and PREVIEW_ACME_EMAIL set in the environment.
+services:
+  traefik:
+    image: traefik:v3.1
+    restart: unless-stopped
+    # NOTE: Traefik v3.1's embedded Docker client speaks API v1.24, which modern daemons reject.
+    # The host daemon must allow it via DOCKER_MIN_API_VERSION=1.24 (a systemd drop-in on the VPS).
+    # Setting DOCKER_API_VERSION on this container does NOT work - Traefik ignores it.
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --providers.docker.network=traefik
+      - --entrypoints.web.address=:80
+      - --entrypoints.websecure.address=:443
+      - --entrypoints.web.http.redirections.entrypoint.to=websecure
+      - --entrypoints.web.http.redirections.entrypoint.scheme=https
+      - --certificatesresolvers.le.acme.email=${PREVIEW_ACME_EMAIL}
+      - --certificatesresolvers.le.acme.storage=/letsencrypt/acme.json
+      - --certificatesresolvers.le.acme.httpchallenge=true
+      - --certificatesresolvers.le.acme.httpchallenge.entrypoint=web
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - traefik-letsencrypt:/letsencrypt
+    networks:
+      - traefik
+
+volumes:
+  traefik-letsencrypt:
+
+networks:
+  traefik:
+    external: true

--- a/docker/docker-compose.uffizzi.yml
+++ b/docker/docker-compose.uffizzi.yml
@@ -1,0 +1,41 @@
+# Uffizzi preview-environment compose template.
+#
+# This is NOT used to run OpenBoxes locally (use docker-compose.yml for that). The Preview
+# Environment workflow substitutes the ${OB_IMAGE} placeholder with the freshly built ttl.sh
+# image and hands the rendered file to Uffizzi, which deploys it as an ephemeral preview and
+# exposes the app via the ingress below.
+x-uffizzi:
+  ingress:
+    service: app
+    port: 8080
+
+services:
+  app:
+    image: "${OB_IMAGE}"
+    # Uffizzi doesn't honor compose's depends_on healthcheck gating, so block until the db is
+    # accepting TCP connections before launching the app (which connects to the db at boot).
+    entrypoint:
+      - /bin/bash
+      - -c
+      - 'until (echo > /dev/tcp/db/3306) 2>/dev/null; do echo "waiting for db:3306..."; sleep 2; done; exec java -Dgrails.env=prod -jar /app/openboxes.war'
+    environment:
+      DATASOURCE_URL: "jdbc:mysql://db/openboxes?serverTimezone=UTC&useSSL=false"
+      DATASOURCE_USERNAME: openboxes
+      DATASOURCE_PASSWORD: openboxes
+      JAVA_TOOL_OPTIONS: "-Xms512m -Xmx1024m -XX:+UseParallelGC -Djava.awt.headless=true"
+    deploy:
+      resources:
+        limits:
+          memory: 1536M
+
+  db:
+    image: mariadb:10
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: openboxes
+      MYSQL_USER: openboxes
+      MYSQL_PASSWORD: openboxes
+    deploy:
+      resources:
+        limits:
+          memory: 512M

--- a/docker/preview-deploy.sh
+++ b/docker/preview-deploy.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Deploy one PR preview behind Traefik on the VPS. Invoked over SSH by the preview workflow.
+# Usage: preview-deploy.sh <project> <host> <image>
+#   project  compose project name, e.g. pr-123
+#   host     preview hostname, e.g. pr-123.preview.openboxes.com
+#   image    image reference to run (the per-PR ttl.sh image)
+# Env: PREVIEW_ACME_EMAIL (required), PREVIEW_MAX_CONCURRENT (optional, default 3)
+set -euo pipefail
+
+PROJECT="$1"
+HOST="$2"
+IMAGE="$3"
+DIR="$HOME/openboxes-preview"
+MAX="${PREVIEW_MAX_CONCURRENT:-3}"
+: "${PREVIEW_ACME_EMAIL:?PREVIEW_ACME_EMAIL must be set}"
+
+# Ensure the shared proxy network and Traefik are running (idempotent).
+docker network create traefik 2>/dev/null || true
+PREVIEW_ACME_EMAIL="$PREVIEW_ACME_EMAIL" \
+  docker compose -p preview-infra -f "$DIR/docker-compose.traefik.yml" up -d
+
+# Concurrency guard (RAM protection): count distinct running pr-* projects.
+mapfile -t projects < <(docker ps --format '{{.Label "com.docker.compose.project"}}' | grep '^pr-' | sort -u)
+count="${#projects[@]}"
+already=0
+for p in "${projects[@]}"; do [ "$p" = "$PROJECT" ] && already=1; done
+if [ "$already" -eq 0 ] && [ "$count" -ge "$MAX" ]; then
+  echo "Cap reached: ${count} preview(s) running (PREVIEW_MAX_CONCURRENT=${MAX}). Close a PR to free a slot." >&2
+  exit 1
+fi
+
+OB_IMAGE="$IMAGE" PREVIEW_PROJECT="$PROJECT" PREVIEW_HOST="$HOST" \
+  docker compose -p "$PROJECT" -f "$DIR/docker-compose.preview.yml" up -d --pull always --remove-orphans
+
+# Reclaim disk from superseded/torn-down preview images (each build is a fresh ~1GB image),
+# so the VPS doesn't fill up. Images backing running containers are in use and kept.
+docker image prune -af >/dev/null 2>&1 || true
+
+echo "Deployed ${PROJECT} -> https://${HOST}/openboxes"


### PR DESCRIPTION
Adds automated per-PR preview environments for OpenBoxes. When a PR opts in (`preview` label, `claude` prefix in branch name), GHA builds the branch image, stores it in a temporary repo (ttl.sh), ship it to a VPS (rimuhosting for now), and Traefik exposes it at a per-PR HTTPS URL. The preview is torn down when the PR closes. GitHub 

Note: I used ghcr.io for the first few runs of this GHA (those images can be purged), but realized we probably want to use a temporary image repo which is when I discovered ttl.sh.  

Here's the first preview environment I created via this GHA
https://pr-5945.preview.openboxes.com/openboxes/auth/login

The main idea behind this is that sometimes we need to quickly preview PRs before they get merged to develop and CI/CD'd to the dev environments. While it works, I hate the process we currently adopt of manually pushing branches to obdev5 or whatever. In addition, I needed a way to auto-deploy PRs while using Claude Code locally or via a web Claude Code session. I'm struggling to find time to sit in front of an IDE, so this was the next best thing. 

Future Enhancements
* Over time I'd like to beef up that VPS to allow 10+ branches to be deployed at a time. 
* ...
