### PR TITLE
OBLS-812 Show Receive button only for shipped and partially received …

### DIFF
--- a/grails-app/views/returns/show.gsp
+++ b/grails-app/views/returns/show.gsp
@@ -74,10 +74,12 @@
                 <img src="${resource(dir: 'images/icons/silk', file: 'pencil.png')}" />&nbsp;
                 <warehouse:message code="default.button.edit.label" />
             </g:link>
-            <g:link controller="partialReceiving" action="create" id="${stockMovement?.shipment?.id}" class="button">
-                <img src="${resource(dir: 'images/icons/', file: 'handtruck.png')}" />&nbsp;
-                <warehouse:message code="default.button.receive.label" />
-            </g:link>
+            <g:if test="${hasBeenPlaced}">
+                <g:link controller="partialReceiving" action="create" id="${stockMovement?.shipment?.id}" class="button">
+                    <img src="${resource(dir: 'images/icons/', file: 'handtruck.png')}" />&nbsp;
+                    <warehouse:message code="default.button.receive.label" />
+                </g:link>
+            </g:if>
             <g:isUserAdmin>
                 <g:if test="${stockMovement?.hasBeenReceived() || stockMovement?.hasBeenPartiallyReceived()}">
                     <g:link controller="partialReceiving" action="rollbackLastReceipt" id="${stockMovement?.shipment?.id}" class="button">


### PR DESCRIPTION
…stock movements

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket: https://openboxes.atlassian.net/browse/OBLS-812**

**Description:**
Before - the Receive button was rendered unconditionally, so it appeared for every return status including Checking (not yet shipped) and Received.

After - the button is wrapped in <g:if test="${hasBeenPlaced}">, reusing the variable already defined: SHIPPED - Visible, PARTIALLY_RECEIVED - Visible, PENDING/RECEIVED - Hidden.

---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
