### PR TITLE
OBLS-620 Add bulk upsert API for products (PUT /api/products) with id-or-code lookup

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/UrlMappings.groovy
+++ b/grails-app/controllers/org/pih/warehouse/UrlMappings.groovy
@@ -119,7 +119,7 @@ class UrlMappings {
 
         "/api/products"(parseRequest: true) {
             controller = { "productApi" }
-            action = [GET: "list", POST: "save"]
+            action = [GET: "list", POST: "save", PUT: "upsert"]
         }
 
         "/api/products/search"(parseRequest: true) {

--- a/grails-app/controllers/org/pih/warehouse/api/ProductApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/ProductApiController.groovy
@@ -336,6 +336,76 @@ class ProductApiController extends BaseDomainApiController {
         render([product: product.toFullJson()] as JSON)
     }
 
+    /**
+     * Create or update one or more products. Accepts either a single product object or an array of
+     * them. Each product is matched to an existing one by id or productCode (the same id-or-code
+     * lookup ProductValueConverter uses) and updated, or created if no match is found.
+     *
+     * Bulk upserts are best-effort: each product is processed in its own transaction so a failure
+     * isolates to that item. The response mirrors the request shape - a single result object for a
+     * single product, an array of results for an array - where each result is either
+     * {status: "created"|"updated", product: {...}} or {status: "error", id, productCode, errors: [...]}.
+     */
+    def upsert() {
+        def json = request.JSON
+        boolean isArray = json instanceof List
+        List items = isArray ? (json as List) : [json]
+        Location location = Location.get(session?.warehouse?.id)
+
+        List results = items.collect { item -> upsertProduct(item, location) }
+
+        render((isArray ? results : results[0]) as JSON)
+    }
+
+    private Map upsertProduct(def item, Location location) {
+        Map result
+        // Each product gets its own transaction so a failure rolls back only that item.
+        Product.withNewTransaction { txStatus ->
+            try {
+                Product product = (item.id || item.productCode) ?
+                        Product.findByIdOrProductCode(item.id as String, item.productCode as String) : null
+                boolean created = product == null
+                if (created) {
+                    product = new Product()
+                }
+
+                // Never rebind the primary key; bind the remaining fields onto the resolved/new product.
+                bindData(product, item, [exclude: ['id']])
+
+                ProductType defaultProductType = ProductType.defaultProductType.list()?.first()
+                if (product.productType?.id != defaultProductType?.id && !product.productType?.code && !product.productType?.productIdentifierFormat) {
+                    throw new IllegalArgumentException(g.message(code: "product.productType.emptyCodeAndIdentifier.error.message"))
+                }
+
+                if (!product?.id || product.validate()) {
+                    if (!product.productCode) {
+                        product.productCode = productService.generateProductIdentifier(product)
+                    }
+                }
+                product.validateRequiredFieldsInLocation(location)
+
+                if (product.hasErrors() || !productService.saveProduct(product)) {
+                    txStatus.setRollbackOnly()
+                    result = [status: "error", id: item.id, productCode: item.productCode,
+                              errors: product.errors.allErrors.collect { g.message(error: it) }]
+                } else {
+                    result = [status: created ? "created" : "updated", product: materializeJson(product.toFullJson())]
+                }
+            } catch (Exception e) {
+                txStatus.setRollbackOnly()
+                result = [status: "error", id: item.id, productCode: item.productCode, errors: [e.message]]
+            }
+        }
+        return result
+    }
+
+    private Object materializeJson(Map jsonMap) {
+        // Render within the open session (forcing lazy associations like Product.attributes to load),
+        // then parse back to plain objects so the response can be serialized after each per-item
+        // transaction/session has closed.
+        return new groovy.json.JsonSlurper().parseText((jsonMap as JSON).toString())
+    }
+
     def importCsv() {
         String fileData = request.inputStream.text
 

--- a/grails-app/utils/org/pih/warehouse/databinding/ProductValueConverter.groovy
+++ b/grails-app/utils/org/pih/warehouse/databinding/ProductValueConverter.groovy
@@ -1,0 +1,18 @@
+package org.pih.warehouse.databinding
+
+import org.springframework.stereotype.Component
+
+import org.pih.warehouse.product.Product
+
+/**
+ * Binds a Product-typed field from a plain String that is either the Product's id or its productCode,
+ * so callers can reference products by their natural key without first resolving the id.
+ */
+@Component
+class ProductValueConverter extends StringValueConverter<Product> {
+
+    @Override
+    Product convertString(String value) {
+        return Product.findByIdOrProductCode(value, value)
+    }
+}

--- a/src/integration-test/groovy/org/pih/warehouse/databinding/ProductValueConverterIntegrationSpec.groovy
+++ b/src/integration-test/groovy/org/pih/warehouse/databinding/ProductValueConverterIntegrationSpec.groovy
@@ -1,0 +1,58 @@
+package org.pih.warehouse.databinding
+
+import grails.web.databinding.DataBindingUtils
+
+import org.pih.warehouse.api.StockMovementItem
+import org.pih.warehouse.api.spec.base.ApiSpec
+import org.pih.warehouse.product.Product
+
+/**
+ * Verifies ProductValueConverter end to end: when Grails data-binds a String into a Product-typed
+ * field, the converter resolves it by id OR productCode (and to null for an unknown identifier).
+ *
+ * StockMovementItem is used because it has a `Product product` field, but the converter is
+ * registered globally, so this exercises the exact path the API uses (bindData -> data binder ->
+ * registered ValueConverter). The binding runs inside a session because the converter issues a
+ * GORM query (Product.findByIdOrProductCode).
+ */
+class ProductValueConverterIntegrationSpec extends ApiSpec {
+
+    void 'binds a Product-typed field from a productCode string'() {
+        given:
+        StockMovementItem item = new StockMovementItem()
+
+        when:
+        Product.withNewSession {
+            DataBindingUtils.bindObjectToInstance(item, [product: product.productCode])
+        }
+
+        then:
+        item.product?.id == product.id
+    }
+
+    void 'binds a Product-typed field from an id string'() {
+        given:
+        StockMovementItem item = new StockMovementItem()
+
+        when:
+        Product.withNewSession {
+            DataBindingUtils.bindObjectToInstance(item, [product: product.id])
+        }
+
+        then:
+        item.product?.id == product.id
+    }
+
+    void 'binds null when the identifier matches no product'() {
+        given:
+        StockMovementItem item = new StockMovementItem()
+
+        when:
+        Product.withNewSession {
+            DataBindingUtils.bindObjectToInstance(item, [product: 'no-such-id-or-code'])
+        }
+
+        then:
+        item.product == null
+    }
+}


### PR DESCRIPTION
Adds PUT /api/products for creating/updating products in bulk.

What's included:
* `upsert` action which accepts a single product or an array, matching each to an existing product by id or productCode (update) or creating a new one. Response mirrors the request shape. Each item runs in its own transaction so a failure isolates to that item, returning {status: "created"|"updated", product} or {status: "error", id, productCode, errors}.
* ProductValueConverter is a globally-registered converter that binds any Product-typed field from a plain string that is either the product id or its productCode, so callers can reference products by their natural key.
* Integration test covering the converter end-to-end (resolves by id, by productCode, and null for unknown identifiers).
