### PR TITLE
OBLS-919 Fixed negative SoH when two outbounds allocate the same stock

### DIFF
--- a/grails-app/services/org/pih/warehouse/allocation/AllocationService.groovy
+++ b/grails-app/services/org/pih/warehouse/allocation/AllocationService.groovy
@@ -246,6 +246,8 @@ class AllocationService {
 
                 if (requisition.autoIssuanceRequested) {
                     stockMovementService.issueRequisition(requisition)
+                    // TODO this is sync refresh as a temporary workaround for async refresh after transaction creation
+                    //  it should be implemented in better way, ticket for it - OBLS-937
                     productAvailabilityService.refreshProductsAvailability(
                             requisition.origin?.id, requisition.requisitionItems*.product*.id, false)
                 } else {

--- a/grails-app/services/org/pih/warehouse/allocation/AllocationService.groovy
+++ b/grails-app/services/org/pih/warehouse/allocation/AllocationService.groovy
@@ -19,6 +19,7 @@ import org.pih.warehouse.api.SuggestedItem
 import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.inventory.InventoryItem
+import org.pih.warehouse.inventory.ProductAvailabilityService
 import org.pih.warehouse.inventory.StockMovementService
 import org.pih.warehouse.picklist.PicklistItem
 import org.pih.warehouse.product.Product
@@ -34,6 +35,7 @@ class AllocationService {
     GrailsApplication grailsApplication
     AuthService authService
     RequisitionService requisitionService
+    ProductAvailabilityService productAvailabilityService
 
     AllocationSourceStrategyHandlerResolver allocationSourceStrategyHandlerResolver = new AllocationSourceStrategyHandlerResolver()
     RotationStrategyResolver rotationStrategyResolver = new RotationStrategyResolver()
@@ -244,6 +246,8 @@ class AllocationService {
 
                 if (requisition.autoIssuanceRequested) {
                     stockMovementService.issueRequisition(requisition)
+                    productAvailabilityService.refreshProductsAvailability(
+                            requisition.origin?.id, requisition.requisitionItems*.product*.id, false)
                 } else {
                     stockMovementService.updateRequisitionStatus(requisitionId, RequisitionStatus.PICKING)
                 }

--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -257,24 +257,18 @@ class ProductAvailabilityService {
         // we should only consider as quantity allocated only the part not moved to staging location or
         // outbound container (as these locations should be unallocable)
         """
-            SUM(
-                CASE
-                    WHEN pli.reason_code IS NOT NULL THEN COALESCE(pli.quantity_picked, 0)
-                    WHEN pli.outbound_container_id IS NULL AND pli.staging_location_id IS NULL
-                        THEN COALESCE(pli.quantity, 0)
-                    ELSE COALESCE(pli.quantity, 0) - COALESCE(pli.quantity_picked, 0)
-                END
-            ) as quantity_allocated
+            CASE
+                WHEN pli.reason_code IS NULL THEN sum(pli.quantity) - sum(pli.quantity_picked)
+                ELSE SUM(pli.quantity_picked)
+            END as quantity_allocated
         """ :
         // If we don't track internal transaction, we should consider the entire quantity as allocated
         // until it is issued
         """
-            SUM(
-                CASE
-                    WHEN pli.reason_code IS NULL THEN COALESCE(pli.quantity, 0)
-                    ELSE COALESCE(pli.quantity_picked, 0)
-                END
-            ) as quantity_allocated
+            CASE
+                WHEN pli.reason_code IS NULL THEN sum(pli.quantity)
+                ELSE SUM(pli.quantity_picked)
+            END as quantity_allocated
         """
 
         def query = """
@@ -306,8 +300,8 @@ class ProductAvailabilityService {
                   AND (lsa.activities IS NULL OR (lsa.activities NOT LIKE '%HOLD_STOCK%' AND lsa.activities NOT LIKE '%LOST_AND_FOUND%')))
                   AND (:productId = '' OR ri.product_id = :productId)
                   ${internalTransactionsWhereClause}
-                GROUP BY pli.bin_location_id, pli.inventory_item_id
-                UNION ALL
+                GROUP BY pli.bin_location_id, pli.inventory_item_id, pli.reason_code
+                UNION
                 SELECT
                     pli.bin_location_id as bin_location_id,
                     pli.inventory_item_id as inventory_item_id,

--- a/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/ProductAvailabilityService.groovy
@@ -257,18 +257,24 @@ class ProductAvailabilityService {
         // we should only consider as quantity allocated only the part not moved to staging location or
         // outbound container (as these locations should be unallocable)
         """
-            CASE
-                WHEN pli.reason_code IS NULL THEN sum(pli.quantity) - sum(pli.quantity_picked)
-                ELSE SUM(pli.quantity_picked)
-            END as quantity_allocated
+            SUM(
+                CASE
+                    WHEN pli.reason_code IS NOT NULL THEN COALESCE(pli.quantity_picked, 0)
+                    WHEN pli.outbound_container_id IS NULL AND pli.staging_location_id IS NULL
+                        THEN COALESCE(pli.quantity, 0)
+                    ELSE COALESCE(pli.quantity, 0) - COALESCE(pli.quantity_picked, 0)
+                END
+            ) as quantity_allocated
         """ :
         // If we don't track internal transaction, we should consider the entire quantity as allocated
         // until it is issued
         """
-            CASE
-                WHEN pli.reason_code IS NULL THEN sum(pli.quantity)
-                ELSE SUM(pli.quantity_picked)
-            END as quantity_allocated
+            SUM(
+                CASE
+                    WHEN pli.reason_code IS NULL THEN COALESCE(pli.quantity, 0)
+                    ELSE COALESCE(pli.quantity_picked, 0)
+                END
+            ) as quantity_allocated
         """
 
         def query = """
@@ -300,8 +306,8 @@ class ProductAvailabilityService {
                   AND (lsa.activities IS NULL OR (lsa.activities NOT LIKE '%HOLD_STOCK%' AND lsa.activities NOT LIKE '%LOST_AND_FOUND%')))
                   AND (:productId = '' OR ri.product_id = :productId)
                   ${internalTransactionsWhereClause}
-                GROUP BY pli.bin_location_id, pli.inventory_item_id, pli.reason_code
-                UNION
+                GROUP BY pli.bin_location_id, pli.inventory_item_id
+                UNION ALL
                 SELECT
                     pli.bin_location_id as bin_location_id,
                     pli.inventory_item_id as inventory_item_id,


### PR DESCRIPTION
**Example reproduction:**
* Product X has QoH = 5
* Two requisitions with enabled `autoAllocationRequested` + `autoIssuanceRequested`, with product X with quantity = 5
* AutomaticAllocationJob allocates and issues both requisitions leaving QoH = -5

**Expected result:**
* first requisition should be allocated and issued successfully
* second requisition should not be allocated because of insufficient stock
* QoH should decrease to 0 

**Actual result:**
* first requisition is allocated and issued successfully
* second requisition is allocated and issued successfully
* QoH decreases to -5

**Root cause:**

`ProductAvailabilityService.getQuantityPickedByProductAndLocation` derives
  `product_availability.quantity_allocated` - and therefore `quantity_available_to_promise` -  from picklist items. In the internal-transactions branch the formula was `sum(quantity) - sum(quantity_picked)`, which relies on an implicit invariant: a picked quantity means the stock has physically left the source bin via an internal transfer, so `quantity_on_hand` already accounts for it and it must not be reserved twice

Only `PickTaskService` upholds that invariant - `pick` / `shortPick` / `dropToStaging` perform a
  real `transferStock` and set `outbound_container_id` / `staging_location_id` in the same
  transaction. Several paths set the picked quantity *without* going through `PickTaskService`, and
  for those the formula returned `quantity - quantity = 0`, so allocating reserved nothing and the
  next outbound could allocate the very same stock

**Changes:**

In the internal-transactions branch, the picked quantity is now discounted only once the stock has actually left the source bin, i.e. only when the outbound container or staging location is set. Both branches were rewritten from a group-level `CASE` over aggregates to a row-level `CASE` inside `SUM`. That is equivalent — `reason_code` was part of the `GROUP BY`, so every row in a group shared its value — but it no longer requires the discriminating columns in the `GROUP BY`. `COALESCE` was added so a `NULL` quantity in older rows no longer nullifies the whole sum.
