### PR TITLE
OBLS-851 Receiving the shipment fails when demand quantity does not match inbound item quantity

### DIFF
--- a/grails-app/services/org/pih/warehouse/allocation/BackorderService.groovy
+++ b/grails-app/services/org/pih/warehouse/allocation/BackorderService.groovy
@@ -9,6 +9,7 @@ import org.pih.warehouse.shipping.ShipmentItem
 @Transactional
 class BackorderService {
 
+    // UPDATE: now the inbound item has to be at least equal to the outbound demand, no longer an exact match
     // Special case: we only fulfill a backorder with an inbound item that exactly matches
     // the outbound demand. The general behaviour of backorder fulfillment is partial matching
     // (any inbound quantity reduces the demanded quantity, even if it only partially fulfills
@@ -33,7 +34,7 @@ class BackorderService {
             for (ShipmentItem inboundItem : inboundItems) {
                 def matchingBackorderItem = backorder.requisitionItems.find { RequisitionItem demand ->
                     demand.product == inboundItem.product &&
-                            demand.quantity == inboundItem.quantity &&
+                            demand.quantity <= inboundItem.quantity &&
                             !demand.isAllocated() &&
                             !consumedRequisitionItems.contains(demand)
                 }


### PR DESCRIPTION
inbound can be greater or equal to outbound

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:**
https://openboxes.atlassian.net/browse/OBLS-851

**Description:**


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
