### PR TITLE
Log request duration in UtilInterceptor

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/LoggingInterceptor.groovy
+++ b/grails-app/controllers/org/pih/warehouse/LoggingInterceptor.groovy
@@ -54,6 +54,19 @@ class LoggingInterceptor {
 
     void afterView() {
         try {
+            // Log the total request duration (controller action + view rendering). afterView() is the last phase in
+            // the request lifecycle, and _timeBeforeRequest is recorded by UtilInterceptor.before(), which runs first
+            // (HIGHEST_PRECEDENCE), so this covers essentially the entire request. We log before clearing the MDC
+            // below so that the duration line still carries the user/location/request context.
+            if (request?._timeBeforeRequest) {
+                long durationInMilliseconds = System.currentTimeMillis() - request._timeBeforeRequest
+                log.info("${request.requestURI} responded in ${durationInMilliseconds} ms")
+            }
+        } catch (Exception e) {
+            log.warn("Error occurred while logging request duration: ${e.message}", e)
+        }
+
+        try {
             MDC.remove('sessionId')
             MDC.remove('username')
             MDC.remove('location')

--- a/grails-app/controllers/org/pih/warehouse/LoggingInterceptor.groovy
+++ b/grails-app/controllers/org/pih/warehouse/LoggingInterceptor.groovy
@@ -54,19 +54,6 @@ class LoggingInterceptor {
 
     void afterView() {
         try {
-            // Log the total request duration (controller action + view rendering). afterView() is the last phase in
-            // the request lifecycle, and _timeBeforeRequest is recorded by UtilInterceptor.before(), which runs first
-            // (HIGHEST_PRECEDENCE), so this covers essentially the entire request. We log before clearing the MDC
-            // below so that the duration line still carries the user/location/request context.
-            if (request?._timeBeforeRequest) {
-                long durationInMilliseconds = System.currentTimeMillis() - request._timeBeforeRequest
-                log.info("${request.requestURI} responded in ${durationInMilliseconds} ms")
-            }
-        } catch (Exception e) {
-            log.warn("Error occurred while logging request duration: ${e.message}", e)
-        }
-
-        try {
             MDC.remove('sessionId')
             MDC.remove('username')
             MDC.remove('location')

--- a/grails-app/controllers/org/pih/warehouse/UtilInterceptor.groovy
+++ b/grails-app/controllers/org/pih/warehouse/UtilInterceptor.groovy
@@ -31,6 +31,7 @@ class UtilInterceptor {
     boolean after() {
         request._timeAfterRequest = System.currentTimeMillis()
         request?.pageLoadInMilliseconds = request?._timeAfterRequest - request?._timeBeforeRequest
+        log.info("${request.requestURI} responded in ${request.pageLoadInMilliseconds} ms")
         return true
     }
 


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:**

**Description:**

Restores logging of request duration. This was originally done in the `UtilFilters` "profiler" filter (`afterView` logged `Request duration for (...): {action}ms/{view}ms`) and was dropped during the Grails 3 migration when filters became interceptors.

`UtilInterceptor` already measures the request and stores `pageLoadInMilliseconds` (used by `_footer.gsp`), so the log simply reuses that value in `after()` rather than recomputing it:

```groovy
boolean after() {
    request._timeAfterRequest = System.currentTimeMillis()
    request?.pageLoadInMilliseconds = request?._timeAfterRequest - request?._timeBeforeRequest
    log.info("${request.requestURI} responded in ${request.pageLoadInMilliseconds} ms")
    return true
}
```

Logging in `after()` keeps the duration next to the calculation that already exists, and the MDC context (user/location/request) is still populated at this phase, so the line carries that context into console logs, New Relic, and Sentry.

---
### :camera: Screenshots & Recordings (optional)

N/A — logging-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2JYhN5bmH63GHa92JPYLY