### PR TITLE
OBS-1981 When asserting request number uniqueness, also check locatio…

### DIFF
--- a/grails-app/services/org/pih/warehouse/requisition/RequisitionIdentifierService.groovy
+++ b/grails-app/services/org/pih/warehouse/requisition/RequisitionIdentifierService.groovy
@@ -3,6 +3,7 @@ package org.pih.warehouse.requisition
 import grails.gorm.transactions.Transactional
 
 import org.pih.warehouse.core.IdentifierService
+import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.identification.BlankIdentifierResolver
 import org.pih.warehouse.shipping.Shipment
 
@@ -16,12 +17,21 @@ class RequisitionIdentifierService extends IdentifierService<Requisition> implem
 
     @Override
     protected Integer countByIdentifier(String id) {
+        Integer count = Requisition.countByRequestNumber(id)
+        if (count > 0) {
+            return count
+        }
+
         // We use requisition.requestNumber as shipment.shipmentNumber when performing stock movements so we need
         // to check that the id is unique for shipments as well. See StockMovementService.createShipment for details.
-        Integer count = Requisition.countByRequestNumber(id)
+        count = Shipment.countByShipmentNumber(id)
+        if (count > 0) {
+            return count
+        }
 
-        // Only bother checking shipment if requisition doesn't already have a duplicate.
-        return count > 0 ? count : Shipment.countByShipmentNumber(id)
+        // We also use shipmentNumber as locationNumber when creating internal receiving locations so we need to verify
+        // that the id is unique for locations as well. See LocationService.findOrCreateInternalLocation for details.
+        return Location.countByLocationNumber(id)
     }
 
     @Override


### PR DESCRIPTION
…n number

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBS-1981

**Description:** If a shipment is coming from a requisition, we use the request number as the shipment number. We then use that same number as the location number for the temporary receiving location. When generating a request number for a requisition, we check if a shipment already exists with that number, but we do not check if a location exists with it. This allowed us to generate a request number that threw an error when trying to receive the shipment because a location already existed with that number.