### PR TITLE
OBLS-811 Add system user authentication for background jobs

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -330,6 +330,12 @@ openboxes:
     ajaxRequest:
         timeout: 120000
 
+    # The user that background/asynchronous jobs authenticate as when they run.
+    # This user provides the current user context (e.g. for createdBy/updatedBy
+    # audit stamping) while a job executes. It is allowed to be disabled
+    # (active = false) since it is only used for internal, non-interactive
+    # authentication. Defaults to the built-in "admin" user but can be pointed
+    # at a dedicated account by overriding the username below.
     system:
         username: "admin"
 

--- a/grails-app/migrations/0.9.x/changelog-2026-06-16-1500-drop-not-null-constraint-on-audit-columns-in-event-log.xml
+++ b/grails-app/migrations/0.9.x/changelog-2026-06-16-1500-drop-not-null-constraint-on-audit-columns-in-event-log.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+
+    <changeSet author="jmiranda" id="160620261500-0">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="event_log" columnName="created_by_id"/>
+        </preConditions>
+        <dropNotNullConstraint tableName="event_log" columnName="created_by_id" columnDataType="CHAR(38)"/>
+        <rollback>
+            <addNotNullConstraint tableName="event_log" columnName="created_by_id" columnDataType="CHAR(38)"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="jmiranda" id="160620261500-1">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="event_log" columnName="updated_by_id"/>
+        </preConditions>
+        <dropNotNullConstraint tableName="event_log" columnName="updated_by_id" columnDataType="CHAR(38)"/>
+        <rollback>
+            <addNotNullConstraint tableName="event_log" columnName="updated_by_id" columnDataType="CHAR(38)"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/grails-app/migrations/0.9.x/changelog.xml
+++ b/grails-app/migrations/0.9.x/changelog.xml
@@ -57,4 +57,5 @@
     <include file="0.9.x/changelog-2026-02-13-0001-alter-table-person-add-identifier.xml" />
     <include file="0.9.x/changelog-2026-02-12-1600-add-shipmentItem-columns-to-store-outbound-sales-link.xml" />
     <include file="0.9.x/changelog-2026-02-25-1200-add-requisitionItem-column-quantity-backordered.xml" />
+    <include file="0.9.x/changelog-2026-06-16-1500-drop-not-null-constraint-on-audit-columns-in-event-log.xml" />
 </databaseChangeLog>

--- a/src/integration-test/groovy/org/pih/warehouse/auth/AuthServiceIntegrationSpec.groovy
+++ b/src/integration-test/groovy/org/pih/warehouse/auth/AuthServiceIntegrationSpec.groovy
@@ -1,0 +1,75 @@
+package org.pih.warehouse.auth
+
+import grails.gorm.transactions.Rollback
+import org.pih.warehouse.common.base.IntegrationSpec
+import org.pih.warehouse.core.Constants
+import org.pih.warehouse.core.User
+
+/**
+ * Verifies that background jobs can authenticate as the configured system user via
+ * {@link AuthService#withSystemUser(groovy.lang.Closure)}, including when that user is disabled.
+ */
+@Rollback
+class AuthServiceIntegrationSpec extends IntegrationSpec {
+
+    AuthService authService
+
+    void 'getSystemUser returns the configured system user'() {
+        when:
+        User systemUser = authService.getSystemUser()
+
+        then:
+        systemUser != null
+        // Defaults to the built-in admin user (openboxes.system.username)
+        systemUser.username == Constants.SYSTEM_USER_USERNAME_DEFAULT_VALUE
+    }
+
+    void 'withSystemUser sets the current user for the duration of the closure and restores it afterward'() {
+        given:
+        assert AuthService.currentUser == null
+
+        when:
+        User userDuringExecution = authService.withSystemUser {
+            return AuthService.currentUser
+        }
+
+        then: 'the system user is the current user while the closure runs'
+        userDuringExecution != null
+        userDuringExecution.username == Constants.SYSTEM_USER_USERNAME_DEFAULT_VALUE
+
+        and: 'the previous (empty) user context is restored afterward'
+        AuthService.currentUser == null
+    }
+
+    void 'withSystemUser restores the previously authenticated user'() {
+        given:
+        User previousUser = User.findByUsername(Constants.SYSTEM_USER_USERNAME_DEFAULT_VALUE)
+        authService.setCurrentUser(previousUser)
+
+        when:
+        authService.withSystemUser {
+            assert AuthService.currentUser != null
+        }
+
+        then:
+        AuthService.currentUser?.id == previousUser.id
+
+        cleanup:
+        authService.setCurrentUser(null)
+    }
+
+    void 'getSystemUser resolves the system user even when the account is disabled'() {
+        given: 'the system user is disabled'
+        User systemUser = User.findByUsername(Constants.SYSTEM_USER_USERNAME_DEFAULT_VALUE)
+        systemUser.active = false
+        systemUser.save(flush: true)
+
+        when: 'the system user is resolved (active flag is intentionally not enforced)'
+        User resolved = authService.getSystemUser()
+
+        then: 'the disabled user is still returned for job authentication'
+        resolved != null
+        resolved.username == Constants.SYSTEM_USER_USERNAME_DEFAULT_VALUE
+        !resolved.active
+    }
+}


### PR DESCRIPTION
## Summary

Background jobs run with no authenticated user, so `AuthService.currentUser` is `null` inside them and records they create are left with null `createdBy`/`updatedBy` audit stamps. This adds a configurable **system user** that jobs can authenticate as, and wires it into `AutomaticReceiptJob`.

## Changes

- **`openboxes.system.username`** config (defaults to the built-in `admin` user).
- **`AuthService.getSystemUser()`** — resolves the configured user. The `active` flag is intentionally **not** enforced, so the system user may be disabled and still be used for internal, non-interactive job authentication.
- **`AuthService.withSystemUser(Closure)`** — static method that runs a block with the system user set as the current user and restores the previous user afterward. Being static, it runs outside the class-level read-only transaction, so the wrapped services keep managing their own transactions; the GORM lookups only need the bound Hibernate session the caller establishes via `withNewSession`.
- **`AutomaticReceiptJob`** wrapped in `Shipment.withNewSession { AuthService.withSystemUser { ... } }` so the receipts it creates are stamped with a valid current user.
- **`event_log.created_by_id` / `updated_by_id` made nullable** (Liquibase migration with rollbacks) so existing event log writes aren't blocked while the system user is rolled out.
- **`AuthServiceIntegrationSpec`** covering resolution, context set/restore, and the disabled-user case.

## Notes

- Targets `feature/obaf-integration` (not the default branch).
- `withSystemUser`/`getSystemUser` avoid GORM dynamic finders since `AuthService` is `@CompileStatic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6FfU8NQukT7xSmD9iB9hw)_