### PR TITLE
OBPIH-7922 Customize Notify.js notification duration

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -449,6 +449,10 @@ openboxes:
         delay: 300
         minLength: 3
 
+    # The amount of time (in milliseconds) to display Notify.js notification popups before hiding them
+    notify:
+        autoHideDelay: 10000
+
     refreshAnalyticsDataOnStartup:
         enabled: true
 

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -449,7 +449,8 @@ openboxes:
         delay: 300
         minLength: 3
 
-    # The amount of time (in milliseconds) to display Notify.js notification popups before hiding them
+    # The amount of time (in milliseconds) to display Notify.js notification popups before hiding them.
+    # Notify.js defaults this value to 5000 (5 seconds) if no config is specified.
     notify:
         autoHideDelay: 10000
 

--- a/grails-app/views/layouts/custom.gsp
+++ b/grails-app/views/layouts/custom.gsp
@@ -226,7 +226,7 @@
 <script src="//cdnjs.cloudflare.com/ajax/libs/datatables/1.9.4/jquery.dataTables.js" type="text/javascript" ></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/notify/0.4.2/notify.js" type="text/javascript"></script>
 <script type="text/javascript">
-    $.notify.defaults({ autoHideDelay: ${grailsApplication.config.openboxes.notify.autoHideDelay ?: 5000} });
+    $.notify.defaults({ autoHideDelay: ${grailsApplication.config.openboxes.notify.autoHideDelay ?: 10000} });
 </script>
 
 <!-- JIRA Issue Collector -->

--- a/grails-app/views/layouts/custom.gsp
+++ b/grails-app/views/layouts/custom.gsp
@@ -225,6 +225,9 @@
 <script src="//cdn.jsdelivr.net/npm/select2@4.0.13/dist/js/select2.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/datatables/1.9.4/jquery.dataTables.js" type="text/javascript" ></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/notify/0.4.2/notify.js" type="text/javascript"></script>
+<script type="text/javascript">
+    $.notify.defaults({ autoHideDelay: ${grailsApplication.config.openboxes.notify.autoHideDelay ?: 5000} });
+</script>
 
 <!-- JIRA Issue Collector -->
 <g:if test="${session.user && Boolean.valueOf(grailsApplication.config.openboxes.jira.issue.collector.enabled)}">


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7922

**Description:** Create an application property that controls the amount of time that Notify.js popups stay on screen (you can still click on them to dismiss them immediately).


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)


https://github.com/user-attachments/assets/97c47905-e5f8-40ca-b8ec-ef682cc83f73

