### PR TITLE
OBLS-760 Add pick task counts per delivery type endpoint

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/api/picking/PickTaskApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/picking/PickTaskApiController.groovy
@@ -12,6 +12,7 @@ class PickTaskApiController extends RestfulController<PickTask> {
     static responseFormats = ['json']
     static allowedMethods = [
             search: 'GET',
+            counts: 'GET',
             read: 'GET',
             patch: 'PATCH',
             drop: 'PATCH',
@@ -42,6 +43,16 @@ class PickTaskApiController extends RestfulController<PickTask> {
                 max: max,
                 offset: offset
         ] as JSON)
+    }
+
+    def counts(SearchPickTaskCommand command) {
+        if (command.hasErrors()) {
+            throw new ValidationException("Validation errors", command.errors)
+        }
+
+        def data = pickTaskService.countOrdersByDeliveryType(command.facility)
+
+        render([data: data] as JSON)
     }
 
     def read(String id) {

--- a/grails-app/controllers/org/pih/warehouse/api/picking/PickUrlMappings.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/picking/PickUrlMappings.groovy
@@ -8,6 +8,11 @@ class PickUrlMappings {
             action = [GET: "search"]
         }
 
+        "/api/facilities/$facility/pick-tasks/counts" {
+            controller = "pickTaskApi"
+            action = [GET: "counts"]
+        }
+
         "/api/facilities/$facility/pick-tasks/$id" {
             controller = "pickTaskApi"
             action = [GET: "read", PATCH: "patch"]

--- a/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
+++ b/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
@@ -110,6 +110,37 @@ class PickTaskService {
     }
 
     @Transactional(readOnly = true)
+    List<Map> countOrdersByDeliveryType(Location facility) {
+        Map<DeliveryTypeCode, Integer> available = countDistinctRequisitionsByDeliveryType(
+                facility, [PickTaskStatus.PENDING, PickTaskStatus.PICKING])
+
+        Map<DeliveryTypeCode, Integer> total = countDistinctRequisitionsByDeliveryType(facility, null)
+
+        return DeliveryTypeCode.values().collect { DeliveryTypeCode code ->
+            [
+                    deliveryTypeCode: code.name(),
+                    availableCount  : available[code] ?: 0,
+                    totalCount      : total[code] ?: 0,
+            ]
+        }
+    }
+
+    private Map<DeliveryTypeCode, Integer> countDistinctRequisitionsByDeliveryType(
+            Location facility, List<PickTaskStatus> statuses) {
+        List results = PickTask.createCriteria().list {
+            projections {
+                groupProperty("deliveryTypeCode")
+                countDistinct("requisition")
+            }
+            eq("facility", facility)
+            if (statuses) {
+                'in'("status", statuses)
+            }
+        }
+        return results.collectEntries { row -> [(row[0]): (row[1] as Integer)] }
+    }
+
+    @Transactional(readOnly = true)
     PickTask get(String id) {
         if (!id) {
             return null


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket: https://openboxes.atlassian.net/browse/OBLS-760**

**Description:**
Adds `GET /api/facilities/{facilityId}/pick-tasks/counts` returning, for every delivery type code, the number of orders (distinct requisitions) that still have pickable tasks (`availableCount`: task status PENDING/PICKING) and the total number of in-progress orders of that type (`totalCount`). `totalCount` is not displayed yet. It's returned so the "5 of 10" progress display can be added frontend-only later IF NEEDED.


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
