### PR TITLE
OBPIH-7933 Initialize CycleCount.cycleCountItems to avoid null pointer

### DIFF
--- a/grails-app/domain/org/pih/warehouse/inventory/CycleCount.groovy
+++ b/grails-app/domain/org/pih/warehouse/inventory/CycleCount.groovy
@@ -34,7 +34,9 @@ class CycleCount {
         status = recomputeStatus()
     }
 
-    SortedSet<CycleCountItem> cycleCountItems
+    // OBPIH-7933: Make sure to initialize set so that it is non-null for instances that are not yet GORM-initialized.
+    // Otherwise, calling new CycleCount().save() can cause null pointers if you try to access the cycleCountItems.
+    SortedSet<CycleCountItem> cycleCountItems = [] as SortedSet<CycleCountItem>
 
     static hasMany = [
             /*
@@ -102,7 +104,7 @@ class CycleCount {
      * @return The largest count index of all the cycle count items. Helps determine what count we're on.
      */
     Integer getMaxCountIndex() {
-        return cycleCountItems.max{ it.countIndex }?.countIndex
+        return cycleCountItems?.max{ it.countIndex }?.countIndex
     }
 
     /**
@@ -110,7 +112,7 @@ class CycleCount {
      */
     Set<CycleCountItem> getItemsOfMostRecentCount() {
         Integer countIndex = maxCountIndex
-        return cycleCountItems.findAll { it.countIndex == countIndex}
+        return cycleCountItems?.findAll { it.countIndex == countIndex}
     }
 
     Integer getNumberOfItemsOfMostRecentCount() {
@@ -118,14 +120,14 @@ class CycleCount {
     }
 
     Set<CycleCountItem> getItemsOfSpecificCount(Integer countIndex) {
-        return cycleCountItems.findAll { it.countIndex == countIndex }
+        return cycleCountItems?.findAll { it.countIndex == countIndex }
     }
 
     /**
      * @return a list of all the products being counted by the cycle count.
      */
     List<Product> getProducts() {
-        return cycleCountItems.collect{ it.product }.unique{ it.id }
+        return cycleCountItems?.collect{ it.product }?.unique{ it.id }
     }
 
     /**
@@ -134,7 +136,7 @@ class CycleCount {
     CycleCountItem getCycleCountItem(
             Product product, Location binLocation, InventoryItem inventoryItem, int countIndex) {
 
-        return cycleCountItems.find{
+        return cycleCountItems?.find{
                     it.product == product &&
                     it.location == binLocation &&
                     it.inventoryItem == inventoryItem &&

--- a/grails-app/services/org/pih/warehouse/inventory/CycleCountService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/CycleCountService.groovy
@@ -568,6 +568,10 @@ class CycleCountService {
 
         List<AvailableItem> itemsToSave = cycleCountProductAvailabilityService.getAvailableItems(
                 facility, request.cycleCountRequest.product)
+        if (!itemsToSave) {
+            throw new RuntimeException("You cannot start a cycle count on a product with no stock.")
+        }
+
         // 1:1 association between cycle count and cycle count request
         request.cycleCountRequest.cycleCount = newCycleCount
         request.cycleCountRequest.status = CycleCountRequestStatus.IN_PROGRESS

--- a/grails-app/services/org/pih/warehouse/inventory/CycleCountService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/CycleCountService.groovy
@@ -569,7 +569,8 @@ class CycleCountService {
         List<AvailableItem> itemsToSave = cycleCountProductAvailabilityService.getAvailableItems(
                 facility, request.cycleCountRequest.product)
         if (!itemsToSave) {
-            throw new RuntimeException("You cannot start a cycle count on a product with no stock.")
+            throw new RuntimeException("Cannot start a cycle count on a product with no stock. Please cancel the " +
+                    "count on product [${request.cycleCountRequest.product.productCode}] to proceed.")
         }
 
         // 1:1 association between cycle count and cycle count request


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7933

**Description:** Because CycleCount.cycleCountItems is in a hasMany, GORM will initialize the set when fetching the entity from the db, but if you do new CycleCount(), cycleCountItems will be null because it has not yet been initialized by GORM.


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

If you trigger this scenario here is the old error:

<img width="1880" height="704" alt="image" src="https://github.com/user-attachments/assets/b8c36105-1afc-4c5c-866c-f16c339e5d20" />

and here is the new error:

<img width="1880" height="704" alt="image" src="https://github.com/user-attachments/assets/0853b949-c948-419b-b62b-8fe687a00933" />

