### PR TITLE
OBPIH-7904 Unable to edit supplementary roles for users

### DIFF
--- a/grails-app/domain/org/pih/warehouse/core/Role.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Role.groovy
@@ -51,9 +51,16 @@ class Role implements Serializable, Comparable<Role> {
 
     @Override
     int compareTo(Role role) {
-        if (role) {
-            return this?.roleType?.sortOrder?.compareTo(role?.roleType?.sortOrder)
+        // Sorts a null role last i.e. this role is always greater than a null role
+        if (!role) {
+            return 1
         }
+        // Order by sortOrder, then by id as a stable tiebreaker. The id is
+        // a tiebreaker that keeps compareTo consistent with equality so that
+        // distinct roles sharing a sortOrder never compare as equal. Without
+        // this Comparable-based operations like minus, unique, TreeSet silently
+        // collapse roles with the same sortOrder. See OBPIH-7904.
+        return (this.roleType?.sortOrder ?: 0) <=> (role.roleType?.sortOrder ?: 0) ?: (this.id <=> role.id)
     }
 
 }

--- a/grails-app/services/org/pih/warehouse/core/UserService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/UserService.groovy
@@ -165,6 +165,10 @@ class UserService {
         /*
          * While it may be tempting to directly assign the roles collection,
          * it's safer, GORM/Hibernate-wise, to add/remove them one at a time.
+         *
+         * Diffing the role objects relies on Role.compareTo being consistent
+         * with equality (it breaks sortOrder ties by id); otherwise Groovy's
+         * minus would collapse same-sortOrder roles. See OBPIH-7904.
          */
         Set<Role> before = (user.roles ?: []) as Set
         Set<Role> after = requestedRoles as Set

--- a/src/main/groovy/org/pih/warehouse/core/RoleType.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/RoleType.groovy
@@ -26,7 +26,7 @@ enum RoleType {
     ROLE_PRODUCT_MANAGER('Product Manager', 100),
 
     // Notification roles for general system events
-            ROLE_ERROR_NOTIFICATION('Error Notification', 100),
+    ROLE_ERROR_NOTIFICATION('Error Notification', 100),
     ROLE_FEEDBACK_NOTIFICATION('Feedback Notifications', 100),
     ROLE_PRODUCT_NOTIFICATION('Product Notifications', 100),
     ROLE_ORDER_NOTIFICATION('Order Notifications', 100),
@@ -42,7 +42,7 @@ enum RoleType {
     ROLE_SHIPMENT_OUTBOUND_RECEIVED_NOTIFICATION('Shipment Outbound Received Notifications', 100),
 
     // Notification roles for stock alerts
-            ROLE_ITEM_ALL_NOTIFICATION('All Stock Notifications', 100),
+    ROLE_ITEM_ALL_NOTIFICATION('All Stock Notifications', 100),
     ROLE_ITEM_EXPIRY_NOTIFICATION('Expiry Notifications', 100),
     ROLE_ITEM_OVERSTOCK_NOTIFICATION('Overstock Notifications', 100),
     ROLE_ITEM_REORDER_NOTIFICATION('Reorder Notifications', 100),

--- a/src/test/groovy/org/pih/warehouse/core/RoleSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/core/RoleSpec.groovy
@@ -12,7 +12,7 @@ class RoleSpec extends Specification implements DomainUnitTest<Role> {
         mockDomain(Role)
     }
 
-    void 'admin() should return the admin role'() {
+    void 'should return the admin role'() {
         given:
         Role role = new Role(roleType: RoleType.ROLE_ADMIN).save(validate: false)
 
@@ -20,7 +20,7 @@ class RoleSpec extends Specification implements DomainUnitTest<Role> {
         assert Role.admin() == role
     }
 
-    void 'manager() should return the manager role'() {
+    void 'should return the manager role'() {
         given:
         Role role = new Role(roleType: RoleType.ROLE_MANAGER).save(validate: false)
 
@@ -28,7 +28,7 @@ class RoleSpec extends Specification implements DomainUnitTest<Role> {
         assert Role.manager() == role
     }
 
-    void 'assistant() should return the assistant role'() {
+    void 'should return the assistant role'() {
         given:
         Role role = new Role(roleType: RoleType.ROLE_ASSISTANT).save(validate: false)
 
@@ -36,11 +36,41 @@ class RoleSpec extends Specification implements DomainUnitTest<Role> {
         assert Role.assistant() == role
     }
 
-    void 'browser() should return the browser role'() {
+    void 'should return the browser role'() {
         given:
         Role role = new Role(roleType: RoleType.ROLE_BROWSER).save(validate: false)
 
         expect:
         assert Role.browser() == role
+    }
+
+    void 'should order roles by sortOrder, with the more privileged role first'() {
+        // FIXME id is not bindable via the map constructor, so it is set directly
+        given: 'an admin role and a finance role with a higher sortOrder'
+        Role admin = new Role(roleType: RoleType.ROLE_ADMIN)     // sortOrder 1
+        admin.id = 'a'
+        Role finance = new Role(roleType: RoleType.ROLE_FINANCE) // sortOrder 100
+        finance.id = 'b'
+
+        expect: 'the role with the lower sortOrder sorts first'
+        admin < finance
+        finance > admin
+    }
+
+    void 'should break sortOrder ties by id so that distinct roles are never equal'() {
+        // FIXME id is not bindable via the map constructor, so it is set directly
+        given: 'two distinct roles that share the same sortOrder'
+        Role finance = new Role(roleType: RoleType.ROLE_FINANCE) // sortOrder 100
+        finance.id = 'a'
+        Role invoice = new Role(roleType: RoleType.ROLE_INVOICE) // sortOrder 100
+        invoice.id = 'b'
+
+        expect: 'that they are not equal when compared'
+        (finance <=> invoice) != 0
+        (invoice <=> finance) != 0
+
+        and: 'they are treated as separate elements when included in a set rather than collapsed (see OBPIH-7904)'
+        (([finance, invoice] as Set) - ([finance] as Set)) == ([invoice] as Set)
+        [finance, invoice].unique().size() == 2
     }
 }

--- a/src/test/groovy/org/pih/warehouse/core/UserServiceRoleValidationSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/core/UserServiceRoleValidationSpec.groovy
@@ -17,6 +17,8 @@ class UserServiceRoleValidationSpec extends Specification implements ServiceUnit
     Role browserRole
     Role managerRole
     Role superuserRole
+    Role financeRole
+    Role invoiceRole
 
     User admin
     User manager
@@ -34,6 +36,10 @@ class UserServiceRoleValidationSpec extends Specification implements ServiceUnit
         browserRole = new Role(roleType: RoleType.ROLE_BROWSER, name: 'Browser').save(validate: false)
         managerRole = new Role(roleType: RoleType.ROLE_MANAGER, name: 'Manager').save(validate: false)
         superuserRole = new Role(roleType: RoleType.ROLE_SUPERUSER, name: 'Superuser').save(validate: false)
+        // Supplementary roles, both sortOrder 100 (see RoleType) - the collision
+        // that triggered OBPIH-7904 when diffed with Groovy's collection minus.
+        financeRole = new Role(roleType: RoleType.ROLE_FINANCE, name: 'Financial User').save(validate: false)
+        invoiceRole = new Role(roleType: RoleType.ROLE_INVOICE, name: 'Invoice user').save(validate: false)
 
         admin = new User(username: 'admin', password: 'pass', passwordConfirm: 'pass',
             firstName: 'Admin', lastName: 'User', email: 'admin@test.com')
@@ -84,28 +90,28 @@ class UserServiceRoleValidationSpec extends Specification implements ServiceUnit
         }
     }
 
-    void "canAddOrRemoveRole #allows #user to add or remove role '#role'"() {
+    void "should #allowOrForbid #user to add or remove the '#role' role"() {
         expect:
-        assert service.canAddOrRemoveRole(userByName(user), roleByName(role)) == (allows == 'allows')
+        assert service.canAddOrRemoveRole(userByName(user), roleByName(role)) == allowed
 
         where:
-        user        | role        || allows
-        'superuser' | 'Admin'     || 'allows'
-        'superuser' | 'Browser'   || 'allows'
-        'superuser' | 'Manager'   || 'allows'
-        'superuser' | 'Superuser' || 'allows'
-        'admin'     | 'Admin'     || 'allows'
-        'admin'     | 'Browser'   || 'allows'
-        'admin'     | 'Manager'   || 'allows'
-        'admin'     | 'Superuser' || 'forbids'
-        'manager'   | 'Admin'     || 'forbids'
-        'manager'   | 'Browser'   || 'allows'
-        'manager'   | 'Manager'   || 'allows'
-        'manager'   | 'Superuser' || 'forbids'
-        'null'      | 'Browser'   || 'forbids'
+        user        | role        | allowOrForbid || allowed
+        'superuser' | 'Admin'     | 'allow'       || true
+        'superuser' | 'Browser'   | 'allow'       || true
+        'superuser' | 'Manager'   | 'allow'       || true
+        'superuser' | 'Superuser' | 'allow'       || true
+        'admin'     | 'Admin'     | 'allow'       || true
+        'admin'     | 'Browser'   | 'allow'       || true
+        'admin'     | 'Manager'   | 'allow'       || true
+        'admin'     | 'Superuser' | 'forbid'      || false
+        'manager'   | 'Admin'     | 'forbid'      || false
+        'manager'   | 'Browser'   | 'allow'       || true
+        'manager'   | 'Manager'   | 'allow'       || true
+        'manager'   | 'Superuser' | 'forbid'      || false
+        'null'      | 'Browser'   | 'forbid'      || false
     }
 
-    void "checkCanAddOrRemoveRoles passes when no roles change"() {
+    void "should allow an update that leaves the roles unchanged"() {
         when:
         service.checkCanAddOrRemoveRoles(admin, manager, [adminRole, managerRole], [adminRole, managerRole])
         service.checkCanAddOrRemoveRoles(manager, admin, [adminRole, managerRole], [adminRole, managerRole])
@@ -114,7 +120,7 @@ class UserServiceRoleValidationSpec extends Specification implements ServiceUnit
         noExceptionThrown()
     }
 
-    void "checkCanAddOrRemoveRoles passes for empty before and after"() {
+    void "should allow an update for a user with no roles before or after"() {
         when:
         service.checkCanAddOrRemoveRoles(superuser, admin, [], [])
         service.checkCanAddOrRemoveRoles(manager, admin, [], [])
@@ -124,7 +130,7 @@ class UserServiceRoleValidationSpec extends Specification implements ServiceUnit
         noExceptionThrown()
     }
 
-    void "updateUser rejects params containing roles keys"() {
+    void "should reject an update whose params contain a 'roles' key"() {
         when:
         service.updateUser(admin.id, superuser.id, [], [roles: [adminRole.id]])
 
@@ -132,7 +138,7 @@ class UserServiceRoleValidationSpec extends Specification implements ServiceUnit
         thrown(ValidationException)
     }
 
-    void "updateUser rejects params containing roles[] keys"() {
+    void "should reject an update whose params contain a 'roles[].id' key"() {
         when:
         service.updateUser(admin.id, superuser.id, [], ['roles[0].id': superuserRole.id])
 
@@ -140,7 +146,7 @@ class UserServiceRoleValidationSpec extends Specification implements ServiceUnit
         thrown(ValidationException)
     }
 
-    void "updateUser rejects params containing locationRoles keys"() {
+    void "should reject an update whose params contain a 'locationRoles' key"() {
         when:
         service.updateUser(admin.id, superuser.id, [], [locationRoles: [adminRole.id]])
 
@@ -148,11 +154,41 @@ class UserServiceRoleValidationSpec extends Specification implements ServiceUnit
         thrown(ValidationException)
     }
 
-    void "updateUser rejects params containing locationRoles[] keys"() {
+    void "should reject an update whose params contain a 'locationRoles[].id' key"() {
         when:
         service.updateUser(admin.id, superuser.id, [], ['locationRoles[0].id': adminRole.id])
 
         then:
         thrown(ValidationException)
+    }
+
+    void "should remove a role while keeping another that shares its sortOrder"() {
+        given: 'a user with two supplementary roles that share a sortOrder'
+        manager.addToRoles(financeRole)
+        manager.addToRoles(invoiceRole)
+        manager.save(validate: false)
+
+        when: 'a superuser requests the same roles minus invoice'
+        service.validateAndApplyRoleChanges(superuser, manager, [managerRole.id, financeRole.id])
+
+        then: 'invoice is removed'
+        !manager.roles.contains(invoiceRole)
+
+        and: 'the manager and finance roles are kept'
+        manager.roles.contains(managerRole)
+        manager.roles.contains(financeRole)
+    }
+
+    void "should add a role that shares a sortOrder with one the user already has"() {
+        given: 'a user that already has one supplementary role'
+        manager.addToRoles(financeRole)
+        manager.save(validate: false)
+
+        when: 'a superuser requests an additional role with the same sortOrder'
+        service.validateAndApplyRoleChanges(superuser, manager, [managerRole.id, financeRole.id, invoiceRole.id])
+
+        then: 'both supplementary roles are present'
+        manager.roles.contains(financeRole)
+        manager.roles.contains(invoiceRole)
     }
 }


### PR DESCRIPTION
As a superuser (or admin), removing supplemental roles with the same sort order silently fails when another role with the same sort order remains. When adding supplemental roles to sets they are treated as equivalent due to a bug in our Role.compareTo() implementation. This PR fixes the role comparison so that roles with the same sort order are treated as different roles.

https://pihemr.atlassian.net/browse/OBPIH-7904

Side note: I also changed a few test names (to follow the should-style BDD convention) in order to demonstrate how we should be writing these going forward. Let me know if I got the intent of any of the tests wrong. 