### PR TITLE
Consolidate role permission handling at the controller/service boundary

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/RoleInterceptor.groovy
+++ b/grails-app/controllers/org/pih/warehouse/RoleInterceptor.groovy
@@ -38,18 +38,19 @@ class RoleInterceptor {
 
     def static managerActions = [
         'inventory'           : ['createOutboundTransfer'],
-        'stockMovementItemApi': ['eraseItem']
+        'stockMovementItemApi': ['eraseItem'],
+        'user'                : ['show', 'edit']
     ]
 
     def static adminControllers = ['createProduct', 'createProductFromTemplate', 'admin']
     def static adminActions = [
-        'product'      : ['create'],
-        'person'       : ['list'],
-        'user'         : ['list'],
-        'location'     : ['edit'],
-        'shipper'      : ['create'],
-        'locationGroup': ['create'],
-        'locationType' : ['list'],
+        'product'        : ['create'],
+        'person'         : ['list'],
+        'user'           : ['list'],
+        'location'       : ['edit'],
+        'shipper'        : ['create'],
+        'locationGroup'  : ['create'],
+        'locationType'   : ['list'],
         'productSupplier': ['create', 'delete', 'edit']
     ]
 

--- a/grails-app/controllers/org/pih/warehouse/user/UserController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/user/UserController.groovy
@@ -9,9 +9,17 @@
  **/
 package org.pih.warehouse.user
 
+import grails.gorm.transactions.Transactional
 import grails.validation.ValidationException
-import org.apache.http.auth.AuthenticationException
 
+import java.awt.Graphics2D
+import java.awt.Image as AWTImage
+import java.awt.image.BufferedImage
+
+import javax.imageio.ImageIO as IIO
+import javax.swing.*
+
+import org.apache.http.auth.AuthenticationException
 import org.pih.warehouse.core.LocalizationService
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.LocationRole
@@ -21,14 +29,6 @@ import org.pih.warehouse.core.Role
 import org.pih.warehouse.core.RoleType
 import org.pih.warehouse.core.User
 import org.pih.warehouse.core.UserDataService
-
-import javax.imageio.ImageIO as IIO
-import javax.swing.*
-import grails.gorm.transactions.Transactional
-
-import java.awt.Graphics2D
-import java.awt.Image as AWTImage
-import java.awt.image.BufferedImage
 
 class UserController {
 
@@ -126,6 +126,28 @@ class UserController {
      */
     def save() {
         log.info "attempt to save the user; show form with validation errors on failure"
+
+        /*
+         * Note that locationRoles is not currently exposed in the UI,
+         * so we can get away with ignoring requestedLocationRoles here.
+         *
+         * The main thing here is to pop all location role params out of
+         * the params map, even unsupported ones, so that GORM doesn't
+         * try to bind them to the User instance without first validating
+         * that the creating user has permissions to assign them.
+         */
+        def (requestedRoles, requestedLocationRoles) = popRoleParamsBeforeBinding(params)
+
+        /*
+         * It's a common pattern for controllers to create a new instance
+         * and the service to save them. We have to be careful in this
+         * pattern to not let GORM bind role parameters to the instance;
+         * that's why we pop them out of the params map and pass them
+         * separately to the service, which can validate them. This might
+         * overall be a bit cleaner if we just let the service create the
+         * instance, but that would break our coding conventions. It's
+         * probably most parsimonious to just be careful.
+         */
         User userInstance = new User(params)
 
         // Default value for active field on Person is set to True
@@ -138,12 +160,12 @@ class UserController {
         userInstance.password = params?.password?.encodeAsPassword()
         userInstance.passwordConfirm = params?.passwordConfirm?.encodeAsPassword()
 
-        User persistedUser = userService.saveUser(userInstance)
-
-        if (persistedUser) {
+        try {
+            userService.saveUser(userInstance, session.user.id, requestedRoles)
             flash.message = "${warehouse.message(code: 'default.created.message', args: [warehouse.message(code: 'user.label'), userInstance.id])}"
             redirect(action: "edit", id: userInstance.id)
-        } else {
+        } catch (ValidationException e) {
+            userInstance.errors = e.errors
             render(view: "create", model: [userInstance: userInstance])
         }
     }
@@ -247,8 +269,10 @@ class UserController {
                 }
             }
 
+            def (requestedRoles, requestedLocationRoles) = popRoleParamsBeforeBinding(params)
+
             try {
-                userInstance = userService.updateUser(params.id, session.user.id, params)
+                userInstance = userService.updateUser(params.id, session.user.id, requestedRoles, params)
                 // Update session data if the user is editing their own profile
                 if (session.user.id == userInstance?.id) {
                     session.user = User.get(userInstance?.id)
@@ -456,8 +480,14 @@ class UserController {
     }
 
     def deleteLocationRole() {
-        String userId = locationRoleDataService.deleteLocationRole(params.id)
-        redirect(action: "edit", id: userId)
+        LocationRole locationRole = LocationRole.get(params.id)
+        try {
+            String userId = userService.deleteLocationRole(params.id, session.user.id)
+            redirect(action: "edit", id: userId)
+        } catch (ValidationException e) {
+            flash.message = e.message // the service localizes its messages for us
+            redirect(action: "edit", id: locationRole?.user?.id)
+        }
     }
 
     def saveLocationRole() {
@@ -466,7 +496,11 @@ class UserController {
         Location location = params.location?.id ? Location.get(params.location.id) : null
         List<Role> roles = params.list("role.id").collect { roleId -> Role.get(roleId) }
         LocationRole locationRole = LocationRole.get(params.id)
-        userService.saveLocationRole(location, locationRole, roles, user)
+        try {
+            userService.saveLocationRole(location, locationRole, roles, user, session.user.id)
+        } catch (ValidationException e) {
+            flash.message = e.message // the service localizes its messages for us
+        }
         redirect(action: "edit", id: params.user.id)
     }
 
@@ -566,5 +600,28 @@ class UserController {
         g2d.dispose()
 
         IIO.write(bi, 'JPEG', out)
+    }
+
+    /**
+     * Extract role values from params and remove all role-adjacent keys.
+     *
+     * Unlike other parameters, we do NOT want GORM to bind role params.
+     * Roles must be passed separately to the service for validation.
+     *
+     * After calling this method, new User(params) is safe to delegate
+     * to GORM.
+     *
+     * @return [roles, locationRoles] as lists
+     */
+    private static List popRoleParamsBeforeBinding(Map params) {
+        // our contract is that roles should be passed under the 'roles' key
+        List roles = params.list('roles')
+        // but GORM may try to bind things like `roles[0].id` if we aren't careful
+        params.keySet().removeAll { it?.toString()?.startsWith('roles') }
+
+        // and similarly for location roles
+        List locationRoles = params.list('locationRoles')
+        params.keySet().removeAll { it?.toString()?.startsWith('locationRoles') }
+        return [roles, locationRoles]
     }
 }

--- a/grails-app/controllers/org/pih/warehouse/user/UserController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/user/UserController.groovy
@@ -23,7 +23,6 @@ import org.apache.http.auth.AuthenticationException
 import org.pih.warehouse.core.LocalizationService
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.LocationRole
-import org.pih.warehouse.core.LocationRoleDataService
 import org.pih.warehouse.core.MailService
 import org.pih.warehouse.core.Role
 import org.pih.warehouse.core.RoleType
@@ -37,7 +36,6 @@ class UserController {
     def userService
     def locationService
     LocalizationService localizationService
-    LocationRoleDataService locationRoleDataService
     UserDataService userGormService
 
     /**
@@ -482,7 +480,7 @@ class UserController {
     def deleteLocationRole() {
         LocationRole locationRole = LocationRole.get(params.id)
         try {
-            String userId = userService.deleteLocationRole(params.id, session.user.id)
+            String userId = userService.deleteLocationRole(locationRole, session.user.id)
             redirect(action: "edit", id: userId)
         } catch (ValidationException e) {
             flash.message = e.message // the service localizes its messages for us

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -3236,6 +3236,11 @@ user.username.unique=Username {2} is already in use
 user.warehouse.label=Warehouse
 # User error messages
 user.errors.cannotEditUserRoles.message=User {0} cannot edit user roles for user {1}
+user.errors.cannotAssignRole.message=User {0} does not have permission to assign role {1}
+user.errors.cannotRemoveRole.message=User {0} does not have permission to remove role {1}
+user.errors.locationRolesNotAllowedOnCreate.message=locationRoles cannot be set during user creation
+user.errors.locationRolesNotAllowedDirectly.message=locationRoles cannot be set directly; use locationRolePairs instead
+user.errors.rolesNotAllowedDirectly.message=roles cannot be set directly; pass them as a separate argument
 user.errors.cannotSetLocaleToTranslationLocale.message=You cannot set your default locale for translation mode locale
 # Warehouse messages
 warehouse.active.label=Active

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -3238,7 +3238,6 @@ user.warehouse.label=Warehouse
 user.errors.cannotEditUserRoles.message=User {0} cannot edit user roles for user {1}
 user.errors.cannotAssignRole.message=User {0} does not have permission to assign role {1}
 user.errors.cannotRemoveRole.message=User {0} does not have permission to remove role {1}
-user.errors.locationRolesNotAllowedOnCreate.message=locationRoles cannot be set during user creation
 user.errors.locationRolesNotAllowedDirectly.message=locationRoles cannot be set directly; use locationRolePairs instead
 user.errors.rolesNotAllowedDirectly.message=roles cannot be set directly; pass them as a separate argument
 user.errors.cannotSetLocaleToTranslationLocale.message=You cannot set your default locale for translation mode locale

--- a/grails-app/services/org/pih/warehouse/core/LocationRoleDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/LocationRoleDataService.groovy
@@ -7,17 +7,4 @@ abstract class LocationRoleDataService {
     abstract LocationRole get(String id)
 
     abstract void delete(String id)
-
-    /**
-     *
-     * @param locationRoleId
-     * @return Returns user's id to the controller to display the edit page of the user after successful removal of location role
-     */
-    String deleteLocationRole(String locationRoleId) {
-        LocationRole locationRole = get(locationRoleId)
-        User user = locationRole?.user
-        user?.removeFromLocationRoles(locationRole)
-        delete(locationRole?.id)
-        return user?.id
-    }
 }

--- a/grails-app/services/org/pih/warehouse/core/UserService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/UserService.groovy
@@ -15,12 +15,11 @@ import grails.gorm.transactions.Transactional
 import grails.util.Holders
 import grails.validation.ValidationException
 import groovy.sql.Sql
-import org.apache.commons.collections.ListUtils
 import org.apache.http.auth.AuthenticationException
 import org.hibernate.sql.JoinType
 import org.pih.warehouse.LocalizationUtil
 import org.pih.warehouse.auth.AuthService
-import org.grails.plugins.web.taglib.ApplicationTagLib
+import org.pih.warehouse.core.localization.MessageLocalizer
 
 @Transactional
 class UserService {
@@ -28,24 +27,65 @@ class UserService {
     def authService
     def dataSource
     GrailsApplication grailsApplication
+    MessageLocalizer messageLocalizer
 
     User getUser(String id) {
         return User.get(id)
     }
 
-    User saveUser(User user) {
-        return user.save()
+    /**
+     * Persist a newly-created user, along with an initial set of roles.
+     *
+     * Role IDs must be passed as an explicit `requestedRoleIds` argument,
+     * separately from any other user fields, so that the service can run
+     * them through {@link #checkCanAddOrRemoveRoles} before they reach the
+     * database. (See {@link #updateUser} for the full rationale.)
+     */
+    User saveUser(User user, String requestingUserId, List<String> requestedRoleIds) {
+        if (user.roles) {
+            throw new IllegalArgumentException(messageLocalizer.localize(
+                'user.errors.rolesNotAllowedDirectly.message'))
+        }
+        if (user.locationRoles) {
+            throw new IllegalArgumentException(messageLocalizer.localize(
+                'user.errors.locationRolesNotAllowedDirectly.message'))
+        }
+        if (requestedRoleIds) {
+            validateAndApplyRoleChanges(User.get(requestingUserId), user, requestedRoleIds)
+        }
+        return user.save(failOnError: true)
     }
 
-
-    def updateUser(String userId, String currentUserId, Map params) {
+    /**
+     * Apply an update to an existing user.
+     *
+     * Role IDs must be passed as an explicit `requestedRoleIds` argument
+     * rather than being left inside the `params` map.
+     *
+     * Non-role fields (firstName, locale, etc.) are pulled from `params` and
+     * applied directly to the user instance before saving. We don't allow this
+     * for roles because, uniquely, the ability to set them depends on the
+     * requesting user's role and permissions. If left in params, GORM will
+     * cheerfully accept and bind them directly to the user, completely ignoring
+     * the validation logic in {@link #checkCanAddOrRemoveRoles}.
+     *
+     * Controllers must extract role IDs and strip them out of the params map
+     * before calling in to the service; see `UserController.update` / `save`.
+     *
+     * {@link #rejectRoleKeysInParams} makes sure they do their homework.
+     */
+    def updateUser(String userId, String requestingUserId, List<String> requestedRoleIds, Map params) {
 
         User userInstance = User.get(userId)
-        List<Role> updatedRoles = params.roles ? Role.findAllByIdInList(params.list("roles")) : []
+        User requestingUser = User.get(requestingUserId)
 
-        if (params.roles) {
-            userInstance.roles = updatedRoles
-            params.remove("roles")
+        rejectRoleKeysInParams(params)
+
+        if (requestedRoleIds) {
+            validateAndApplyRoleChanges(requestingUser, userInstance, requestedRoleIds)
+        }
+        if (params.locationRolePairs) {
+            validateAndApplyLocationRoleChanges(requestingUser, userInstance, params)
         }
 
         // Password in the db is different from the one specified
@@ -61,39 +101,13 @@ class UserService {
             userInstance.errors.rejectValue("locale", "user.errors.cannotSetLocaleToTranslationLocale.message", "You cannot set your default locale for translation mode locale")
             throw new ValidationException("user.errors.cannotSetLocaleToTranslationLocale.message", userInstance.errors)
         }
-        // If a non-admin user edits their profile they will not have access to
-        // the roles or location roles, so we need to prevent the updateRoles
-        // method from being called.
-        if (params.locationRolePairs) {
-            updateRoles(userInstance, params.locationRolePairs)
-        }
 
-        // We need to cache current role and check edit privilege here because the roles association
-        // may change once we merge user and request parameters
-        if (params.updateRoles) {
-            User currentUser = User.load(currentUserId)
-            Boolean canEditRoles = canEditUserRoles(currentUser, userInstance)
-
-            // Check to make sure the roles are dirty
-            HashSet<Role> currentRoles = new HashSet(userInstance?.roles)
-            boolean isRolesDirty = !ListUtils.isEqualList(updatedRoles, currentRoles)
-            log.info "User update: ${updatedRoles} vs ${currentRoles}: isDirty=${isRolesDirty}, canEditRoles=${canEditRoles}"
-            if (isRolesDirty && !canEditRoles) {
-                Object[] args = [currentUser.username, userInstance.username]
-                userInstance.errors.rejectValue("roles", "user.errors.cannotEditUserRoles.message", args, "User cannot edit user roles")
-                throw new ValidationException("user.errors.cannotEditUserRoles.message", userInstance.errors)
-            }
-        }
-        log.info "User has errors: ${userInstance.hasErrors()} ${userInstance.errors}"
         return userInstance.save(failOnError: true)
     }
 
     void changePassword(User user, String password, String passwordConfirm) {
         if (!canUserEditPassword(AuthService.currentUser, user)) {
-            String errorMessage = applicationTagLib.message(
-                    code: 'errors.accessDenied.message',
-                    default: 'Apologies, but you are not authorized to access this page or to perform this action.',
-            )
+            String errorMessage = messageLocalizer.localize('errors.accessDenied.message')
             throw new AuthenticationException(errorMessage)
         }
 
@@ -124,26 +138,65 @@ class UserService {
         }
     }
 
-    private void updateRoles(user, locationRolePairs) {
-        def newAndUpdatedRoles = locationRolePairs.keySet().collect { locationId ->
-            if (locationRolePairs[locationId]) {
-                def location = Location.get(locationId)
-                def role = Role.get(locationRolePairs[locationId])
-                def existingRole = user.locationRoles.find { it.location == location }
-                if (existingRole) {
-                    existingRole.role = role
+    /**
+     * Controllers must never pass role-related keys in a params map.
+     *
+     * They must be extracted by the controller and passed as separate arguments.
+     */
+    private void rejectRoleKeysInParams(Map params) {
+        if (params.any { key, val -> key?.toString()?.startsWith('roles') }) {
+            throw new IllegalArgumentException(messageLocalizer.localize(
+                'user.errors.rolesNotAllowedDirectly.message'))
+        }
+        if (params.any { key, val -> key?.toString()?.startsWith('locationRoles') }) {
+            throw new IllegalArgumentException(messageLocalizer.localize(
+                'user.errors.locationRolesNotAllowedDirectly.message'))
+        }
+    }
+
+    private void validateAndApplyRoleChanges(User requestingUser, User user, List<String> requestedRoleIds) {
+        List<Role> requestedRoles = Role.findAllByIdInList(requestedRoleIds)
+        checkCanAddOrRemoveRoles(requestingUser, user, user.roles, requestedRoles)
+
+        /*
+         * While it may be tempting to directly assign the roles collection,
+         * it's safer, GORM/Hibernate-wise, to add/remove them one at a time.
+         */
+        Set<Role> before = (user.roles ?: []) as Set
+        Set<Role> after = requestedRoles as Set
+        (before - after).each { user.removeFromRoles(it) }
+        (after - before).each { user.addToRoles(it) }
+    }
+
+    private void validateAndApplyLocationRoleChanges(User requestingUser, User user, Map params) {
+        Map<String, String> locationRolePairs = params.locationRolePairs
+        checkCanAddOrRemoveLocationRoles(requestingUser, user, locationRolePairs)
+
+        // remove location roles not present in the update
+        user.locationRoles
+            ?.findAll { !locationRolePairs[it.location.id] }
+            ?.each { user.removeFromLocationRoles(it) }
+
+        // add or update location roles
+        locationRolePairs.each { locationId, roleId ->
+            if (roleId) {
+                Location location = Location.get(locationId)
+                Role role = Role.get(roleId)
+                LocationRole existing = user.locationRoles?.find { it.location == location }
+                if (existing?.role == role) {
+                    // nothing to do
+                } else if (existing) {
+                    // modify existing locationRole with new role type
+                    existing.role = role
                 } else {
-                    def newLocationRole = new LocationRole(user: user, location: location, role: role)
-                    user.addToLocationRoles(newLocationRole)
+                    // no existing locationRole for this location, add new one
+                    user.addToLocationRoles(new LocationRole(user: user, location: location, role: role))
                 }
             }
         }
-        def rolesToRemove = user.locationRoles.findAll { oldRole ->
-            !locationRolePairs[oldRole.location.id]
-        }
-        rolesToRemove.each {
-            user.removeFromLocationRoles(it)
-        }
+
+        // GORM ignores this anyway, but it doesn't hurt to clean up when we're done
+        params.remove('locationRolePairs')
     }
 
     Boolean isSuperuser(User u) {
@@ -266,9 +319,61 @@ class UserService {
         return false
     }
 
-    Boolean canEditUserRoles(User currentUser, User otherUser) {
-        def location = authService.currentLocation
-        return isSuperuser(currentUser) || (currentUser.getHighestRole(location) >= otherUser.getHighestRole(location))
+    /**
+     * Returns true if requestingUser has permission to assign or remove targetRole.
+     */
+    Boolean canAddOrRemoveRole(User requestingUser, Role targetRole) {
+        if (!requestingUser) {
+            return false
+        }
+        if (isSuperuser(requestingUser)) {
+            return true
+        }
+
+        /*
+         * FIXME: we should check the user's highest role at the location
+         * of the role being assigned, not just their highest role overall.
+         */
+        Role currentHighest = requestingUser.getHighestRole(authService.currentLocation)
+        if (!currentHighest) {
+            return false
+        }
+
+        return currentHighest.roleType.sortOrder <= targetRole.roleType.sortOrder
+    }
+
+    private void rejectRoleChange(User targetUser, String messageCode, User requestingUser, Role role) {
+        String message = messageLocalizer.localize(messageCode, requestingUser?.username, role.name)
+        log.warn("Rejected role change on user ${targetUser} by ${requestingUser}: ${messageCode}")
+        targetUser.errors.reject(messageCode, [requestingUser?.username, role.name] as Object[], message)
+        throw new ValidationException(message, targetUser.errors)
+    }
+
+    void checkCanAddOrRemoveRoles(User requestingUser, User targetUser, Collection<Role> before, Collection<Role> after) {
+        if (isSuperuser(requestingUser)) {
+            return
+        }
+        Set<Role> added = ((after ?: []) as Set) - ((before ?: []) as Set)
+        Set<Role> removed = ((before ?: []) as Set) - ((after ?: []) as Set)
+        for (Role role : added) {
+            if (!canAddOrRemoveRole(requestingUser, role)) {
+                rejectRoleChange(targetUser, 'user.errors.cannotAssignRole.message', requestingUser, role)
+            }
+        }
+        for (Role role : removed) {
+            if (!canAddOrRemoveRole(requestingUser, role)) {
+                rejectRoleChange(targetUser, 'user.errors.cannotRemoveRole.message', requestingUser, role)
+            }
+        }
+    }
+
+    private void checkCanAddOrRemoveLocationRoles(User requestingUser, User targetUser, Map<String, String> locationRolePairs) {
+        List<Role> before = targetUser.locationRoles?.collect { it.role }
+        List<Role> after = locationRolePairs.values()
+            .findAll { it }
+            .collect { Role.get(it) }
+            .findAll { it }
+        checkCanAddOrRemoveRoles(requestingUser, targetUser, before, after)
     }
 
     boolean isUserInAllRoles(String userId, Collection roleTypes, String locationId) {
@@ -529,7 +634,15 @@ class UserService {
         return user.deserializeDashboardConfig()
     }
 
-    def saveLocationRole(Location location, LocationRole locationRole, List<Role> roles, User user) {
+    def saveLocationRole(Location location, LocationRole locationRole, List<Role> roles, User user, String requestingUserId) {
+        /*
+         * This method both creates a location role and assigns it. If the
+         * requester doesn't have permission to assign the role, stop immediately.
+         */
+        User requestingUser = User.get(requestingUserId)
+        List<Role> before = locationRole ? [locationRole.role] : []
+        checkCanAddOrRemoveRoles(requestingUser, user, before, roles)
+
         // Update existing role
         if (locationRole && roles.size() == 1) {
             locationRole.role = roles.first()
@@ -551,6 +664,19 @@ class UserService {
         user.save(failOnError: true)
     }
 
+    String deleteLocationRole(String locationRoleId, String requestingUserId) {
+        LocationRole locationRole = LocationRole.get(locationRoleId)
+        if (locationRole) {
+            User requestingUser = User.get(requestingUserId)
+            checkCanAddOrRemoveRoles(requestingUser, locationRole.user, [locationRole.role], [])
+        }
+        User user = locationRole?.user
+        user?.removeFromLocationRoles(locationRole)
+        locationRole?.delete()
+        user?.save(failOnError: true)
+        return user?.id
+    }
+
     Role[] extractDefaultRoles(String defaultRolesString) {
         String[] defaultRoles = defaultRolesString?.split(",")
         Role[] roles = defaultRoles.collect { String roleTypeName ->
@@ -569,7 +695,4 @@ class UserService {
         currentUser?.id == userToEdit.id || isUserAdmin(currentUser)
     }
 
-    def getApplicationTagLib() {
-        return grailsApplication.mainContext.getBean(ApplicationTagLib)
-    }
 }

--- a/grails-app/services/org/pih/warehouse/core/UserService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/UserService.groovy
@@ -43,12 +43,14 @@ class UserService {
      */
     User saveUser(User user, String requestingUserId, List<String> requestedRoleIds) {
         if (user.roles) {
-            throw new IllegalArgumentException(messageLocalizer.localize(
-                'user.errors.rolesNotAllowedDirectly.message'))
+            String message = messageLocalizer.localize('user.errors.rolesNotAllowedDirectly.message')
+            user.errors.reject('user.errors.rolesNotAllowedDirectly.message', message)
+            throw new ValidationException(message, user.errors)
         }
         if (user.locationRoles) {
-            throw new IllegalArgumentException(messageLocalizer.localize(
-                'user.errors.locationRolesNotAllowedDirectly.message'))
+            String message = messageLocalizer.localize('user.errors.locationRolesNotAllowedDirectly.message')
+            user.errors.reject('user.errors.locationRolesNotAllowedDirectly.message', message)
+            throw new ValidationException(message, user.errors)
         }
         if (requestedRoleIds) {
             validateAndApplyRoleChanges(User.get(requestingUserId), user, requestedRoleIds)
@@ -79,7 +81,7 @@ class UserService {
         User userInstance = User.get(userId)
         User requestingUser = User.get(requestingUserId)
 
-        rejectRoleKeysInParams(params)
+        rejectRoleKeysInParams(userInstance, params)
 
         if (requestedRoleIds) {
             validateAndApplyRoleChanges(requestingUser, userInstance, requestedRoleIds)
@@ -143,14 +145,16 @@ class UserService {
      *
      * They must be extracted by the controller and passed as separate arguments.
      */
-    private void rejectRoleKeysInParams(Map params) {
+    private void rejectRoleKeysInParams(User user, Map params) {
         if (params.any { key, val -> key?.toString()?.startsWith('roles') }) {
-            throw new IllegalArgumentException(messageLocalizer.localize(
-                'user.errors.rolesNotAllowedDirectly.message'))
+            String message = messageLocalizer.localize('user.errors.rolesNotAllowedDirectly.message')
+            user.errors.reject('user.errors.rolesNotAllowedDirectly.message', message)
+            throw new ValidationException(message, user.errors)
         }
         if (params.any { key, val -> key?.toString()?.startsWith('locationRoles') }) {
-            throw new IllegalArgumentException(messageLocalizer.localize(
-                'user.errors.locationRolesNotAllowedDirectly.message'))
+            String message = messageLocalizer.localize('user.errors.locationRolesNotAllowedDirectly.message')
+            user.errors.reject('user.errors.locationRolesNotAllowedDirectly.message', message)
+            throw new ValidationException(message, user.errors)
         }
     }
 
@@ -664,8 +668,7 @@ class UserService {
         user.save(failOnError: true)
     }
 
-    String deleteLocationRole(String locationRoleId, String requestingUserId) {
-        LocationRole locationRole = LocationRole.get(locationRoleId)
+    String deleteLocationRole(LocationRole locationRole, String requestingUserId) {
         if (locationRole) {
             User requestingUser = User.get(requestingUserId)
             checkCanAddOrRemoveRoles(requestingUser, locationRole.user, [locationRole.role], [])

--- a/src/test/groovy/org/pih/warehouse/RoleInterceptorSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/RoleInterceptorSpec.groovy
@@ -1,0 +1,152 @@
+package org.pih.warehouse
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class RoleInterceptorSpec extends Specification {
+
+    // convenience method so we can write a big, expressive, expansive @Unroll table
+    private boolean needRoleRouter(String controller, String action, String role) {
+        switch (role) {
+            case 'superuser':       return RoleInterceptor.needSuperuser(controller, action)
+            case 'admin':           return RoleInterceptor.needAdmin(controller, action)
+            case 'manager':         return RoleInterceptor.needManager(controller, action)
+            case 'invoice':         return RoleInterceptor.needInvoice(controller, action)
+            case 'product manager': return RoleInterceptor.needProductManager(controller, action)
+            default:                throw new IllegalArgumentException("Unsupported role: ${role}")
+        }
+    }
+
+    void "#controller.#action #requires '#role' access or above"() {
+        expect:
+        assert needRoleRouter(controller, action, role) == (requires == 'requires')
+
+        where:
+        role              | controller              | action                        || requires
+        'superuser'       | 'console'               | 'execute'                     || 'requires'
+        'superuser'       | 'console'               | 'index'                       || 'requires'
+        'superuser'       | 'console'               | 'list'                        || 'does not require'
+        'superuser'       | 'inventory'             | 'createInboundTransfer'       || 'requires'
+        'superuser'       | 'inventory'             | 'deleteTransaction'           || 'requires'
+        'superuser'       | 'inventory'             | 'list'                        || 'does not require'
+        'superuser'       | 'inventoryItem'         | 'adjustStock'                 || 'requires'
+        'superuser'       | 'inventoryItem'         | 'transferStock'               || 'requires'
+        'superuser'       | 'jobs'                  | 'list'                        || 'requires'
+        'superuser'       | 'locationType'          | 'create'                      || 'requires'
+        'superuser'       | 'productCatalog'        | 'create'                      || 'requires'
+        'superuser'       | 'productType'           | 'edit'                        || 'requires'
+        'superuser'       | 'quartz'                | 'index'                       || 'requires'
+        'superuser'       | 'transactionEntry'      | 'delete'                      || 'requires'
+        'superuser'       | 'user'                  | 'edit'                        || 'does not require'
+        'superuser'       | 'user'                  | 'impersonate'                 || 'requires'
+        'superuser'       | 'user'                  | 'list'                        || 'does not require'
+        'admin'           | 'location'              | 'edit'                        || 'requires'
+        'admin'           | 'location'              | 'list'                        || 'does not require'
+        'admin'           | 'locationGroup'         | 'create'                      || 'requires'
+        'admin'           | 'locationType'          | 'list'                        || 'requires'
+        'admin'           | 'person'                | 'list'                        || 'requires'
+        'admin'           | 'person'                | 'show'                        || 'does not require'
+        'admin'           | 'product'               | 'create'                      || 'requires'
+        'admin'           | 'product'               | 'edit'                        || 'does not require'
+        'admin'           | 'product'               | 'list'                        || 'does not require'
+        'admin'           | 'productSupplier'       | 'create'                      || 'requires'
+        'admin'           | 'productSupplier'       | 'delete'                      || 'requires'
+        'admin'           | 'productSupplier'       | 'edit'                        || 'requires'
+        'admin'           | 'productSupplier'       | 'list'                        || 'does not require'
+        'admin'           | 'shipper'               | 'create'                      || 'requires'
+        'admin'           | 'user'                  | 'delete'                      || 'does not require'
+        'admin'           | 'user'                  | 'deleteLocationRole'          || 'does not require'
+        'admin'           | 'user'                  | 'edit'                        || 'does not require'
+        'admin'           | 'user'                  | 'list'                        || 'requires'
+        'admin'           | 'user'                  | 'save'                        || 'does not require'
+        'admin'           | 'user'                  | 'saveLocationRole'            || 'does not require'
+        'admin'           | 'user'                  | 'show'                        || 'does not require'
+        'admin'           | 'user'                  | 'toggleActivation'            || 'does not require'
+        'admin'           | 'user'                  | 'update'                      || 'does not require'
+        'manager'         | 'inventory'             | 'createOutboundTransfer'      || 'requires'
+        'manager'         | 'inventoryItem'         | 'showRecordInventory'         || 'requires'
+        'manager'         | 'product'               | 'exportAsCsv'                 || 'requires'
+        'manager'         | 'stockMovement'         | 'importOutboundStockMovement' || 'requires'
+        'manager'         | 'stockMovementItemApi'  | 'eraseItem'                   || 'requires'
+        'manager'         | 'user'                  | 'delete'                      || 'requires'
+        'manager'         | 'user'                  | 'deleteLocationRole'          || 'requires'
+        'manager'         | 'user'                  | 'edit'                        || 'requires'
+        'manager'         | 'user'                  | 'list'                        || 'does not require'
+        'manager'         | 'user'                  | 'save'                        || 'requires'
+        'manager'         | 'user'                  | 'saveLocationRole'            || 'requires'
+        'manager'         | 'user'                  | 'show'                        || 'requires'
+        'manager'         | 'user'                  | 'toggleActivation'            || 'requires'
+        'manager'         | 'user'                  | 'update'                      || 'requires'
+        'invoice'         | 'invoice'               | 'list'                        || 'requires'
+        'invoice'         | 'user'                  | 'list'                        || 'does not require'
+        'product manager' | 'productSupplier'       | 'create'                      || 'requires'
+        'product manager' | 'productSupplier'       | 'delete'                      || 'requires'
+        'product manager' | 'productSupplier'       | 'edit'                        || 'requires'
+        'product manager' | 'productSupplier'       | 'list'                        || 'does not require'
+    }
+
+    void "#controller.#prefix* requires 'manager' access or above"() {
+
+        /*
+         * All controllers should prefix-match in the same way;
+         * I just picked a few representative ones for testing.
+         * Feel free to add your favorite controller to the table.
+         */
+        expect:
+        assert RoleInterceptor.needManager(controller, "${prefix}Something")
+        assert !RoleInterceptor.needSuperuser(controller, "${prefix}Something")
+        assert !RoleInterceptor.needInvoice(controller, "${prefix}Something")
+        assert !RoleInterceptor.needProductManager(controller, "${prefix}Something")
+
+        where:
+        controller   | prefix
+        'inventory'  | 'add'
+        'inventory'  | 'cancel'
+        'inventory'  | 'change'
+        'inventory'  | 'create'
+        'inventory'  | 'delete'
+        'inventory'  | 'importData'
+        'inventory'  | 'process'
+        'inventory'  | 'receive'
+        'inventory'  | 'save'
+        'inventory'  | 'toggle'
+        'inventory'  | 'update'
+        'inventory'  | 'withdraw'
+        'product'    | 'add'
+        'product'    | 'create'
+        'product'    | 'delete'
+        'product'    | 'save'
+        'product'    | 'update'
+        'shipment'   | 'add'
+        'shipment'   | 'create'
+        'shipment'   | 'save'
+        'user'       | 'add'
+        'user'       | 'create'
+        'user'       | 'delete'
+        'user'       | 'save'
+        'user'       | 'update'
+    }
+
+    void "#controller #requires '#role' access or above for all actions"() {
+        expect:
+        // under the covers, these controllers use wildcards
+        assert needRoleRouter(controller, 'list', role) == (requires == 'requires')
+        assert needRoleRouter(controller, 'show', role) == (requires == 'requires')
+        assert needRoleRouter(controller, 'anyAction', role) == (requires == 'requires')
+        assert needRoleRouter(controller, 'someOtherAction', role) == (requires == 'requires')
+        assert needRoleRouter(controller, 'literallyAnything', role) == (requires == 'requires')
+
+        where:
+        controller                  | role      || requires
+        'admin'                     | 'admin'   || 'requires'
+        'admin'                     | 'manager' || 'does not require'
+        'admin'                     | 'invoice' || 'does not require'
+        'createProduct'             | 'admin'   || 'requires'
+        'createProduct'             | 'manager' || 'does not require'
+        'createProduct'             | 'invoice' || 'does not require'
+        'createProductFromTemplate' | 'admin'   || 'requires'
+        'createProductFromTemplate' | 'manager' || 'requires'
+        'createProductFromTemplate' | 'invoice' || 'does not require'
+    }
+}

--- a/src/test/groovy/org/pih/warehouse/core/UserControllerSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/core/UserControllerSpec.groovy
@@ -14,7 +14,8 @@ class UserControllerSpec extends Specification {
     void setup() {
         mockCodec(PasswordCodec)
 
-        new User(username: "asd",
+        // several controller actions read session.user.id
+        session.user = new User(username: "asd",
             firstName: "Asd",
             lastName: "Qwe",
             password: "test123",

--- a/src/test/groovy/org/pih/warehouse/core/UserServiceRoleValidationSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/core/UserServiceRoleValidationSpec.groovy
@@ -129,7 +129,7 @@ class UserServiceRoleValidationSpec extends Specification implements ServiceUnit
         service.updateUser(admin.id, superuser.id, [], [roles: [adminRole.id]])
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(ValidationException)
     }
 
     void "updateUser rejects params containing roles[] keys"() {
@@ -137,7 +137,7 @@ class UserServiceRoleValidationSpec extends Specification implements ServiceUnit
         service.updateUser(admin.id, superuser.id, [], ['roles[0].id': superuserRole.id])
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(ValidationException)
     }
 
     void "updateUser rejects params containing locationRoles keys"() {
@@ -145,7 +145,7 @@ class UserServiceRoleValidationSpec extends Specification implements ServiceUnit
         service.updateUser(admin.id, superuser.id, [], [locationRoles: [adminRole.id]])
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(ValidationException)
     }
 
     void "updateUser rejects params containing locationRoles[] keys"() {
@@ -153,6 +153,6 @@ class UserServiceRoleValidationSpec extends Specification implements ServiceUnit
         service.updateUser(admin.id, superuser.id, [], ['locationRoles[0].id': adminRole.id])
 
         then:
-        thrown(IllegalArgumentException)
+        thrown(ValidationException)
     }
 }

--- a/src/test/groovy/org/pih/warehouse/core/UserServiceRoleValidationSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/core/UserServiceRoleValidationSpec.groovy
@@ -1,0 +1,158 @@
+package org.pih.warehouse.core
+
+import grails.testing.gorm.DataTest
+import grails.testing.services.ServiceUnitTest
+import grails.validation.ValidationException
+
+import org.pih.warehouse.auth.AuthService
+import org.pih.warehouse.core.localization.MessageLocalizer
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@Unroll
+class UserServiceRoleValidationSpec extends Specification implements ServiceUnitTest<UserService>, DataTest {
+
+    Role adminRole
+    Role browserRole
+    Role managerRole
+    Role superuserRole
+
+    User admin
+    User manager
+    User superuser
+
+    void setupSpec() {
+        mockDomain(Location)
+        mockDomain(LocationRole)
+        mockDomain(Role)
+        mockDomain(User)
+    }
+
+    void setup() {
+        adminRole = new Role(roleType: RoleType.ROLE_ADMIN, name: 'Admin').save(validate: false)
+        browserRole = new Role(roleType: RoleType.ROLE_BROWSER, name: 'Browser').save(validate: false)
+        managerRole = new Role(roleType: RoleType.ROLE_MANAGER, name: 'Manager').save(validate: false)
+        superuserRole = new Role(roleType: RoleType.ROLE_SUPERUSER, name: 'Superuser').save(validate: false)
+
+        admin = new User(username: 'admin', password: 'pass', passwordConfirm: 'pass',
+            firstName: 'Admin', lastName: 'User', email: 'admin@test.com')
+        admin.addToRoles(adminRole)
+        admin.save(validate: false)
+
+        manager = new User(username: 'manager', password: 'pass', passwordConfirm: 'pass',
+            firstName: 'Manager', lastName: 'User', email: 'mgr@test.com')
+        manager.addToRoles(managerRole)
+        manager.save(validate: false)
+
+        superuser = new User(username: 'superuser', password: 'pass', passwordConfirm: 'pass',
+            firstName: 'Super', lastName: 'User', email: 'su@test.com')
+        superuser.addToRoles(superuserRole)
+        superuser.save(validate: false)
+
+        /*
+         * If currentLocation is null, requestingUser.getHighestRole() can
+         * still check global roles. Not ideal (see FIXME in UserService
+         * for more details), but it's enough for testing purposes, for now.
+         */
+        service.authService = Stub(AuthService) {
+            getCurrentLocation() >> null
+        }
+
+        // offers the bare minimum for localized error messages to work
+        service.messageLocalizer = Stub(MessageLocalizer) {
+            localize(_ as String, _) >> { String code, Object[] args -> code }
+            localize(_ as String) >> { String code -> code }
+        }
+    }
+
+    private User userByName(String name) {
+        switch (name) {
+            case 'superuser': return superuser
+            case 'admin':     return admin
+            case 'manager':   return manager
+            case 'null':      return null
+        }
+    }
+
+    private Role roleByName(String name) {
+        switch (name) {
+            case 'Superuser': return superuserRole
+            case 'Admin':     return adminRole
+            case 'Manager':   return managerRole
+            case 'Browser':   return browserRole
+        }
+    }
+
+    void "canAddOrRemoveRole #allows #user to add or remove role '#role'"() {
+        expect:
+        assert service.canAddOrRemoveRole(userByName(user), roleByName(role)) == (allows == 'allows')
+
+        where:
+        user        | role        || allows
+        'superuser' | 'Admin'     || 'allows'
+        'superuser' | 'Browser'   || 'allows'
+        'superuser' | 'Manager'   || 'allows'
+        'superuser' | 'Superuser' || 'allows'
+        'admin'     | 'Admin'     || 'allows'
+        'admin'     | 'Browser'   || 'allows'
+        'admin'     | 'Manager'   || 'allows'
+        'admin'     | 'Superuser' || 'forbids'
+        'manager'   | 'Admin'     || 'forbids'
+        'manager'   | 'Browser'   || 'allows'
+        'manager'   | 'Manager'   || 'allows'
+        'manager'   | 'Superuser' || 'forbids'
+        'null'      | 'Browser'   || 'forbids'
+    }
+
+    void "checkCanAddOrRemoveRoles passes when no roles change"() {
+        when:
+        service.checkCanAddOrRemoveRoles(admin, manager, [adminRole, managerRole], [adminRole, managerRole])
+        service.checkCanAddOrRemoveRoles(manager, admin, [adminRole, managerRole], [adminRole, managerRole])
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "checkCanAddOrRemoveRoles passes for empty before and after"() {
+        when:
+        service.checkCanAddOrRemoveRoles(superuser, admin, [], [])
+        service.checkCanAddOrRemoveRoles(manager, admin, [], [])
+        service.checkCanAddOrRemoveRoles(admin, manager, [], [])
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "updateUser rejects params containing roles keys"() {
+        when:
+        service.updateUser(admin.id, superuser.id, [], [roles: [adminRole.id]])
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    void "updateUser rejects params containing roles[] keys"() {
+        when:
+        service.updateUser(admin.id, superuser.id, [], ['roles[0].id': superuserRole.id])
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    void "updateUser rejects params containing locationRoles keys"() {
+        when:
+        service.updateUser(admin.id, superuser.id, [], [locationRoles: [adminRole.id]])
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    void "updateUser rejects params containing locationRoles[] keys"() {
+        when:
+        service.updateUser(admin.id, superuser.id, [], ['locationRoles[0].id': adminRole.id])
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+}


### PR DESCRIPTION
UserController used to bind request params directly to the User domain, which would allow Grails' data binding rules, not our policy, to determine which roles could be assigned.

Extract role IDs at the controller and pass them to the service as explicit arguments; make the service reject any role-shaped keys still in the params map (`rejectRoleKeysInParams()`) so the boundary is enforced from both sides. A `popRoleParamsBeforeBinding()` helper applies the same extraction pattern consistently in `save()` and `update()`.

Consolidate the permission checks themselves into
`checkCanAddOrRemoveRoles()` and `checkCanAddOrRemoveLocationRoles()`, used by every path that can change role assignments: `saveUser`, `updateUser`, `saveLocationRole`, `deleteLocationRole`.

Role validation logic moves into `validateAndApplyRoleChanges()` and `validateAndApplyLocationRoleChanges()`, which add and remove roles one at a time to steer clear of any GORM/Hibernate cascade quirks.

`checkCanAddOrRemove*Roles()` takes the target `User` as a parameter so validation errors attach to the right object. A new `rejectRoleChange` helper throws `ValidationException` with a localized message that UserController surfaces directly in `flash.message` instead of re-localizing.

Separately, `user.edit` and `user.show` had no entry in any of `RoleInterceptor`'s role lists. Any authenticated, browse-capable user could reach them through the default fall-through path. Add them to `managerActions` so the interceptor enforces at least manager-level access for both. This gets exercise in a big Spock table in `RoleInterceptorSpec`.

While I was in there:
- Hoisted `deleteLocationRole` logic from `UserController` into `UserService`.
- Added five message keys to clarify error conditions to users.
- Added Javadoc on `saveUser`, `updateUser`, and `rejectRoleKeysInParams()` to explain why role IDs must not travel inside the params map.
- Covered the controller/service boundary with a new `UserServiceRoleValidationSpec` exercising role assignment, role removal, and params-map rejection.
- Updated `UserControllerSpec` setup to stub `session.user`, since `saveUser`'s new signature reads `session.user.id` to identify the requesting user.
- Used idiomatic Spock in `RoleInterceptorSpec`: `@Unroll` hoisted to the class, `||` separator marking expected output, `assert` used in expectations that delegate via a helper method.
