### PR TITLE
OBLS-514 Sort NOLOC Products to Temporary Container and Assign Location

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -558,6 +558,10 @@ openboxes:
             enabled: true
             cronExpression: "0 */5 * * * ?"     # every five minutes
             delayInMilliseconds: 1000
+
+        # should only be triggered by persistence event listener
+        putawayLocationReslottingJob:
+            enabled: true
     # LDAP configuration
     ldap:
         enabled: false

--- a/grails-app/controllers/org/pih/warehouse/api/PutawayApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/PutawayApiController.groovy
@@ -151,7 +151,7 @@ class PutawayApiController {
             putaway.putawayNumber = orderIdentifierService.generate(order)
         }
 
-        putaway.putawayAssignee = currentUser
+        putaway.orderedBy = currentUser
 
         return putaway
     }

--- a/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy
@@ -21,7 +21,7 @@ import util.InventoryUtil
 class InventoryLevel implements Comparable<InventoryLevel> {
 
     def publishReslottingEvent() {
-        Holders.grailsApplication.mainContext.publishEvent(new ReslottingEvent(this.id, AuthService.currentUser))
+        Holders.grailsApplication.mainContext.publishEvent(new ReslottingEvent(this.id, AuthService.currentUser?.id))
     }
 
     def afterUpdate() {

--- a/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy
@@ -13,7 +13,6 @@ import grails.databinding.BindUsing
 import grails.util.Holders
 import org.apache.commons.lang.StringUtils
 import org.pih.warehouse.EmptyStringsToNullBinder
-import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.product.Product
 import util.InventoryUtil
@@ -21,7 +20,7 @@ import util.InventoryUtil
 class InventoryLevel implements Comparable<InventoryLevel> {
 
     def publishReslottingEvent() {
-        Holders.grailsApplication.mainContext.publishEvent(new ReslottingEvent(this.id, AuthService.currentUser))
+        Holders.grailsApplication.mainContext.publishEvent(new ReslottingEvent(this.id))
     }
 
     def afterUpdate() {

--- a/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy
@@ -21,7 +21,7 @@ import util.InventoryUtil
 class InventoryLevel implements Comparable<InventoryLevel> {
 
     def publishReslottingEvent() {
-        Holders.grailsApplication.mainContext.publishEvent(new ReslottingEvent(this.id, AuthService.currentUser?.id))
+        Holders.grailsApplication.mainContext.publishEvent(new ReslottingEvent(this.id, AuthService.currentUser))
     }
 
     def afterUpdate() {

--- a/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/InventoryLevel.groovy
@@ -10,13 +10,23 @@
 package org.pih.warehouse.inventory
 
 import grails.databinding.BindUsing
+import grails.util.Holders
 import org.apache.commons.lang.StringUtils
 import org.pih.warehouse.EmptyStringsToNullBinder
+import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.product.Product
 import util.InventoryUtil
 
 class InventoryLevel implements Comparable<InventoryLevel> {
+
+    def publishReslottingEvent() {
+        Holders.grailsApplication.mainContext.publishEvent(new ReslottingEvent(this.id, AuthService.currentUser))
+    }
+
+    def afterUpdate() {
+        publishReslottingEvent()
+    }
 
     String id
 

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -800,6 +800,7 @@ enum.ActivityCode.ALLOW_OVERPICK=Allow over-pick
 enum.ActivityCode.CYCLE_COUNT=Cycle Count
 enum.ActivityCode.INBOUND_SORTATION=Inbound sortation
 enum.ActivityCode.LOST_AND_FOUND=Lost and found
+enum.ActivityCode.UNDEFINED_LOCATION=Undefined location
 enum.ActivityCode.PUTAWAY_CART=Putaway Cart
 enum.ActivityCode.OUTBOUND_CONTAINER=Outbound Container
 enum.ActivityCode.STAGING_LOCATION=Staging Location

--- a/grails-app/jobs/org/pih/warehouse/jobs/PutawayLocationReslottingJob.groovy
+++ b/grails-app/jobs/org/pih/warehouse/jobs/PutawayLocationReslottingJob.groovy
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2012 Partners In Health.  All rights reserved.
+ * The use and distribution terms for this software are covered by the
+ * Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+ * which can be found in the file epl-v10.html at the root of this distribution.
+ * By using this software in any fashion, you are agreeing to be bound by
+ * the terms of this license.
+ * You must not remove this notice, or any other, from this software.
+ **/
+package org.pih.warehouse.jobs
+
+import org.pih.warehouse.api.Putaway
+import org.pih.warehouse.api.PutawayItem
+import org.pih.warehouse.core.ActivityCode
+import org.pih.warehouse.core.Location
+import org.pih.warehouse.core.LocationService
+import org.pih.warehouse.inventory.InventoryLevel
+import org.pih.warehouse.putaway.PutawayService
+import org.quartz.JobExecutionContext
+
+class PutawayLocationReslottingJob {
+
+    PutawayService putawayService
+    LocationService locationService
+
+    static concurrent = true
+
+    def sessionRequired = false
+
+    // Should never be triggered on a schedule - should only be triggered by persistence event listener
+    static triggers = {}
+
+    void execute(JobExecutionContext context) {
+        if (!JobUtils.shouldExecute(PutawayLocationReslottingJob)) {
+            log.info("Reslotting Putaway location job is disabled")
+            return
+        }
+
+        String inventoryLevelId = context.mergedJobDataMap.get('inventoryLevelId')
+        InventoryLevel inventoryLevel = InventoryLevel.read(inventoryLevelId)
+        if (!inventoryLevel) {
+            log.warn "InventoryLevel with id ${inventoryLevelId} not found, cannot trigger reslotting"
+            return
+        }
+        if (inventoryLevel.preferredBinLocation?.supports(ActivityCode.UNDEFINED_LOCATION)) {
+            // the update hasn't changed preferredBinLocation type from UNDEFINED; no reslotting
+            return
+        }
+        if (inventoryLevel.internalLocation?.supports(ActivityCode.UNDEFINED_LOCATION)) {
+            // the update hasn't changed internalLocation type from UNDEFINED; no reslotting
+            return
+        }
+
+        log.info("Reslotting Putaway location for " + inventoryLevel.product)
+        List<Location> binLocations = locationService.getLocationsSupportingActivity(ActivityCode.UNDEFINED_LOCATION)
+        List<Putaway> putaways = putawayService.getPutawayOrders(inventoryLevel.product, binLocations, inventoryLevel.inventory.warehouse)
+        putaways?.each { Putaway putaway ->
+            List<PutawayItem> putawayItems = putaway.putawayItems.findAll { it.putawayLocation?.supports(ActivityCode.UNDEFINED_LOCATION) }
+            putawayItems?.each { it.putawayLocation = inventoryLevel.preferredBinLocation ?: inventoryLevel.internalLocation }
+            putawayService.savePutaway(putaway)
+        }
+    }
+}

--- a/grails-app/jobs/org/pih/warehouse/jobs/PutawayLocationReslottingJob.groovy
+++ b/grails-app/jobs/org/pih/warehouse/jobs/PutawayLocationReslottingJob.groovy
@@ -23,18 +23,14 @@ class PutawayLocationReslottingJob {
     PutawayService putawayService
     LocationService locationService
 
-    static concurrent = true
-
     def sessionRequired = false
-
-    // Should never be triggered on a schedule - should only be triggered by persistence event listener
-    static triggers = {}
 
     void execute(JobExecutionContext context) {
         if (!JobUtils.shouldExecute(PutawayLocationReslottingJob)) {
             log.info("Reslotting Putaway location job is disabled")
             return
         }
+        log.info "Executing PutawayLocationReslotting job"
 
         String inventoryLevelId = context.mergedJobDataMap.get('inventoryLevelId')
         InventoryLevel inventoryLevel = InventoryLevel.read(inventoryLevelId)
@@ -53,10 +49,14 @@ class PutawayLocationReslottingJob {
 
         log.info("Reslotting Putaway location for " + inventoryLevel.product)
         List<Location> binLocations = locationService.getLocationsSupportingActivity(ActivityCode.UNDEFINED_LOCATION)
-        List<Putaway> putaways = putawayService.getPutawayOrders(inventoryLevel.product, binLocations, inventoryLevel.inventory.warehouse)
-        putaways?.each { Putaway putaway ->
-            List<PutawayItem> putawayItems = putaway.putawayItems.findAll { it.putawayLocation?.supports(ActivityCode.UNDEFINED_LOCATION) }
-            putawayItems?.each { it.putawayLocation = inventoryLevel.preferredBinLocation ?: inventoryLevel.internalLocation }
+        List<Putaway> pendingPutaways = putawayService.getPendingPutawayOrders(inventoryLevel.product, binLocations, inventoryLevel.inventory.warehouse)
+        pendingPutaways?.each { Putaway putaway ->
+            List<PutawayItem> putawayItems = putaway.putawayItems.findAll {
+                it.putawayLocation?.supports(ActivityCode.UNDEFINED_LOCATION)
+            }
+            putawayItems?.each {
+                it.putawayLocation = inventoryLevel.preferredBinLocation ?: inventoryLevel.internalLocation
+            }
             putawayService.savePutaway(putaway)
         }
     }

--- a/grails-app/services/org/pih/warehouse/inboundSortation/InboundSortationService.groovy
+++ b/grails-app/services/org/pih/warehouse/inboundSortation/InboundSortationService.groovy
@@ -83,6 +83,7 @@ class InboundSortationService {
                 expirationDate: receiptItem.inventoryItem.expirationDate,
                 currentBinLocation: receiptItem.binLocation,
                 preferredBin: receiptItem.product.getInventoryLevel(shipment.destination.id)?.preferredBinLocation,
+                internalLocation: receiptItem.product.getInventoryLevel(shipment.destination.id)?.internalLocation,
                 quantity: receiptItem.quantityReceived,
                 backorderReference: receiptItem.shipmentItem.backorderReference,
                 backorderItem: receiptItem.shipmentItem.backorderItem,

--- a/grails-app/services/org/pih/warehouse/inboundSortation/InboundSortationService.groovy
+++ b/grails-app/services/org/pih/warehouse/inboundSortation/InboundSortationService.groovy
@@ -95,7 +95,7 @@ class InboundSortationService {
                 origin: putawayContext.facility,
                 destination: putawayContext.facility,
                 putawayNumber: orderIdentifierService.generate(new Order()),
-                putawayAssignee: createdBy,
+                orderedBy: createdBy,
                 putawayStatus: PutawayStatus.PENDING
         )
     }

--- a/grails-app/services/org/pih/warehouse/inventory/ReslottingEventService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ReslottingEventService.groovy
@@ -4,7 +4,6 @@ import org.pih.warehouse.api.AvailableItem
 import org.pih.warehouse.api.Putaway
 import org.pih.warehouse.api.PutawayItem
 import org.pih.warehouse.api.PutawayStatus
-import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.LocationService
@@ -14,16 +13,13 @@ import org.pih.warehouse.inboundSortation.PutawayResult
 import org.pih.warehouse.inboundSortation.SlottingService
 import org.pih.warehouse.order.Order
 import org.pih.warehouse.order.OrderIdentifierService
-import org.pih.warehouse.product.Product
 import org.pih.warehouse.putaway.PutawayService
-import org.springframework.transaction.annotation.Propagation
-import org.springframework.transaction.event.TransactionPhase
-import org.springframework.transaction.event.TransactionalEventListener
+import org.springframework.context.ApplicationListener
 
 import javax.transaction.Transactional
 
 @Transactional
-class ReslottingEventService {
+class ReslottingEventService implements ApplicationListener<ReslottingEvent> {
 
     SlottingService slottingService
     PutawayService putawayService
@@ -31,8 +27,8 @@ class ReslottingEventService {
     ProductAvailabilityService productAvailabilityService
     LocationService locationService
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    void onReslottingEvent(ReslottingEvent event) {
+    @Override
+    void onApplicationEvent(ReslottingEvent event) {
         log.info "Application event $event has been published! " + event.properties
 
         InventoryLevel inventoryLevel = InventoryLevel.get(event.source)
@@ -41,7 +37,7 @@ class ReslottingEventService {
             return
         }
 
-        if (inventoryLevel.internalLocation?.supports(ActivityCode.UNDEFINED_LOCATION)) {
+        if (inventoryLevel.internalLocation.supports(ActivityCode.UNDEFINED_LOCATION)) {
             // the update hasn't changed internalLocation to anything specific; no reslotting
             return
         }
@@ -51,18 +47,13 @@ class ReslottingEventService {
             List<AvailableItem> availableItems = productAvailabilityService.getAvailableItems(bin).findAll {
                 it?.inventoryItem?.product == inventoryLevel.product
             }
-            availableItems.each { AvailableItem availableItem ->
-                ValuesPutawayContext valuesPutawayContext = createValuesPutawayContext(inventoryLevel, availableItem)
-                executeSlotting(valuesPutawayContext, event.updatedByUserId)
-            }
+            availableItems.each { AvailableItem availableItem -> executeSlotting(inventoryLevel, availableItem, event.updatedBy) }
         }
     }
 
-    @grails.gorm.transactions.Transactional(propagation = Propagation.REQUIRES_NEW)
-    private void executeSlotting(ValuesPutawayContext valuesPutawayContext, String updatedByUserId) {
-        PutawayContext putawayContext = createPutawayContext(valuesPutawayContext)
+    private void executeSlotting(InventoryLevel inventoryLevel, AvailableItem availableItem, User user) {
+        PutawayContext putawayContext = createPutawayContext(inventoryLevel, availableItem)
         List<PutawayResult> results = slottingService.execute(putawayContext)
-        User user = User.load(updatedByUserId)
         results.each { PutawayResult result ->
             if (result.quantity > 0) {
                 Putaway putaway = createPutaway(putawayContext, user)
@@ -73,30 +64,16 @@ class ReslottingEventService {
         }
     }
 
-    private PutawayContext createPutawayContext(ValuesPutawayContext valuesPutawayContext) {
+    private PutawayContext createPutawayContext(InventoryLevel inventoryLevel, AvailableItem availableItem) {
         new PutawayContext(
-                facility: Location.get(valuesPutawayContext.facilityId),
-                product: Product.get(valuesPutawayContext.productId),
-                inventoryItem: InventoryItem.get(valuesPutawayContext.inventoryItemId),
-                lotNumber: valuesPutawayContext.lotNumber,
-                expirationDate: valuesPutawayContext.expirationDate,
-                currentBinLocation: Location.get(valuesPutawayContext.currentBinLocationId),
-                preferredBin: Location.get(valuesPutawayContext.preferredBinId),
-                internalLocation: Location.get(valuesPutawayContext.internalLocationId),
-                quantity: valuesPutawayContext.quantity,
-        )
-    }
-
-    private ValuesPutawayContext createValuesPutawayContext(InventoryLevel inventoryLevel, AvailableItem availableItem) {
-        new ValuesPutawayContext(
-                facilityId: availableItem.binLocation?.parentLocation?.id,
-                productId: inventoryLevel.product?.id,
-                inventoryItemId: availableItem.inventoryItem?.id,
+                facility: availableItem.binLocation?.parentLocation,
+                product: inventoryLevel.product,
+                inventoryItem: availableItem.inventoryItem,
                 lotNumber: availableItem.inventoryItem.lotNumber,
                 expirationDate: availableItem.inventoryItem.expirationDate,
-                currentBinLocationId: availableItem.binLocation?.id,
-                preferredBinId: inventoryLevel.preferredBinLocation?.id,
-                internalLocationId: inventoryLevel.internalLocation?.id,
+                currentBinLocation: availableItem.binLocation,
+                preferredBin: inventoryLevel.preferredBinLocation,
+                internalLocation: inventoryLevel.internalLocation,
                 quantity: availableItem.quantityOnHand,
         )
     }
@@ -123,17 +100,5 @@ class ReslottingEventService {
                 putawayStatus: PutawayStatus.PENDING,
                 comment: task.comment
         )
-    }
-
-    private class ValuesPutawayContext {
-        String facilityId
-        String productId
-        String inventoryItemId
-        String lotNumber
-        Date expirationDate
-        String currentBinLocationId
-        String preferredBinId
-        String internalLocationId
-        Integer quantity
     }
 }

--- a/grails-app/services/org/pih/warehouse/inventory/ReslottingEventService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ReslottingEventService.groovy
@@ -1,0 +1,104 @@
+package org.pih.warehouse.inventory
+
+import org.pih.warehouse.api.AvailableItem
+import org.pih.warehouse.api.Putaway
+import org.pih.warehouse.api.PutawayItem
+import org.pih.warehouse.api.PutawayStatus
+import org.pih.warehouse.core.ActivityCode
+import org.pih.warehouse.core.Location
+import org.pih.warehouse.core.LocationService
+import org.pih.warehouse.core.User
+import org.pih.warehouse.inboundSortation.PutawayContext
+import org.pih.warehouse.inboundSortation.PutawayResult
+import org.pih.warehouse.inboundSortation.SlottingService
+import org.pih.warehouse.order.Order
+import org.pih.warehouse.order.OrderIdentifierService
+import org.pih.warehouse.putaway.PutawayService
+import org.springframework.context.ApplicationListener
+
+import javax.transaction.Transactional
+
+@Transactional
+class ReslottingEventService implements ApplicationListener<ReslottingEvent> {
+
+    SlottingService slottingService
+    PutawayService putawayService
+    OrderIdentifierService orderIdentifierService
+    ProductAvailabilityService productAvailabilityService
+    LocationService locationService
+
+    @Override
+    void onApplicationEvent(ReslottingEvent event) {
+        log.info "Application event $event has been published! " + event.properties
+
+        InventoryLevel inventoryLevel = InventoryLevel.get(event.source)
+        if (!inventoryLevel) {
+            log.warn "InventoryLevel with id ${event.source} not found, cannot trigger reslotting"
+            return
+        }
+
+        if (inventoryLevel.internalLocation.supports(ActivityCode.UNDEFINED_LOCATION)) {
+            // the update hasn't changed internalLocation to anything specific; no reslotting
+            return
+        }
+
+        List<Location> binLocations = locationService.getLocationsSupportingActivity(ActivityCode.UNDEFINED_LOCATION)
+        binLocations.each { Location bin ->
+            List<AvailableItem> availableItems = productAvailabilityService.getAvailableItems(bin).findAll {
+                it?.inventoryItem?.product == inventoryLevel.product
+            }
+            availableItems.each { AvailableItem availableItem -> executeSlotting(inventoryLevel, availableItem, event.updatedBy) }
+        }
+    }
+
+    private void executeSlotting(InventoryLevel inventoryLevel, AvailableItem availableItem, User user) {
+        PutawayContext putawayContext = createPutawayContext(inventoryLevel, availableItem)
+        List<PutawayResult> results = slottingService.execute(putawayContext)
+        results.each { PutawayResult result ->
+            if (result.quantity > 0) {
+                Putaway putaway = createPutaway(putawayContext, user)
+                PutawayItem putawayItem = createPutawayItem(result)
+                putaway.putawayItems.add(putawayItem)
+                putawayService.savePutaway(putaway)
+            }
+        }
+    }
+
+    private PutawayContext createPutawayContext(InventoryLevel inventoryLevel, AvailableItem availableItem) {
+        new PutawayContext(
+                facility: availableItem.binLocation?.parentLocation,
+                product: inventoryLevel.product,
+                inventoryItem: availableItem.inventoryItem,
+                lotNumber: availableItem.inventoryItem.lotNumber,
+                expirationDate: availableItem.inventoryItem.expirationDate,
+                currentBinLocation: availableItem.binLocation,
+                preferredBin: inventoryLevel.preferredBinLocation,
+                internalLocation: inventoryLevel.internalLocation,
+                quantity: availableItem.quantityOnHand,
+        )
+    }
+
+    private Putaway createPutaway(PutawayContext putawayContext, User createdBy) {
+        new Putaway(
+                origin: putawayContext.facility,
+                destination: putawayContext.facility,
+                putawayNumber: orderIdentifierService.generate(new Order()),
+                putawayAssignee: createdBy,
+                putawayStatus: PutawayStatus.PENDING
+        )
+    }
+
+    private PutawayItem createPutawayItem(PutawayResult task) {
+        new PutawayItem(
+                product: task.product,
+                inventoryItem: task.inventoryItem,
+                quantity: task.quantity,
+                currentFacility: task.facility,
+                currentLocation: task.location,
+                putawayLocation: task.destination,
+                containerLocation: task.container,
+                putawayStatus: PutawayStatus.PENDING,
+                comment: task.comment
+        )
+    }
+}

--- a/grails-app/services/org/pih/warehouse/inventory/ReslottingEventService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ReslottingEventService.groovy
@@ -1,104 +1,17 @@
 package org.pih.warehouse.inventory
 
-import org.pih.warehouse.api.AvailableItem
-import org.pih.warehouse.api.Putaway
-import org.pih.warehouse.api.PutawayItem
-import org.pih.warehouse.api.PutawayStatus
-import org.pih.warehouse.core.ActivityCode
-import org.pih.warehouse.core.Location
-import org.pih.warehouse.core.LocationService
-import org.pih.warehouse.core.User
-import org.pih.warehouse.inboundSortation.PutawayContext
-import org.pih.warehouse.inboundSortation.PutawayResult
-import org.pih.warehouse.inboundSortation.SlottingService
-import org.pih.warehouse.order.Order
-import org.pih.warehouse.order.OrderIdentifierService
-import org.pih.warehouse.putaway.PutawayService
-import org.springframework.context.ApplicationListener
+import org.pih.warehouse.jobs.PutawayLocationReslottingJob
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
 
-import javax.transaction.Transactional
+class ReslottingEventService{
 
-@Transactional
-class ReslottingEventService implements ApplicationListener<ReslottingEvent> {
-
-    SlottingService slottingService
-    PutawayService putawayService
-    OrderIdentifierService orderIdentifierService
-    ProductAvailabilityService productAvailabilityService
-    LocationService locationService
-
-    @Override
-    void onApplicationEvent(ReslottingEvent event) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    void onReslottingEvent(ReslottingEvent event) {
         log.info "Application event $event has been published! " + event.properties
 
-        InventoryLevel inventoryLevel = InventoryLevel.get(event.source)
-        if (!inventoryLevel) {
-            log.warn "InventoryLevel with id ${event.source} not found, cannot trigger reslotting"
-            return
-        }
-
-        if (inventoryLevel.internalLocation.supports(ActivityCode.UNDEFINED_LOCATION)) {
-            // the update hasn't changed internalLocation to anything specific; no reslotting
-            return
-        }
-
-        List<Location> binLocations = locationService.getLocationsSupportingActivity(ActivityCode.UNDEFINED_LOCATION)
-        binLocations.each { Location bin ->
-            List<AvailableItem> availableItems = productAvailabilityService.getAvailableItems(bin).findAll {
-                it?.inventoryItem?.product == inventoryLevel.product
-            }
-            availableItems.each { AvailableItem availableItem -> executeSlotting(inventoryLevel, availableItem, event.updatedBy) }
-        }
-    }
-
-    private void executeSlotting(InventoryLevel inventoryLevel, AvailableItem availableItem, User user) {
-        PutawayContext putawayContext = createPutawayContext(inventoryLevel, availableItem)
-        List<PutawayResult> results = slottingService.execute(putawayContext)
-        results.each { PutawayResult result ->
-            if (result.quantity > 0) {
-                Putaway putaway = createPutaway(putawayContext, user)
-                PutawayItem putawayItem = createPutawayItem(result)
-                putaway.putawayItems.add(putawayItem)
-                putawayService.savePutaway(putaway)
-            }
-        }
-    }
-
-    private PutawayContext createPutawayContext(InventoryLevel inventoryLevel, AvailableItem availableItem) {
-        new PutawayContext(
-                facility: availableItem.binLocation?.parentLocation,
-                product: inventoryLevel.product,
-                inventoryItem: availableItem.inventoryItem,
-                lotNumber: availableItem.inventoryItem.lotNumber,
-                expirationDate: availableItem.inventoryItem.expirationDate,
-                currentBinLocation: availableItem.binLocation,
-                preferredBin: inventoryLevel.preferredBinLocation,
-                internalLocation: inventoryLevel.internalLocation,
-                quantity: availableItem.quantityOnHand,
-        )
-    }
-
-    private Putaway createPutaway(PutawayContext putawayContext, User createdBy) {
-        new Putaway(
-                origin: putawayContext.facility,
-                destination: putawayContext.facility,
-                putawayNumber: orderIdentifierService.generate(new Order()),
-                putawayAssignee: createdBy,
-                putawayStatus: PutawayStatus.PENDING
-        )
-    }
-
-    private PutawayItem createPutawayItem(PutawayResult task) {
-        new PutawayItem(
-                product: task.product,
-                inventoryItem: task.inventoryItem,
-                quantity: task.quantity,
-                currentFacility: task.facility,
-                currentLocation: task.location,
-                putawayLocation: task.destination,
-                containerLocation: task.container,
-                putawayStatus: PutawayStatus.PENDING,
-                comment: task.comment
-        )
+        Date runAt = new Date(System.currentTimeMillis())
+        log.info "Triggering Putaway location reslotting job"
+        PutawayLocationReslottingJob.schedule(runAt, [inventoryLevelId: event.source])
     }
 }

--- a/grails-app/services/org/pih/warehouse/inventory/ReslottingEventService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ReslottingEventService.groovy
@@ -4,6 +4,7 @@ import org.pih.warehouse.api.AvailableItem
 import org.pih.warehouse.api.Putaway
 import org.pih.warehouse.api.PutawayItem
 import org.pih.warehouse.api.PutawayStatus
+import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.LocationService
@@ -13,13 +14,16 @@ import org.pih.warehouse.inboundSortation.PutawayResult
 import org.pih.warehouse.inboundSortation.SlottingService
 import org.pih.warehouse.order.Order
 import org.pih.warehouse.order.OrderIdentifierService
+import org.pih.warehouse.product.Product
 import org.pih.warehouse.putaway.PutawayService
-import org.springframework.context.ApplicationListener
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
 
 import javax.transaction.Transactional
 
 @Transactional
-class ReslottingEventService implements ApplicationListener<ReslottingEvent> {
+class ReslottingEventService {
 
     SlottingService slottingService
     PutawayService putawayService
@@ -27,8 +31,8 @@ class ReslottingEventService implements ApplicationListener<ReslottingEvent> {
     ProductAvailabilityService productAvailabilityService
     LocationService locationService
 
-    @Override
-    void onApplicationEvent(ReslottingEvent event) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    void onReslottingEvent(ReslottingEvent event) {
         log.info "Application event $event has been published! " + event.properties
 
         InventoryLevel inventoryLevel = InventoryLevel.get(event.source)
@@ -37,7 +41,7 @@ class ReslottingEventService implements ApplicationListener<ReslottingEvent> {
             return
         }
 
-        if (inventoryLevel.internalLocation.supports(ActivityCode.UNDEFINED_LOCATION)) {
+        if (inventoryLevel.internalLocation?.supports(ActivityCode.UNDEFINED_LOCATION)) {
             // the update hasn't changed internalLocation to anything specific; no reslotting
             return
         }
@@ -47,13 +51,18 @@ class ReslottingEventService implements ApplicationListener<ReslottingEvent> {
             List<AvailableItem> availableItems = productAvailabilityService.getAvailableItems(bin).findAll {
                 it?.inventoryItem?.product == inventoryLevel.product
             }
-            availableItems.each { AvailableItem availableItem -> executeSlotting(inventoryLevel, availableItem, event.updatedBy) }
+            availableItems.each { AvailableItem availableItem ->
+                ValuesPutawayContext valuesPutawayContext = createValuesPutawayContext(inventoryLevel, availableItem)
+                executeSlotting(valuesPutawayContext, event.updatedByUserId)
+            }
         }
     }
 
-    private void executeSlotting(InventoryLevel inventoryLevel, AvailableItem availableItem, User user) {
-        PutawayContext putawayContext = createPutawayContext(inventoryLevel, availableItem)
+    @grails.gorm.transactions.Transactional(propagation = Propagation.REQUIRES_NEW)
+    private void executeSlotting(ValuesPutawayContext valuesPutawayContext, String updatedByUserId) {
+        PutawayContext putawayContext = createPutawayContext(valuesPutawayContext)
         List<PutawayResult> results = slottingService.execute(putawayContext)
+        User user = User.load(updatedByUserId)
         results.each { PutawayResult result ->
             if (result.quantity > 0) {
                 Putaway putaway = createPutaway(putawayContext, user)
@@ -64,16 +73,30 @@ class ReslottingEventService implements ApplicationListener<ReslottingEvent> {
         }
     }
 
-    private PutawayContext createPutawayContext(InventoryLevel inventoryLevel, AvailableItem availableItem) {
+    private PutawayContext createPutawayContext(ValuesPutawayContext valuesPutawayContext) {
         new PutawayContext(
-                facility: availableItem.binLocation?.parentLocation,
-                product: inventoryLevel.product,
-                inventoryItem: availableItem.inventoryItem,
+                facility: Location.get(valuesPutawayContext.facilityId),
+                product: Product.get(valuesPutawayContext.productId),
+                inventoryItem: InventoryItem.get(valuesPutawayContext.inventoryItemId),
+                lotNumber: valuesPutawayContext.lotNumber,
+                expirationDate: valuesPutawayContext.expirationDate,
+                currentBinLocation: Location.get(valuesPutawayContext.currentBinLocationId),
+                preferredBin: Location.get(valuesPutawayContext.preferredBinId),
+                internalLocation: Location.get(valuesPutawayContext.internalLocationId),
+                quantity: valuesPutawayContext.quantity,
+        )
+    }
+
+    private ValuesPutawayContext createValuesPutawayContext(InventoryLevel inventoryLevel, AvailableItem availableItem) {
+        new ValuesPutawayContext(
+                facilityId: availableItem.binLocation?.parentLocation?.id,
+                productId: inventoryLevel.product?.id,
+                inventoryItemId: availableItem.inventoryItem?.id,
                 lotNumber: availableItem.inventoryItem.lotNumber,
                 expirationDate: availableItem.inventoryItem.expirationDate,
-                currentBinLocation: availableItem.binLocation,
-                preferredBin: inventoryLevel.preferredBinLocation,
-                internalLocation: inventoryLevel.internalLocation,
+                currentBinLocationId: availableItem.binLocation?.id,
+                preferredBinId: inventoryLevel.preferredBinLocation?.id,
+                internalLocationId: inventoryLevel.internalLocation?.id,
                 quantity: availableItem.quantityOnHand,
         )
     }
@@ -100,5 +123,17 @@ class ReslottingEventService implements ApplicationListener<ReslottingEvent> {
                 putawayStatus: PutawayStatus.PENDING,
                 comment: task.comment
         )
+    }
+
+    private class ValuesPutawayContext {
+        String facilityId
+        String productId
+        String inventoryItemId
+        String lotNumber
+        Date expirationDate
+        String currentBinLocationId
+        String preferredBinId
+        String internalLocationId
+        Integer quantity
     }
 }

--- a/grails-app/services/org/pih/warehouse/inventory/ReslottingEventService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ReslottingEventService.groovy
@@ -1,17 +1,14 @@
 package org.pih.warehouse.inventory
 
 import org.pih.warehouse.jobs.PutawayLocationReslottingJob
-import org.springframework.transaction.event.TransactionPhase
-import org.springframework.transaction.event.TransactionalEventListener
+import org.springframework.context.ApplicationListener
 
-class ReslottingEventService{
+class ReslottingEventService implements ApplicationListener<ReslottingEvent> {
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
-    void onReslottingEvent(ReslottingEvent event) {
+    @Override
+    void onApplicationEvent(ReslottingEvent event) {
         log.info "Application event $event has been published! " + event.properties
 
-        Date runAt = new Date(System.currentTimeMillis())
-        log.info "Triggering Putaway location reslotting job"
-        PutawayLocationReslottingJob.schedule(runAt, [inventoryLevelId: event.source])
+        PutawayLocationReslottingJob.triggerNow([inventoryLevelId: event.source])
     }
 }

--- a/grails-app/services/org/pih/warehouse/putaway/PutawayService.groovy
+++ b/grails-app/services/org/pih/warehouse/putaway/PutawayService.groovy
@@ -329,6 +329,32 @@ class PutawayService implements EventPublisher  {
         return putawayOrders
     }
 
+    List<Putaway> getPutawayOrders(Product product, List<Location> destinationBinLocations, Location origin) {
+        OrderType putawayOrderType = OrderType.findByCode(Constants.PUTAWAY_ORDER)
+
+        List<OrderStatus> statusesBelowCompleted = OrderStatus.values().findAll {
+            it.sortOrder < OrderStatus.COMPLETED.sortOrder
+        }
+        List<OrderItemStatusCode> orderItemStatusCodes = OrderItemStatusCode.values().findAll {
+            it.sortOrder < OrderItemStatusCode.COMPLETED.sortOrder
+        }
+
+        List<Order> orders = OrderItem.createCriteria().list {
+            projections {
+                distinct "order"
+            }
+            eq("product", product)
+            'in'("destinationBinLocation", destinationBinLocations)
+            'in'("orderItemStatusCode", orderItemStatusCodes)
+            order {
+                eq("origin", origin)
+                eq("orderType", putawayOrderType)
+                'in'("status", statusesBelowCompleted)
+            }
+        } as List<OrderItem>
+        return orders?.collect { Putaway.createFromOrder(it)} ?: []
+    }
+
     void processSplitItems(Putaway putaway) {
 
         putaway.putawayItems.toArray().each { PutawayItem oldPutawayItem ->

--- a/grails-app/services/org/pih/warehouse/putaway/PutawayService.groovy
+++ b/grails-app/services/org/pih/warehouse/putaway/PutawayService.groovy
@@ -10,10 +10,8 @@
 package org.pih.warehouse.putaway
 
 import grails.core.GrailsApplication
-import grails.events.Event
 import grails.events.EventPublisher
 import grails.events.annotation.Publisher
-import grails.events.annotation.Subscriber
 import grails.gorm.transactions.Transactional
 import org.apache.commons.beanutils.BeanUtils
 import org.grails.web.json.JSONObject
@@ -26,7 +24,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.pih.warehouse.api.Putaway
 import org.pih.warehouse.api.PutawayItem
 import org.pih.warehouse.api.PutawayStatus
-import org.pih.warehouse.api.PutawayTaskStatus
 import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.EventCode
@@ -53,7 +50,6 @@ import org.pih.warehouse.product.ProductAvailability
 import org.pih.warehouse.receiving.Receipt
 import org.pih.warehouse.receiving.ReceiptItem
 import org.pih.warehouse.shipping.Shipment
-import org.springframework.context.event.EventListener
 
 @Transactional
 class PutawayService implements EventPublisher  {
@@ -329,15 +325,11 @@ class PutawayService implements EventPublisher  {
         return putawayOrders
     }
 
-    List<Putaway> getPutawayOrders(Product product, List<Location> destinationBinLocations, Location origin) {
+    List<Putaway> getPendingPutawayOrders(Product product, List<Location> destinationBinLocations, Location origin) {
         OrderType putawayOrderType = OrderType.findByCode(Constants.PUTAWAY_ORDER)
 
-        List<OrderStatus> statusesBelowCompleted = OrderStatus.values().findAll {
-            it.sortOrder < OrderStatus.COMPLETED.sortOrder
-        }
-        List<OrderItemStatusCode> orderItemStatusCodes = OrderItemStatusCode.values().findAll {
-            it.sortOrder < OrderItemStatusCode.COMPLETED.sortOrder
-        }
+        List<OrderStatus> statusesBelowCompleted = OrderStatus.listPending()
+        List<OrderItemStatusCode> orderItemStatusCodes = OrderItemStatusCode.listPending()
 
         List<Order> orders = OrderItem.createCriteria().list {
             projections {

--- a/grails-app/services/org/pih/warehouse/putaway/PutawayService.groovy
+++ b/grails-app/services/org/pih/warehouse/putaway/PutawayService.groovy
@@ -94,7 +94,7 @@ class PutawayService implements EventPublisher  {
                 putaway.destination = location
                 putaway.putawayDate = new Date()
                 putaway.putawayStatus = PutawayStatus.PENDING
-                putaway.putawayAssignee = putawayAssignee
+                putaway.orderedBy = putawayAssignee
                 putawayCandidate.putawayLocation = putawayLocation
                 putaway.putawayItems.add(putawayCandidate)
                 savePutaway(putaway)
@@ -448,7 +448,7 @@ class PutawayService implements EventPublisher  {
         if (!order.orderNumber) {
             order.orderNumber = "P-${putaway.putawayNumber ?: orderIdentifierService.generate(order)}"
         }
-        order.orderedBy = putaway.putawayAssignee
+        order.orderedBy = putaway.orderedBy
         order.dateOrdered = new Date()
         order.origin = putaway.origin
         order.destination = putaway.destination

--- a/grails-app/services/org/pih/warehouse/putaway/PutawayTaskService.groovy
+++ b/grails-app/services/org/pih/warehouse/putaway/PutawayTaskService.groovy
@@ -420,8 +420,8 @@ class PutawayTaskService {
         Order order = currentItem.order
 
         Putaway putaway = Putaway.createFromOrder(order)
-        if (!putaway.putawayAssignee) {
-            putaway.putawayAssignee = AuthService.currentUser
+        if (!putaway.orderedBy) {
+            putaway.orderedBy = AuthService.currentUser
         }
         PutawayItem itemToSplit = putaway.putawayItems.find { it.id == currentItem.id }
 

--- a/src/main/groovy/org/pih/warehouse/core/ActivityCode.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/ActivityCode.groovy
@@ -138,6 +138,9 @@ enum ActivityCode {
     // Putaway container codes
     PUTAWAY_CART('PUTAWAY_CART'),
 
+    // Putaway no specific location
+    UNDEFINED_LOCATION('UNDEFINED_LOCATION'),
+
     // Outbound container codes
     OUTBOUND_CONTAINER('OUTBOUND_CONTAINER'),
 
@@ -223,6 +226,7 @@ enum ActivityCode {
                 INBOUND_SORTATION,
                 LOST_AND_FOUND,
                 PUTAWAY_CART,
+                UNDEFINED_LOCATION,
 
                 // Internal locations used for picking
                 OUTBOUND_CONTAINER,

--- a/src/main/groovy/org/pih/warehouse/inboundSortation/PutawayContext.groovy
+++ b/src/main/groovy/org/pih/warehouse/inboundSortation/PutawayContext.groovy
@@ -13,6 +13,7 @@ class PutawayContext {
     Date expirationDate
     Location currentBinLocation
     Location preferredBin
+    Location internalLocation
     Integer quantity
     String backorderReference
     RequisitionItem backorderItem

--- a/src/main/groovy/org/pih/warehouse/inboundSortation/strategy/DefaultSlottingStrategy.groovy
+++ b/src/main/groovy/org/pih/warehouse/inboundSortation/strategy/DefaultSlottingStrategy.groovy
@@ -1,5 +1,6 @@
 package org.pih.warehouse.inboundSortation.strategy
 
+import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.inboundSortation.PutawayContext
 import org.pih.warehouse.inboundSortation.PutawayResult
@@ -18,6 +19,16 @@ class DefaultSlottingStrategy implements PutawayStrategy {
                     destination: context.preferredBin,
                     quantity: quantityRemaining,
                     comment: "Default Location",
+            )
+        } else if (context.internalLocation && context.internalLocation.supports(ActivityCode.UNDEFINED_LOCATION)) {
+            putawayTasks << new PutawayResult(
+                    facility: context.facility,
+                    product: context.product,
+                    inventoryItem: context.inventoryItem,
+                    location: context.currentBinLocation,
+                    destination: context.internalLocation,
+                    quantity: quantityRemaining,
+                    comment: "Default Internal Location",
             )
         }
 

--- a/src/main/groovy/org/pih/warehouse/inventory/ReslottingEvent.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/ReslottingEvent.groovy
@@ -9,14 +9,11 @@
  **/
 package org.pih.warehouse.inventory
 
-import org.pih.warehouse.core.User
 import org.springframework.context.ApplicationEvent
 
 class ReslottingEvent extends ApplicationEvent {
-    User updatedBy
 
-    ReslottingEvent(String inventoryLevelId, User updatedBy) {
+    ReslottingEvent(String inventoryLevelId) {
         super(inventoryLevelId)
-        this.updatedBy = updatedBy
     }
 }

--- a/src/main/groovy/org/pih/warehouse/inventory/ReslottingEvent.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/ReslottingEvent.groovy
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2012 Partners In Health.  All rights reserved.
+ * The use and distribution terms for this software are covered by the
+ * Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+ * which can be found in the file epl-v10.html at the root of this distribution.
+ * By using this software in any fashion, you are agreeing to be bound by
+ * the terms of this license.
+ * You must not remove this notice, or any other, from this software.
+ **/
+package org.pih.warehouse.inventory
+
+import org.pih.warehouse.core.User
+import org.springframework.context.ApplicationEvent
+
+class ReslottingEvent extends ApplicationEvent {
+    User updatedBy
+
+    ReslottingEvent(String inventoryLevelId, User updatedBy) {
+        super(inventoryLevelId)
+        this.updatedBy = updatedBy
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/inventory/ReslottingEvent.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/ReslottingEvent.groovy
@@ -9,13 +9,14 @@
  **/
 package org.pih.warehouse.inventory
 
+import org.pih.warehouse.core.User
 import org.springframework.context.ApplicationEvent
 
 class ReslottingEvent extends ApplicationEvent {
-    String updatedByUserId
+    User updatedBy
 
-    ReslottingEvent(String inventoryLevelId, String updatedByUserId) {
+    ReslottingEvent(String inventoryLevelId, User updatedBy) {
         super(inventoryLevelId)
-        this.updatedByUserId = updatedByUserId
+        this.updatedBy = updatedBy
     }
 }

--- a/src/main/groovy/org/pih/warehouse/inventory/ReslottingEvent.groovy
+++ b/src/main/groovy/org/pih/warehouse/inventory/ReslottingEvent.groovy
@@ -9,14 +9,13 @@
  **/
 package org.pih.warehouse.inventory
 
-import org.pih.warehouse.core.User
 import org.springframework.context.ApplicationEvent
 
 class ReslottingEvent extends ApplicationEvent {
-    User updatedBy
+    String updatedByUserId
 
-    ReslottingEvent(String inventoryLevelId, User updatedBy) {
+    ReslottingEvent(String inventoryLevelId, String updatedByUserId) {
         super(inventoryLevelId)
-        this.updatedBy = updatedBy
+        this.updatedByUserId = updatedByUserId
     }
 }

--- a/src/main/groovy/org/pih/warehouse/order/OrderItemStatusCode.groovy
+++ b/src/main/groovy/org/pih/warehouse/order/OrderItemStatusCode.groovy
@@ -19,4 +19,7 @@ enum OrderItemStatusCode {
         [PENDING, STARTED, IN_PROGRESS, COMPLETED, CANCELED, BACKORDER]
     }
 
+    static listPending() {
+        [PENDING, STARTED, IN_PROGRESS]
+    }
 }


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:**
https://openboxes.atlassian.net/browse/OBLS-514

**Description:**
Create Putaway to NOLOC location when it was given in a Inventory Levels. Later, when the NOLOC is changed in the Inventory Levels, find the matching Putaway and modify it's location.
In the end I had to use a job to update Putaway location.
It's worth mentioning that I've changed 'putawayAssignee' and 'orderedBy' in several places. I found this mixed together between Order and Putaway. I'm not sure about this solution so I kept these changes in my last commit here. [commit](https://github.com/openboxes/openboxes/commit/e7ecfb35eeb57751ed91027bdfcbabf78150b341)

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
