### PR TITLE
Fix document upload in Firefox/Safari (outbound Send + DropzoneFileSelect) (#6031)

### DIFF
--- a/src/js/components/form-elements/v2/DropzoneFileSelect.jsx
+++ b/src/js/components/form-elements/v2/DropzoneFileSelect.jsx
@@ -28,12 +28,13 @@ const DropzoneFileSelect = ({
   isFormDisabled,
   showButtonOnly,
   throwErrorOnInvalidFiles,
+  onChange,
   ...fieldProps
 }) => {
   const maxFileSize = useSelector(getMaxUploadFileSize);
 
   const onDrop = useCallback((acceptedFiles) => {
-    fieldProps.onChange?.(multiple ? acceptedFiles : acceptedFiles[0]);
+    onChange?.(multiple ? acceptedFiles : acceptedFiles[0]);
   }, []);
 
   const translate = useTranslate();
@@ -212,6 +213,8 @@ DropzoneFileSelect.propTypes = {
   showButtonOnly: PropTypes.bool,
   // If true, will display errors for invalid files (useful when displaying only the button)
   throwErrorOnInvalidFiles: PropTypes.bool,
+  // Called with the selected file(s) when the user picks files
+  onChange: PropTypes.func,
 };
 
 DropzoneFileSelect.defaultProps = {
@@ -234,4 +237,5 @@ DropzoneFileSelect.defaultProps = {
   isFormDisabled: false,
   showButtonOnly: false,
   throwErrorOnInvalidFiles: false,
+  onChange: () => {},
 };

--- a/src/js/components/stock-movement-wizard/combined-shipments/SendMovementPage.jsx
+++ b/src/js/components/stock-movement-wizard/combined-shipments/SendMovementPage.jsx
@@ -755,8 +755,9 @@ class SendMovementPage extends Component {
                       onDrop={this.onDrop}
                       multiple
                     >
-                      {({ getRootProps }) => (
+                      {({ getRootProps, getInputProps }) => (
                         <div {...getRootProps()}>
+                          <input {...getInputProps()} />
                           <span>
                             <i className="fa fa-upload pr-2" />
                             <Translate id="react.stockMovement.uploadDocuments.label" defaultMessage="Upload Documents" />

--- a/src/js/components/stock-movement-wizard/outbound/SendMovementPage.jsx
+++ b/src/js/components/stock-movement-wizard/outbound/SendMovementPage.jsx
@@ -867,8 +867,9 @@ class SendMovementPage extends Component {
                       onDrop={this.onDrop}
                       multiple
                     >
-                      {({ getRootProps }) => (
+                      {({ getRootProps, getInputProps }) => (
                         <div {...getRootProps()}>
+                          <input {...getInputProps()} />
                           <span>
                             <i className="fa fa-upload pr-2" />
                             <Translate id="react.stockMovement.uploadDocuments.label" defaultMessage="Upload Documents" />


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:** Fixes #6031

**Description:**

Document upload is broken in Firefox and Safari (and in any browser served over plain HTTP), in two places with the same root cause. `react-dropzone` v14 only uses the File System Access API in a secure-context Chromium browser (`window.isSecureContext && 'showOpenFilePicker' in window`); everywhere else it falls back to a hidden `<input>`, and two components don't handle that fallback correctly.

**1. Outbound / combined-shipments Send page — clicking upload does nothing**

`outbound/SendMovementPage.jsx` and `combined-shipments/SendMovementPage.jsx` render the dropzone render-prop without `<input {...getInputProps()} />`, so `open()` has no input to trigger. The legacy `inbound/SendMovementPage.jsx` already renders it and works; this adds the same two lines to the other two.

**2. DropzoneFileSelect — crash after selecting a file**

`DropzoneFileSelect.jsx` kept `onChange` inside `{...fieldProps}` and spread it onto the wrapper `<div>`. When the fallback `<input>` fires its native change event, it bubbles to the div and calls the handler with a `SyntheticEvent` instead of a file array, throwing `Invalid attempt to spread non-iterable instance` and blanking the inbound V2 Send page and every import flow (outbound import, location/category/bin import). Fixed by destructuring `onChange` out of the spread so it no longer lands on the div.

Both paths work in secure-context Chrome because react-dropzone uses the File System Access API there and never touches the input fallback, which is why this is easy to miss in dev.

---
### :camera: Screenshots & Recordings

Before recording attached in the issue.
Fix:

https://github.com/user-attachments/assets/9a38f2a2-bd3c-4986-869e-3703771742b9

