### PR TITLE
OBPIH-7778 part 2: Fix custom data binding overrides during import

### DIFF
--- a/src/main/groovy/org/pih/warehouse/importer/BulkDataBinder.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/BulkDataBinder.groovy
@@ -62,6 +62,8 @@ class BulkDataBinder {
     BulkDataBinderResult bindData(BulkDataBinderConfig config, BulkDataReaderResult readerResult) {
         Map<String, BulkDataBinderFieldConfig> fieldConfigs = config.fields
         Class<Importable> bindTo = config.bindTo
+        BulkDataType bulkDataType = config.bulkDataType
+        Map<String, String> columnByFieldName = config.columnByFieldName
         EpochDate epochDate = readerResult.epochDate
         List<Map<String, BulkDataCell>> rawRows = readerResult.rows
 
@@ -85,8 +87,7 @@ class BulkDataBinder {
                 }
 
                 try {
-                    def parsedValue = parseField(
-                            cell.value, fieldNameToTypeMap.get(columnName), fieldConfig, epochDate)
+                    def parsedValue = parseField(cell.value, fieldNameToTypeMap.get(columnName), fieldConfig, epochDate)
                     boundRow.setProperty(columnName, parsedValue)
                 } catch (Exception e) {
                     result.bindErrors.add(new BulkDataError(
@@ -108,15 +109,68 @@ class BulkDataBinder {
             throw new RuntimeException("Something went wrong during the data binding process. Processed ${rawRows.size()} raw rows but ended up with ${result.boundRows.size()} bound rows.")
         }
 
-        // Now that the automatic data binding has completed, we can perform any custom data binding. If no bulk data
-        // type was specified (which can be true if a custom config is specified), no custom binding is required.
-        ConfiguresBulkDataBinder importConfigurer = componentResolver.getBulkDataBinderConfigurer(config.bulkDataType)
-        if (importConfigurer) {
-            // We rely on customBindData to modify the result object itself with any data changes and errors.
-            importConfigurer.customBindData(rawRows, result)
-        }
+        // The custom data binding directly modifies the rows, so the only thing left do is collect the errors.
+        result.bindErrors.addAll(customBindData(bulkDataType, columnByFieldName, rawRows, result.boundRows))
 
         return result
+    }
+
+    /**
+     * Perform any custom data binding as declared by the configurer for the given bulk data type.
+     */
+    private List<BulkDataError> customBindData(BulkDataType bulkDataType,
+                                               Map<String, String> columnByFieldName,
+                                               List<Map<String, BulkDataCell>> rawRows,
+                                               List<Importable> boundRows) {
+        ConfiguresBulkDataBinder configuresDataBinder = componentResolver.getBulkDataBinderConfigurer(bulkDataType)
+        if (!configuresDataBinder) {
+            return []
+        }
+
+        // We provide two hook-ins for configuring custom data binding. One for binding across rows...
+        List<BulkDataError> errors = configuresDataBinder.customBindDataAcrossRows(rawRows, boundRows)?.allErrors ?: []
+
+        // And one for binding rows individually.
+        errors.addAll(customBindEachRow(configuresDataBinder, rawRows, boundRows))
+
+        for (customError in errors) {
+            // To make it simpler to implement custom data binding for a feature, we set the column index on the errors
+            // here instead of requiring the custom configuration to know how to set the field itself.
+            if (customError.column == null && customError.fieldName != null) {
+                customError.column = columnByFieldName.get(customError.fieldName)
+            }
+
+            // We may not have performed localization on custom errors yet, so make sure to do so. Again, this is
+            // so that the custom configuration doesn't need to remember to do this.
+            if (customError.localizedMessage == null && customError.localizableMessage != null) {
+                customError.localizedMessage = messageLocalizer.localize(customError.localizableMessage)
+            }
+        }
+
+        return errors
+    }
+
+    private List<BulkDataError> customBindEachRow(ConfiguresBulkDataBinder configuresDataBinder,
+                                                  List<Map<String, BulkDataCell>> rawRows,
+                                                  List<Importable> boundRows) {
+        List<BulkDataError> errors = []
+        for (int rowIndex = 0; rowIndex < rawRows.size(); rowIndex++) {
+            // We assume that we are given the same number of raw rows and bound rows. There's a check for this
+            // earlier in the data binder so we don't bother checking again here.
+            Map<String, BulkDataCell> rawRow = rawRows.get(rowIndex)
+            Importable boundRow = boundRows.get(rowIndex)
+
+            List<BulkDataError> rowErrors = configuresDataBinder.customBindDataRow(rawRow, boundRow)?.allErrors
+            if (!rowErrors) {
+                continue
+            }
+
+            // To make it simpler to implement custom data binding for a feature, we set the row index on the errors
+            // here instead of requiring the custom configuration to know how to set the field itself.
+            rowErrors.each { it.row = rowIndex }
+            errors.addAll(rowErrors)
+        }
+        return errors
     }
 
     /**

--- a/src/main/groovy/org/pih/warehouse/importer/BulkDataBinder.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/BulkDataBinder.groovy
@@ -127,8 +127,10 @@ class BulkDataBinder {
             return []
         }
 
+        List<BulkDataError> errors = []
+
         // We provide two hook-ins for configuring custom data binding. One for binding across rows...
-        List<BulkDataError> errors = configuresDataBinder.customBindDataAcrossRows(rawRows, boundRows)?.allErrors ?: []
+        errors.addAll(configuresDataBinder.customBindDataAcrossRows(rawRows, boundRows)?.allErrors ?: [])
 
         // And one for binding rows individually.
         errors.addAll(customBindEachRow(configuresDataBinder, rawRows, boundRows))

--- a/src/main/groovy/org/pih/warehouse/importer/BulkDataBinderConfig.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/BulkDataBinderConfig.groovy
@@ -22,4 +22,16 @@ class BulkDataBinderConfig {
      * name matches the name in the BulkDataReaderConfig.columnMapping
      */
     Map<String, BulkDataBinderFieldConfig> fields
+
+    /**
+     * Maps field/property name to the column in the source object.
+     *
+     * In this mapping, columns can be represented as either zero-indexed numerical keys, or as letters (which is how
+     * they appear in Excel). The first column can be represented as "0" or "A", the second as "1" or "B", ...
+     *
+     * For example:
+     * - Excel importers might have a mapping like: ["field0": "A", "field1": "B", ...]
+     * - CSV importers might have a mapping like:   ["field0": "0", "field1": "1", ...]
+     */
+    Map<String, String> columnByFieldName = [:]
 }

--- a/src/main/groovy/org/pih/warehouse/importer/BulkDataBinderFieldConfigDefaults.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/BulkDataBinderFieldConfigDefaults.groovy
@@ -14,6 +14,13 @@ class BulkDataBinderFieldConfigDefaults {
     static final BulkDataBinderFieldConfig DEFAULT_CONFIG = new BulkDataBinderFieldConfig()
 
     /**
+     * The default configuration when we want to manually bind a field via custom data binding.
+     */
+    static final BulkDataBinderFieldConfig MANUALLY_BOUND = new BulkDataBinderFieldConfig(
+            dataBindingMethod: DataBindingMethod.MANUAL
+    )
+
+    /**
      * Builds a default configuration for binding Enum fields.
      */
     static BulkDataBinderFieldConfig buildDefaultEnumFieldConfig(Class enumClass) {

--- a/src/main/groovy/org/pih/warehouse/importer/BulkDataImportConfigurer.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/BulkDataImportConfigurer.groovy
@@ -73,15 +73,20 @@ abstract class BulkDataImportConfigurer<T extends Importable> implements
                 bindTo: getSourceType(),
                 bulkDataType: bulkDataType,
                 fields: dataBinderFieldConfig,
+                columnByFieldName: getColumnByFieldName(),
         )
     }
 
     @Override
     BulkDataValidatorConfig getBulkDataValidatorConfig() {
         return new BulkDataValidatorConfig(
-                // The validator needs the inverse of the column mapping that the readers use
-                columnByFieldName: columnMapping.collectEntries { k, v -> [v, k] } as Map<String, String>,
+                columnByFieldName: columnByFieldName,
         )
+    }
+
+    private Map<String, String> getColumnByFieldName() {
+        // Column index keyed on field name. The inverse of the column mapping that the readers use.
+        return columnMapping.collectEntries { k, v -> [v, k] } as Map<String, String>
     }
 
     private Class<T> getSourceType() {

--- a/src/main/groovy/org/pih/warehouse/importer/BulkDataValidator.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/BulkDataValidator.groovy
@@ -112,8 +112,10 @@ class BulkDataValidator {
             return []
         }
 
+        List<BulkDataError> errors = []
+
         // We provide two hook-ins for configuring custom validation. One for validating across rows...
-        List<BulkDataError> errors = configuresValidator.customValidateAcrossRows(rows)?.allErrors ?: []
+        errors.addAll(configuresValidator.customValidateAcrossRows(rows)?.allErrors ?: [])
 
         // And one for validating rows individually.
         errors.addAll(customValidateEachRow(configuresValidator, rows))

--- a/src/main/groovy/org/pih/warehouse/importer/ConfiguresBulkDataBinder.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/ConfiguresBulkDataBinder.groovy
@@ -17,46 +17,36 @@ trait ConfiguresBulkDataBinder<T extends Importable> {
     abstract BulkDataType getBulkDataType()
 
     /**
-     * Performs any custom data binding that was not already automatically handled by the data binder.
+     * Designed to be overridden when you need to perform custom data binding that spans across multiple rows.
+     * Implementations can utilize the add*Error(...) methods on CustomBulkDataErrors to raise validation errors.
      *
-     * This method expects that the fields of each Importable row in BulkDataBinderResult.boundRows are already
-     * populated with data if the field's config was marked with DataBindingMethod.AUTO. When custom binding, it
-     * is safe to rely on the value of the AUTO bound fields of the Importable objects, as well as any field values
-     * in the raw data.
-     *
-     * Any fields on the Importable objects in  BulkDataBinderResult.boundRows marked with the DataBindingMethod.MANUAL
-     * config option will need to have their values set manually by this method.
-     *
-     * To provide custom binding logic, a feature will typically override customBindDataRow. However, if you need
-     * the custom logic to be more complex, such as comparing data across rows, this method can also be overridden.
-     */
-    void customBindData(List<Map<String, BulkDataCell>> rawRows, BulkDataBinderResult<T> result) {
-        // We assume that we are given the same number of raw rows and bound rows. There's a check for this in
-        // the bulk data binder so we don't bother checking again here.
-        List<T> boundRows = result.boundRows
-        for (int rowIndex = 0; rowIndex < rawRows.size(); rowIndex++) {
-            // We expect customBindDataRow to directly write to the Importable object for each row so we don't need
-            // to do any further data binding. All we do here is collect any errors that occurred when custom binding.
-            List<BulkDataError> errors = customBindDataRow(rawRows.get(rowIndex), boundRows.get(rowIndex))
-            if (errors) {
-                result.bindErrors.addAll(errors)
-            }
-        }
-    }
-
-    /**
-     * Performs any custom data binding on a row that was not already automatically handled by the data binder.
-     * This method is designed to be overridden by child implementations (unless no custom binding is required).
+     * Note that this validation will be executed after the default data binding is executed. This means that
+     * the fields of the bound rows that are marked with the DataBindingMethod.AUTO config will already be populated.
      *
      * We expect the fields of the boundRow object to be directly modified by this method.
      *
-     * Any errors that occur when custom binding the row should be collected and returned by this method.
+     * @param rawRows The raw input data. Read only.
+     * @param boundRows The strongly typed object that the raw data was bound to. Custom binding writes to this object.
+     * @return The list of errors that occurred when custom binding the rows.
+     */
+    CustomBulkDataErrors customBindDataAcrossRows(List<Map<String, BulkDataCell>> rawRows, List<T> boundRows) {
+        return null  // Do nothing by default
+    }
+
+    /**
+     * Designed to be overridden when you need to perform custom data binding on each row individually.
+     * Implementations can utilize the add*Error(...) methods on CustomBulkDataErrors to raise validation errors.
+     *
+     * Note that this validation will be executed after the default data binding is executed. This means that
+     * the fields of the bound row that are marked with the DataBindingMethod.AUTO config will already be populated.
+     *
+     * We expect the fields of the boundRow object to be directly modified by this method.
      *
      * @param rawRow The raw input data. Read only.
      * @param boundRow The strongly typed object that the raw data was bound to. Custom binding writes to this object.
      * @return The list of errors that occurred when custom binding the fields of the row.
      */
-    List<BulkDataError> customBindDataRow(Map<String, BulkDataCell> rawRow, T boundRow) {
-        return []  // Do nothing by default
+    CustomBulkDataErrors customBindDataRow(Map<String, BulkDataCell> rawRow, T boundRow) {
+        return null  // Do nothing by default
     }
 }

--- a/src/main/groovy/org/pih/warehouse/importer/ConfiguresBulkDataBinder.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/ConfiguresBulkDataBinder.groovy
@@ -30,7 +30,7 @@ trait ConfiguresBulkDataBinder<T extends Importable> {
      * @return The list of errors that occurred when custom binding the rows.
      */
     CustomBulkDataErrors customBindDataAcrossRows(List<Map<String, BulkDataCell>> rawRows, List<T> boundRows) {
-        return null  // Do nothing by default
+        return CustomBulkDataErrors.NO_ERRORS  // Do nothing by default
     }
 
     /**
@@ -47,6 +47,6 @@ trait ConfiguresBulkDataBinder<T extends Importable> {
      * @return The list of errors that occurred when custom binding the fields of the row.
      */
     CustomBulkDataErrors customBindDataRow(Map<String, BulkDataCell> rawRow, T boundRow) {
-        return null  // Do nothing by default
+        return CustomBulkDataErrors.NO_ERRORS  // Do nothing by default
     }
 }

--- a/src/main/groovy/org/pih/warehouse/importer/ConfiguresBulkDataValidator.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/ConfiguresBulkDataValidator.groovy
@@ -17,22 +17,22 @@ trait ConfiguresBulkDataValidator<T extends Importable> {
     abstract BulkDataValidatorConfig getBulkDataValidatorConfig()
 
     /**
-     * Performs any cross-row validation that was not already automatically handled by the data validator.
-     * Implementations can utilize the add*Error(...) methods on BulkDataValidationErrors to raise validation errors.
+     * Designed to be overridden when you need to perform custom validation that spans across multiple rows.
+     * Implementations can utilize the add*Error(...) methods on CustomBulkDataErrors to raise validation errors.
      *
-     * This method is designed to be overridden when you need to perform validation that spans across multiple rows.
+     * Note that this validation will be executed after the default validation is executed.
      */
-    BulkDataValidationErrors customValidateAcrossRows(List<T> rows) {
+    CustomBulkDataErrors customValidateAcrossRows(List<T> rows) {
         return null  // Do nothing by default
     }
 
     /**
-     * Performs any custom validation on a row that was not already automatically handled by the data validator.
-     * Implementations can utilize the add*Error(...) methods on BulkDataValidationErrors to raise validation errors.
+     * Designed to be overridden when you need to perform custom validation on each row individually.
+     * Implementations can utilize the add*Error(...) methods on CustomBulkDataErrors to raise validation errors.
      *
-     * This method is designed to be overridden when you need to perform per row validation.
+     * Note that this validation will be executed after the default validation is executed.
      */
-    BulkDataValidationErrors customValidateRow(T row) {
+    CustomBulkDataErrors customValidateRow(T row) {
         return null  // Do nothing by default
     }
 }

--- a/src/main/groovy/org/pih/warehouse/importer/ConfiguresBulkDataValidator.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/ConfiguresBulkDataValidator.groovy
@@ -23,7 +23,7 @@ trait ConfiguresBulkDataValidator<T extends Importable> {
      * Note that this validation will be executed after the default validation is executed.
      */
     CustomBulkDataErrors customValidateAcrossRows(List<T> rows) {
-        return null  // Do nothing by default
+        return CustomBulkDataErrors.NO_ERRORS  // Do nothing by default
     }
 
     /**
@@ -33,6 +33,6 @@ trait ConfiguresBulkDataValidator<T extends Importable> {
      * Note that this validation will be executed after the default validation is executed.
      */
     CustomBulkDataErrors customValidateRow(T row) {
-        return null  // Do nothing by default
+        return CustomBulkDataErrors.NO_ERRORS  // Do nothing by default
     }
 }

--- a/src/main/groovy/org/pih/warehouse/importer/CustomBulkDataErrors.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/CustomBulkDataErrors.groovy
@@ -3,12 +3,13 @@ package org.pih.warehouse.importer
 import org.pih.warehouse.core.localization.LocalizableMessage
 
 /**
- * Wraps the errors that occur when custom validating bulk data.
+ * Wraps the errors that occur when performing custom, feature-specific bulk data operations such as
+ * in {@link ConfiguresBulkDataBinder} and {@link ConfiguresBulkDataValidator}.
  *
- * Exists solely for the purpose of making it more intuitive to implement {@link ConfiguresBulkDataValidator}
- * since we're only exposing a small number of methods here for constructing errors.
+ * The purpose of this object is to make it more intuitive to raise new bulk data errors since
+ * we're only exposing a small number of methods here for constructing errors.
  */
-class BulkDataValidationErrors {
+class CustomBulkDataErrors {
     private List<BulkDataError> errors = []
 
     List<BulkDataError> getAllErrors() {
@@ -29,11 +30,11 @@ class BulkDataValidationErrors {
                        BulkDataErrorSeverity severity=BulkDataErrorSeverity.ERROR) {
 
         errors.add(new BulkDataError(
-                row: null,  // We rely on the BulkDataValidator to set this later
-                column: null,  // We rely on the BulkDataValidator to set this later
+                row: null,  // We rely on the caller to set this later
+                column: null,  // We rely on the caller to set this later
                 fieldName: fieldName,
                 severity: severity,
-                // We rely on the BulkDataValidator to localize this message later
+                // We rely on the caller to localize this message later
                 localizableMessage: new LocalizableMessage(
                         code: errorCode,
                         args: errorArgs,
@@ -54,9 +55,9 @@ class BulkDataValidationErrors {
                         BulkDataErrorSeverity severity=BulkDataErrorSeverity.ERROR) {
 
         errors.add(new BulkDataError(
-                row: null,  // We rely on the BulkDataValidator to set this later
+                row: null,  // We rely on the caller to set this later
                 severity: severity,
-                // We rely on the BulkDataValidator to localize this message later
+                // We rely on the caller to localize this message later
                 localizableMessage: new LocalizableMessage(
                         code: errorCode,
                         args: errorArgs,

--- a/src/main/groovy/org/pih/warehouse/importer/CustomBulkDataErrors.groovy
+++ b/src/main/groovy/org/pih/warehouse/importer/CustomBulkDataErrors.groovy
@@ -10,10 +10,17 @@ import org.pih.warehouse.core.localization.LocalizableMessage
  * we're only exposing a small number of methods here for constructing errors.
  */
 class CustomBulkDataErrors {
+
+    /**
+     * Represents the state where no bulk data errors occurred.
+     */
+    static final CustomBulkDataErrors NO_ERRORS = new CustomBulkDataErrors(errors: [])
+
     private List<BulkDataError> errors = []
 
     List<BulkDataError> getAllErrors() {
-        return errors
+        // We make this immutable to control the behaviour. If you want to add an error, do it via an add*Error method.
+        return errors.asImmutable()
     }
 
     /**

--- a/src/test/groovy/org/pih/warehouse/importer/BulkDataBinderSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/importer/BulkDataBinderSpec.groovy
@@ -8,7 +8,6 @@ import testutil.MessageLocalizerStub
 import org.pih.warehouse.core.parser.DefaultTypeParser
 import org.pih.warehouse.core.parser.Parser
 import org.pih.warehouse.core.parser.ParserContext
-import org.pih.warehouse.core.parser.StringParser
 
 @Unroll
 class BulkDataBinderSpec extends Specification {
@@ -16,11 +15,12 @@ class BulkDataBinderSpec extends Specification {
     // Chosen arbitrarily. This will be stubbed so all that matters is that we're consistent.
     private static final BulkDataType BULK_DATA_TYPE = BulkDataType.PERSON
     private static final BulkDataType UNKNOWN_BULK_DATA_TYPE = BulkDataType.CATEGORY
+    private static final int VALUE_THAT_FAILS_CUSTOM_BINDING = -1
+    private static final int VALUE_THAT_WARNS_CUSTOM_BINDING = -2
 
     BulkDataBinder bulkDataBinder
 
     DefaultTypeParser defaultTypeParserStub
-    ConfiguresBulkDataBinder bulkDataBinderConfigurerStub
     Parser parserStub
 
     void setup() {
@@ -33,9 +33,8 @@ class BulkDataBinderSpec extends Specification {
             getDefaultParser(_ as Class<Object>) >> parserStub
         }
 
-        bulkDataBinderConfigurerStub = Stub(ConfiguresBulkDataBinder)
         BulkDataImportComponentResolver componentResolverStub = Stub(BulkDataImportComponentResolver) {
-            getBulkDataBinderConfigurer(BULK_DATA_TYPE) >> bulkDataBinderConfigurerStub
+            getBulkDataBinderConfigurer(BULK_DATA_TYPE) >> new BulkDataBinderConfigurerForTest()
             getBulkDataBinderConfigurer(UNKNOWN_BULK_DATA_TYPE) >> null
         }
 
@@ -57,19 +56,8 @@ class BulkDataBinderSpec extends Specification {
                 ],
         ])
 
-        and: "the config to use when data binding"
-        bulkDataBinderConfigurerStub.bulkDataBinderConfig >> new BulkDataBinderConfig(
-                bindTo: ImportableStub,
-                bulkDataType: dataImportType,
-                fields: [
-                        "stringField": new BulkDataBinderFieldConfig(),
-                        "integerField": new BulkDataBinderFieldConfig(),
-                ]
-        )
-
         and: "stubbed values for the parser to return"
         parserStub.parse("Hi", _ as ParserContext) >> "Hi"
-        parserStub.parse(1, _ as ParserContext) >> 1
 
         when:
         BulkDataBinderResult result = bulkDataBinder.bindData(dataImportType, readerResult)
@@ -89,32 +77,24 @@ class BulkDataBinderSpec extends Specification {
         BulkDataReaderResult readerResult = new BulkDataReaderResult(rows: [
                 [
                         "stringField": new BulkDataCell(row: 0, column: 0, fieldName: "stringField", value: "Hi"),
-                        "integerField": new BulkDataCell(row: 0, column: 1, fieldName: "integerField", value: 1)
+                        "integerField": new BulkDataCell(row: 0, column: 1, fieldName: "integerField", value: 1),
+                        // Not in the config!
+                        "otherField": new BulkDataCell(row: 0, column: 2, fieldName: "otherField", value: "Ignored"),
                 ],
         ])
 
-        and: "the config to use when data binding"
-        bulkDataBinderConfigurerStub.bulkDataBinderConfig >> new BulkDataBinderConfig(
-                bindTo: ImportableStub,
-                bulkDataType: dataImportType,
-                fields: [
-                        "stringField": new BulkDataBinderFieldConfig(),
-                        // integerField is not included!
-                ]
-        )
-
         and: "stubbed values for the parser to return"
         parserStub.parse("Hi", _ as ParserContext) >> "Hi"
-        parserStub.parse(1, _ as ParserContext) >> 1
 
         when:
         BulkDataBinderResult result = bulkDataBinder.bindData(dataImportType, readerResult)
         List<ImportableStub> rows = result.boundRows as List<ImportableStub>
 
-        then:
+        then: "The row is bound without errors and the non-configured field is ignored"
         assert rows.size() == 1
-        assert rows[0].stringField == "Hi"   // Should parse normally
-        assert rows[0].integerField == null  // Should be ignored
+        assert rows[0].stringField == "Hi"
+        assert rows[0].integerField == 1
+        assert !rows[0].hasProperty("otherField")
 
         assert result.bindErrors.size() == 0
     }
@@ -129,119 +109,62 @@ class BulkDataBinderSpec extends Specification {
                 ],
         ])
 
-        and: "the config to use when data binding"
-        bulkDataBinderConfigurerStub.bulkDataBinderConfig >> new BulkDataBinderConfig(
-                bindTo: ImportableStub,
-                bulkDataType: dataImportType,
-                fields: [
-                        "stringField": new BulkDataBinderFieldConfig(parser: StringParser),
-                        // Wrong type! In reality this wouldn't error because the String parser can handle integers,
-                        // but it doesn't matter because we force an error below to simulate the behaviour.
-                        "integerField": new BulkDataBinderFieldConfig(parser: StringParser),
-                ]
-        )
-
-        and: "stubbed values for the parser to return"
-        parserStub.parse("Hi", _ as ParserContext) >> "Hi"
-        parserStub.parse(1, _ as ParserContext) >> { throw new RuntimeException("PARSER ERROR") }
+        and: "parsing the stringField will fail"
+        parserStub.parse("Hi", _ as ParserContext) >> { throw new RuntimeException("PARSER ERROR") }
 
         when:
         BulkDataBinderResult result = bulkDataBinder.bindData(dataImportType, readerResult)
         List<ImportableStub> rows = result.boundRows as List<ImportableStub>
 
-        then:
+        then: "the stringField fails to be bound"
         assert rows.size() == 1
-        assert rows[0].stringField == "Hi"
-        assert rows[0].integerField == null
+        assert rows[0].stringField == null
+        assert rows[0].integerField == 1
 
+        and: "the error is returned as expected"
         assert result.bindErrors.size() == 1
         assert result.bindErrors[0].row == 0
-        assert result.bindErrors[0].column == "1"
-        assert result.bindErrors[0].fieldName == "integerField"
+        assert result.bindErrors[0].column == "0"
+        assert result.bindErrors[0].fieldName == "stringField"
         assert result.bindErrors[0].severity == BulkDataErrorSeverity.ERROR
         assert result.bindErrors[0].localizedMessage == "import.binder.error"
         assert result.bindErrors[0].exception.message == "PARSER ERROR"
     }
 
-    void "bindData should successfully custom bind data"() {
+    void "bindData should handle #expectedSeverity when custom bind data"() {
         given: "the raw data being bound"
         BulkDataType dataImportType = BULK_DATA_TYPE
         BulkDataReaderResult readerResult = new BulkDataReaderResult(rows: [
                 [
                         "stringField": new BulkDataCell(row: 0, column: 0, fieldName: "stringField", value: "Hi"),
+                        "integerField": new BulkDataCell(row: 0, column: 1, fieldName: "integerField", value: integerFieldValue),
                 ],
         ])
 
-        and: "the config to use when data binding"
-        bulkDataBinderConfigurerStub.bulkDataBinderConfig >> new BulkDataBinderConfig(
-                bindTo: ImportableStub,
-                bulkDataType: dataImportType,
-                fields: [
-                        "stringField": new BulkDataBinderFieldConfig(dataBindingMethod: DataBindingMethod.MANUAL),
-                ]
-        )
-
-        and: "the custom binding logic"
-        bulkDataBinderConfigurerStub.customBindData(_ as List, _ as BulkDataBinderResult) >> {
-            List rawRowsList, BulkDataBinderResult<ImportableStub> result ->
-
-                result.boundRows[0].stringField = "CUSTOM VALUE"
-        }
+        and: "stubbed values for the parser to return"
+        parserStub.parse("Hi", _ as ParserContext) >> "Hi"
 
         when:
         BulkDataBinderResult result = bulkDataBinder.bindData(dataImportType, readerResult)
         List<ImportableStub> rows = result.boundRows as List<ImportableStub>
 
-        then:
+        then: "the fields are still bound, despite the error"
         assert rows.size() == 1
-        assert rows[0].stringField == "CUSTOM VALUE"
+        assert rows[0].stringField == "Hi"
+        assert rows[0].integerField == integerFieldValue
 
-        assert result.bindErrors.size() == 0
-    }
-
-    void "bindData should handle errors when custom bind data"() {
-        given: "the raw data being bound"
-        BulkDataType dataImportType = BULK_DATA_TYPE
-        BulkDataReaderResult readerResult = new BulkDataReaderResult(rows: [
-                [
-                        "stringField": new BulkDataCell(row: 0, column: 0, fieldName: "stringField", value: "Hi"),
-                ],
-        ])
-
-        and: "the config to use when data binding"
-        bulkDataBinderConfigurerStub.bulkDataBinderConfig >> new BulkDataBinderConfig(
-                bindTo: ImportableStub,
-                bulkDataType: dataImportType,
-                fields: [
-                        "stringField": new BulkDataBinderFieldConfig(dataBindingMethod: DataBindingMethod.MANUAL),
-                ]
-        )
-
-        and: "the custom binding logic"
-        bulkDataBinderConfigurerStub.customBindData(_ as List, _ as BulkDataBinderResult) >> {
-            List rawRowsList, BulkDataBinderResult<ImportableStub> result ->
-
-                result.bindErrors.add(new BulkDataError(
-                        row: 0,
-                        column: 0,
-                        fieldName: "stringField",
-                        localizedMessage: "CUSTOM BINDING ERROR",
-                ))
-        }
-
-        when:
-        BulkDataBinderResult result = bulkDataBinder.bindData(dataImportType, readerResult)
-        List<ImportableStub> rows = result.boundRows as List<ImportableStub>
-
-        then:
-        assert rows.size() == 1
-        assert rows[0].stringField == null
-
+        and: "the error is returned as expected"
         assert result.bindErrors.size() == 1
         assert result.bindErrors[0].row == 0
-        assert result.bindErrors[0].column == "0"
-        assert result.bindErrors[0].fieldName == "stringField"
-        assert result.bindErrors[0].localizedMessage == "CUSTOM BINDING ERROR"
+        assert result.bindErrors[0].column == "1"
+        assert result.bindErrors[0].fieldName == "integerField"
+        assert result.bindErrors[0].localizedMessage == expectedMessage
+        assert result.bindErrors[0].severity == expectedSeverity
+
+        where:
+        integerFieldValue               || expectedMessage | expectedSeverity
+        VALUE_THAT_FAILS_CUSTOM_BINDING || "error.code"    | BulkDataErrorSeverity.ERROR
+        VALUE_THAT_WARNS_CUSTOM_BINDING || "warn.code"     | BulkDataErrorSeverity.WARNING
     }
 
     void "bindData should fail if there is no configurer associated with the given bulk data type"() {
@@ -264,5 +187,48 @@ class BulkDataBinderSpec extends Specification {
     class ImportableStub implements Importable {
         String stringField
         Integer integerField
+    }
+
+    /**
+     * A simple configurer of custom data binding for use in tests.
+     * The data binding itself is arbitrary. We just define something so that we can make assertions on it.
+     */
+    class BulkDataBinderConfigurerForTest implements ConfiguresBulkDataBinder<ImportableStub> {
+
+        @Override
+        BulkDataType getBulkDataType() {
+            return BULK_DATA_TYPE
+        }
+
+        @Override
+        BulkDataBinderConfig getBulkDataBinderConfig() {
+            return new BulkDataBinderConfig(
+                    bindTo: ImportableStub,
+                    bulkDataType: bulkDataType,
+                    fields: [
+                            "stringField": BulkDataBinderFieldConfigDefaults.DEFAULT_CONFIG,
+                            "integerField": BulkDataBinderFieldConfigDefaults.MANUALLY_BOUND,
+                    ],
+                    columnByFieldName: [
+                            "stringField": "0",
+                            "integerField": "1",
+                    ]
+            )
+        }
+
+        @Override
+        CustomBulkDataErrors customBindDataRow(Map<String, BulkDataCell> rawRow, ImportableStub boundRow) {
+            CustomBulkDataErrors errors = new CustomBulkDataErrors()
+
+            boundRow.integerField = rawRow["integerField"].value as Integer
+
+            if (boundRow.integerField == VALUE_THAT_FAILS_CUSTOM_BINDING) {
+                errors.addFieldError("integerField", "error.code")
+            }
+            if (boundRow.integerField == VALUE_THAT_WARNS_CUSTOM_BINDING) {
+                errors.addFieldError("integerField", "warn.code", null, BulkDataErrorSeverity.WARNING)
+            }
+            return errors
+        }
     }
 }

--- a/src/test/groovy/org/pih/warehouse/importer/BulkDataValidatorSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/importer/BulkDataValidatorSpec.groovy
@@ -145,8 +145,8 @@ class BulkDataValidatorSpec extends Specification {
         }
 
         @Override
-        BulkDataValidationErrors customValidateRow(ImportableForTest row) {
-            BulkDataValidationErrors errors = new BulkDataValidationErrors()
+        CustomBulkDataErrors customValidateRow(ImportableForTest row) {
+            CustomBulkDataErrors errors = new CustomBulkDataErrors()
             if (row.stringField == VALUE_THAT_FAILS_VALIDATION) {
                 errors.addFieldError("stringField", "some.code")
             }


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7778

**Description:** Refactor the data binder to make the custom binding behave like the custom validation does. Now we have two overrides/hook-ins for manual data binding:
1) customBindDataAcrossRows: for when you need access to all rows
2) customBindDataRow: for when you only need access to each row individually

I didn't want to add this to the original PR and balloon things further so I split it out into its own review.