### PR TITLE
Add PlainObjectValidator

### DIFF
--- a/grails-app/services/org/pih/warehouse/api/receiving/v2/ReceiptV2Service.groovy
+++ b/grails-app/services/org/pih/warehouse/api/receiving/v2/ReceiptV2Service.groovy
@@ -75,9 +75,7 @@ class ReceiptV2Service {
             throw new ObjectNotFoundException(shipmentId, Shipment.toString())
         }
 
-        if (!shipmentForReceiptValidator.validate(shipment)) {
-            throw new ValidationException("Shipment invalid for receipt", shipment.errors)
-        }
+        shipmentForReceiptValidator.validate(shipment)
 
         Receipt receipt = new Receipt()
         receipt.receiptNumber = receiptIdentifierService.generate(receipt)

--- a/src/main/groovy/org/pih/warehouse/core/validation/DomainValidatable.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/validation/DomainValidatable.groovy
@@ -3,13 +3,13 @@ package org.pih.warehouse.core.validation
 import org.grails.datastore.gorm.GormValidateable
 
 /**
- * Marks a domain entity as able to be validated by our custom validation logic.
+ * Marks a domain entity as able to be validated by our custom validation flow.
+ * This is achieved by hooking our custom validation into the entity's validate() method.
  *
- * Hooks into Grails validation by wrapping GormValidateable.validate() methods with additional validation.
- *
- * @param <V> Optional. The {@link Validator} component containing additional validation to perform on this object.
+ * @param <V> Optional. The {@link DomainValidator} component containing additional validation to perform on this
+ *            object. If not provided, will only validate via Grails constraints and Javax annotations.
  */
-trait DomainValidatable<V extends Validator> implements Validatable<V>, GormValidateable {
+trait DomainValidatable<V extends DomainValidator> implements Validatable<V>, GormValidateable {
 
     @Override
     boolean validate() {

--- a/src/main/groovy/org/pih/warehouse/core/validation/DomainValidator.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/validation/DomainValidator.groovy
@@ -1,15 +1,16 @@
 package org.pih.warehouse.core.validation
 
-import org.grails.datastore.gorm.GormValidateable
 import org.springframework.validation.Errors
 
 /**
- * A validator for a Grails Domain class.
+ * A validator for a {@link DomainValidatable} Grails Domain entity.
+ *
+ * Will be triggered when calling x.validate() on an instance of the target domain.
  */
-trait DomainValidator<T extends GormValidateable> implements Validator<T> {
+abstract class DomainValidator<T extends DomainValidatable> extends Validator<T> {
 
     @Override
     Errors getErrors(T toValidate) {
-        return toValidate.errors
+        return toValidate?.errors
     }
 }

--- a/src/main/groovy/org/pih/warehouse/core/validation/ObjectValidatable.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/validation/ObjectValidatable.groovy
@@ -3,13 +3,18 @@ package org.pih.warehouse.core.validation
 import grails.validation.Validateable
 
 /**
- * Marks a non-entity object (such as a Command Object) as able to be validated by our custom validation logic.
+ * Marks a Grails Validateable object (such as a Request DTO / Command Object) as able to be validated by our
+ * custom validation flow. This is achieved by hooking our custom validation into the object's validate() method.
  *
- * Hooks into Grails validation by wrapping Validateable.validate() methods with additional validation.
+ * This allows us to use the @Valid annotation. Any ObjectValidatable in a controller method declaration that
+ * is annotated with @Valid will automatically throw an exception if any of its fields are invalid.
  *
- * @param <V> Optional. The {@link Validator} component containing additional validation to perform on this object.
+ * For example: "def someAction(@Valid XCommand request) { ... }" will throw an error if the XCommand is invalid.
+ *
+ * @param <V> Optional. The {@link ObjectValidator} component containing additional validation to perform on this
+ *            object. If not provided, will only validate via Grails constraints and Javax annotations.
  */
-trait ObjectValidatable<V extends Validator> implements Validatable<V>, Validateable {
+trait ObjectValidatable<V extends ObjectValidator> implements Validatable<V>, Validateable {
 
     @Override
     boolean validate(List fieldsToValidate, Map<String, Object> params, Closure<?>... adHocConstraintsClosures) {

--- a/src/main/groovy/org/pih/warehouse/core/validation/ObjectValidator.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/validation/ObjectValidator.groovy
@@ -1,15 +1,17 @@
 package org.pih.warehouse.core.validation
 
-import grails.validation.Validateable
 import org.springframework.validation.Errors
 
 /**
- * A validator for a non-domain validatable object (such as a Command Object).
+ * A validator for an {@link ObjectValidatable} Grails object, such as a Request DTO / Command Object.
+ *
+ * Will be triggered automatically for command object instances in controller method args, or when calling
+ * x.validate() on an instance of the target object.
  */
-trait ObjectValidator<T extends Validateable> implements Validator<T> {
+abstract class ObjectValidator<T extends ObjectValidatable> extends Validator<T> {
 
     @Override
     Errors getErrors(T toValidate) {
-        return toValidate.errors
+        return toValidate?.errors
     }
 }

--- a/src/main/groovy/org/pih/warehouse/core/validation/PlainObjectValidator.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/validation/PlainObjectValidator.groovy
@@ -1,0 +1,37 @@
+package org.pih.warehouse.core.validation
+
+import org.springframework.validation.BeanPropertyBindingResult
+import org.springframework.validation.Errors
+
+/**
+ * A simple object validator that exist outside of the context of the framework.
+ *
+ * For use when your object doesn't rely on Grails or Javax validation, or for when you don't want to trigger
+ * framework validation.
+ *
+ * This is different from an {@link ObjectValidator} in that it cannot be hooked into Grails validation. You can only
+ * use this validator directly via xValidator.validate(x) calls. There is no way to hook a PlainObjectValidator into an
+ * object's x.validate() method like you can with the other {@link Validator} implementations. If you need to rely on
+ * framework validation (such as when saving domain entities or binding request DTOs), use the other validator
+ * implementations that are framework-aware.
+ *
+ * It is perfectly fine to have a PlainObjectValidator that operates on an {@link ObjectValidatable}, but know that
+ * it will ignore any Grails constraints and Javax annotations on the object.
+ */
+abstract class PlainObjectValidator<T> extends Validator<T> {
+
+    @Override
+    Errors getErrors(T toValidate) {
+        /*
+         * This validator is intentionally framework unaware, so we don't want to rely on the existence of a Grails
+         * "errors" field on the object. As such, we need to initialize our own Errors object.
+         *
+         * This also means that even if the object has an "errors" field, triggering this validator will not populate
+         * the field. You must rely on the errors field in the returned ObjectValidationResult.
+         *
+         * Counterintuitively, BeanPropertyBindingResult is the recommended Errors implementation to use, even for
+         * non-data binding errors.
+         */
+        return new BeanPropertyBindingResult(toValidate, toValidate?.class?.simpleName)
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/core/validation/Validatable.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/validation/Validatable.groovy
@@ -3,6 +3,7 @@ package org.pih.warehouse.core.validation
 import grails.util.Holders
 import grails.validation.ValidationException
 import java.lang.reflect.Method
+import java.lang.reflect.Modifier
 import java.lang.reflect.Parameter
 import javax.validation.ConstraintViolation
 import javax.validation.Valid
@@ -14,7 +15,11 @@ import org.springframework.web.context.request.RequestContextHolder
 import org.pih.warehouse.core.AppUtil
 
 /**
- * Marks a class as able to be validated by a Validator class.
+ * Hooks our custom validation logic into the validation flow of a Grails framework-aware class (such as a domain
+ * entity or request DTO).
+ *
+ * Validators that do not rely on framework behaviour (such as {@link PlainObjectValidator}) do not need their objects
+ * to implement this trait.
  *
  * There are three supported validation methods:
  * 1) Via javax.validation.constraints.* annotations: for simple validations
@@ -24,10 +29,8 @@ import org.pih.warehouse.core.AppUtil
  * When X.validate() is called, constraints defined in any/all of the above approaches will be triggered. As such,
  * you can rely on more than one of the above validation solutions at the same time.
  *
- * This also allows us to use the @Valid annotation on controller action method params. Any controller action
- * method param that is annotated with @Valid will automatically throw an exception if any of its fields are invalid.
- *
- * For example: def someAction(@Valid XCommand requestBody) { ... }
+ * @param <V> Optional. The {@link Validator} component containing additional validation to perform on this object.
+ *            If not provided, will only validate via Grails constraints and Javax annotations.
  */
 trait Validatable<V extends Validator> {
 
@@ -48,7 +51,15 @@ trait Validatable<V extends Validator> {
         boolean javaxValid = performJavaxValidation(fieldsToValidate as Set<String>)
 
         V validator = validator()
-        boolean validatorValid = validator ? validator.validate(this) : true
+
+        /*
+         * The Validator adds all of its errors to an Errors object. For all Validatable implementations,
+         * this Errors object will be the "errors" field of the Validatable. This means we don't need to parse
+         * the ObjectValidationResult here because the errors will be already attached to the object.
+         *
+         * We set errorOnFailure to false because we will throw our own exception later in this method.
+         */
+        boolean validatorValid = validator ? validator.validate(this, false).valid : true
 
         // The object is only considered valid if all of the validation steps return valid
         boolean validOverall = grailsValidationResult && javaxValid && validatorValid
@@ -109,9 +120,12 @@ trait Validatable<V extends Validator> {
     private V validator() {
         // Determines (statically but at runtime) the class type of the validator and uses that to fetch the bean.
         Class validatorClass = GenericTypeResolver.resolveTypeArgument(getClass(), Validatable.class)
-        // If no validator was specified in the class-level generic declaration, the base Validator type is what the
-        // generic will resolve to. In that case return null because it means there is no custom validator.
-        return (!validatorClass || validatorClass == Validator) ? null : AppUtil.getBean((Class<V>) validatorClass)
+        // If the validator generic is omitted in the extends clause of the Validatable (ie "X extends Validatable"
+        // instead of "X extends Validatable<XValidator>"), the generic will resolve to a non-concrete Validator
+        // implementation. In that case, return null because it means there is no custom validator to use.
+        return (!validatorClass || Modifier.isAbstract(validatorClass.modifiers)) ?
+                null :
+                AppUtil.getBean((Class<V>) validatorClass)
     }
 
     /**

--- a/src/main/groovy/org/pih/warehouse/core/validation/Validator.groovy
+++ b/src/main/groovy/org/pih/warehouse/core/validation/Validator.groovy
@@ -1,6 +1,6 @@
 package org.pih.warehouse.core.validation
 
-import org.springframework.core.GenericTypeResolver
+import grails.validation.ValidationException
 import org.springframework.validation.Errors
 import org.springframework.validation.FieldError
 import org.springframework.validation.ObjectError
@@ -8,26 +8,24 @@ import org.springframework.validation.ObjectError
 /**
  * Validates instances of some class.
  *
- * We can create validator components s for objects whose validation involves performing complex operations such as
+ * We suggest creating validator components for objects whose validation involves performing complex operations, such as
  * calling out to beans and/or making database queries. By breaking validation logic out into a separate, dedicated
  * component, we let our objects remain small and single purpose.
  *
- * This validator works in tandem with Grails Domain classes and non-domain classes that implement {@link Validatable}.
- * The validation in this class is in addition to any validation defined in the static constraints block of the object
- * as well as to any javax constraint annotations.
+ * This validator works in tandem with framework-aware objects such as Grails Domain classes and Request DTOs.
+ * As long as the framework-aware object implements {@link Validatable}, the validation in this class will be triggered
+ * alongside any validation defined in the static constraints block of the object and via javax constraint annotations.
  */
-trait Validator<T> implements org.springframework.validation.Validator {
+abstract class Validator<T> {
 
     /**
      * Contains the main validation logic for the validator. The returned ObjectValidationResult should contain
      * all validation errors that were triggered during validation.
      *
-     * Do not call this method directly! To validate an object, call {@link #validate(T)} instead.
-     *
      * @param toValidate The object instance to be validated.
      * @return ObjectValidationResult the result of the validation. Contains validation errors if there are any.
      */
-    abstract ObjectValidationResult doValidate(T toValidate)
+    protected abstract ObjectValidationResult doValidate(T toValidate)
 
     /**
      * Extracts the Errors object from the object to validate (or initializes a new Errors instance).
@@ -35,36 +33,24 @@ trait Validator<T> implements org.springframework.validation.Validator {
      */
     abstract Errors getErrors(T toValidate)
 
-    private Class<T> getClassOfValidatableObject() {
-        // Determines (at runtime) the type of the class level generic "T".
-        return (Class<T>) GenericTypeResolver.resolveTypeArgument(getClass(), Validator.class)
-    }
-
-    @Override
-    boolean supports(Class<?> clazz) {
-        return classOfValidatableObject.isAssignableFrom(clazz)
-    }
-
-    @Override
-    void validate(Object toValidate, Errors errors) {
-        if (!supports(toValidate.class)) {
-            throw new IllegalArgumentException("Validator ${getClass()} does not support validating class: ${toValidate.class}")
-        }
-
-        validate(classOfValidatableObject.cast(toValidate))
-    }
-
     /**
      * Validates the given object. The errors object associated with the object to validate will be populated
      * with any validation errors that occur.
      *
+     * It's important to note that for framework-aware Validateable objects, if you call the validator directly
+     * via xValidator.validate(x) ONLY the validator logic will be triggered. To trigger the full validation flow
+     * of the framework (which includes Grails constraints and Javax annotations), you must use the object's
+     * x.validate() method.
+     *
+     * @param toValidate The object instance to be validated.
+     * @param errorOnFailure True if we should throw an exception if validation fails.
      * @return true if the object is valid, false otherwise.
      */
-    boolean validate(T toValidate) {
+    ObjectValidationResult validate(T toValidate, boolean errorOnFailure = true) {
         // We do not clear errors before validating because we assume that will be handled by the framework.
         ObjectValidationResult results = doValidate(toValidate)
         if (results.valid) {
-            return true
+            return results
         }
 
         // If there are errors, we add them all to the "errors" field of the object being validated.
@@ -84,7 +70,12 @@ trait Validator<T> implements org.springframework.validation.Validator {
                     throw new IllegalArgumentException("Unknown error type ${error.class}")
             }
         }
-        return !errors.hasErrors()
+
+        if (errorOnFailure) {
+            throw new ValidationException("Validation failed for ${toValidate?.class?.simpleName}", errors)
+        }
+
+        return results
     }
 
     /**
@@ -95,7 +86,10 @@ trait Validator<T> implements org.springframework.validation.Validator {
      * @param errorCode The l10n message key containing the message to display when rendering the errors of the entity.
      * @param errorArgs Values to use for any args contained within the errorCode message
      */
-    FieldError rejectField(String fieldName, Object rejectedValue, String errorCode, Object[] errorArgs=null) {
+    protected FieldError rejectField(String fieldName,
+                                     Object rejectedValue,
+                                     String errorCode,
+                                     Object[] errorArgs=null) {
         return new FieldError(
                 "Object",  // objectName will be set automatically when adding the errors to the object being validated.
                 fieldName,
@@ -109,12 +103,10 @@ trait Validator<T> implements org.springframework.validation.Validator {
     /**
      * Mark the object itself as invalid. For use when not validating a specific field.
      *
-     * @param field The name of the field that failed validation
      * @param errorCode The l10n message key containing the message to display when rendering the errors of the entity.
      * @param errorArgs Values to use for any args contained within the errorCode message
      */
-    ObjectError rejectObject(Errors errors, String field, String errorCode, Object[] errorArgs=null) {
-        errors.rejectValue(field, errorCode, errorArgs, null)
+    protected ObjectError rejectObject(String errorCode, Object[] errorArgs=null) {
         return new ObjectError(
                 "Object",  // objectName will be set automatically when adding the errors to the object being validated.
                 [errorCode] as String[],

--- a/src/main/groovy/org/pih/warehouse/product/ProductAssociationValidator.groovy
+++ b/src/main/groovy/org/pih/warehouse/product/ProductAssociationValidator.groovy
@@ -6,10 +6,10 @@ import org.springframework.stereotype.Component
 import org.springframework.validation.ObjectError
 
 @Component
-class ProductAssociationValidator implements DomainValidator<ProductAssociation> {
+class ProductAssociationValidator extends DomainValidator<ProductAssociation> {
 
     @Override
-    ObjectValidationResult doValidate(ProductAssociation productAssociation) {
+    protected ObjectValidationResult doValidate(ProductAssociation productAssociation) {
         return new ObjectValidationResult(
                 validateDuplicates(productAssociation),
         )

--- a/src/main/groovy/org/pih/warehouse/product/ProductValidator.groovy
+++ b/src/main/groovy/org/pih/warehouse/product/ProductValidator.groovy
@@ -14,7 +14,7 @@ import org.pih.warehouse.shipping.ShipmentService
 import org.pih.warehouse.shipping.ShipmentStatusCode
 
 @Component
-class ProductValidator implements DomainValidator<Product> {
+class ProductValidator extends DomainValidator<Product> {
 
     private static String ACTIVE_FIELD_NAME = "active"
 
@@ -28,7 +28,7 @@ class ProductValidator implements DomainValidator<Product> {
     ShipmentService shipmentService
 
     @Override
-    ObjectValidationResult doValidate(Product product) {
+    protected ObjectValidationResult doValidate(Product product) {
         return new ObjectValidationResult(
                 validateActive(product),
         )

--- a/src/main/groovy/org/pih/warehouse/receiving/ReceiptCompleteRequestCommandValidator.groovy
+++ b/src/main/groovy/org/pih/warehouse/receiving/ReceiptCompleteRequestCommandValidator.groovy
@@ -7,10 +7,10 @@ import org.pih.warehouse.core.validation.ObjectValidationResult
 import org.pih.warehouse.core.validation.ObjectValidator
 
 @Component
-class ReceiptCompleteRequestCommandValidator implements ObjectValidator<ReceiptCompleteRequestCommand> {
+class ReceiptCompleteRequestCommandValidator extends ObjectValidator<ReceiptCompleteRequestCommand> {
 
     @Override
-    ObjectValidationResult doValidate(ReceiptCompleteRequestCommand command) {
+    protected ObjectValidationResult doValidate(ReceiptCompleteRequestCommand command) {
         return new ObjectValidationResult(
                 validateReceiptIsPending(command),
                 validateReceiptIsV2(command),

--- a/src/main/groovy/org/pih/warehouse/receiving/ReceiptEditReceivingInfoCommandValidator.groovy
+++ b/src/main/groovy/org/pih/warehouse/receiving/ReceiptEditReceivingInfoCommandValidator.groovy
@@ -7,10 +7,10 @@ import org.pih.warehouse.core.validation.ObjectValidationResult
 import org.pih.warehouse.core.validation.ObjectValidator
 
 @Component
-class ReceiptEditReceivingInfoCommandValidator implements ObjectValidator<ReceiptEditReceivingInfoCommand> {
+class ReceiptEditReceivingInfoCommandValidator extends ObjectValidator<ReceiptEditReceivingInfoCommand> {
 
     @Override
-    ObjectValidationResult doValidate(ReceiptEditReceivingInfoCommand command) {
+    protected ObjectValidationResult doValidate(ReceiptEditReceivingInfoCommand command) {
         return new ObjectValidationResult(
                 validateReceiptIsPending(command),
                 validateItemsToSaveAreValid(command),

--- a/src/main/groovy/org/pih/warehouse/receiving/ReceiptItemCommentCreateCommandValidator.groovy
+++ b/src/main/groovy/org/pih/warehouse/receiving/ReceiptItemCommentCreateCommandValidator.groovy
@@ -7,10 +7,10 @@ import org.pih.warehouse.core.validation.ObjectValidationResult
 import org.pih.warehouse.core.validation.ObjectValidator
 
 @Component
-class ReceiptItemCommentCreateCommandValidator implements ObjectValidator<ReceiptItemCommentCreateCommand> {
+class ReceiptItemCommentCreateCommandValidator extends ObjectValidator<ReceiptItemCommentCreateCommand> {
 
     @Override
-    ObjectValidationResult doValidate(ReceiptItemCommentCreateCommand command) {
+    protected ObjectValidationResult doValidate(ReceiptItemCommentCreateCommand command) {
         return new ObjectValidationResult(
                 validateReceiptItemHasNoComment(command),
         )

--- a/src/main/groovy/org/pih/warehouse/receiving/ReceiptItemCommentUpdateCommandValidator.groovy
+++ b/src/main/groovy/org/pih/warehouse/receiving/ReceiptItemCommentUpdateCommandValidator.groovy
@@ -7,10 +7,10 @@ import org.pih.warehouse.core.validation.ObjectValidationResult
 import org.pih.warehouse.core.validation.ObjectValidator
 
 @Component
-class ReceiptItemCommentUpdateCommandValidator implements ObjectValidator<ReceiptItemCommentUpdateCommand> {
+class ReceiptItemCommentUpdateCommandValidator extends ObjectValidator<ReceiptItemCommentUpdateCommand> {
 
     @Override
-    ObjectValidationResult doValidate(ReceiptItemCommentUpdateCommand command) {
+    protected ObjectValidationResult doValidate(ReceiptItemCommentUpdateCommand command) {
         return new ObjectValidationResult(
                 validateReceiptItemHasComment(command),
         )

--- a/src/main/groovy/org/pih/warehouse/receiving/ReceiptItemsBatchRequestValidator.groovy
+++ b/src/main/groovy/org/pih/warehouse/receiving/ReceiptItemsBatchRequestValidator.groovy
@@ -7,10 +7,10 @@ import org.pih.warehouse.core.validation.ObjectValidationResult
 import org.pih.warehouse.core.validation.ObjectValidator
 
 @Component
-class ReceiptItemsBatchRequestValidator implements ObjectValidator<ReceiptItemsBatchRequest> {
+class ReceiptItemsBatchRequestValidator extends ObjectValidator<ReceiptItemsBatchRequest> {
 
     @Override
-    ObjectValidationResult doValidate(ReceiptItemsBatchRequest request) {
+    protected ObjectValidationResult doValidate(ReceiptItemsBatchRequest request) {
         return new ObjectValidationResult(
                 validateReceiptIsPending(request),
                 validateItemsToSaveAreValid(request),

--- a/src/main/groovy/org/pih/warehouse/receiving/ShipmentForReceiptValidator.groovy
+++ b/src/main/groovy/org/pih/warehouse/receiving/ShipmentForReceiptValidator.groovy
@@ -5,8 +5,8 @@ import org.springframework.validation.ObjectError
 
 import org.pih.warehouse.api.receiving.v2.ReceiptV2Service
 import org.pih.warehouse.core.Location
-import org.pih.warehouse.core.validation.DomainValidator
 import org.pih.warehouse.core.validation.ObjectValidationResult
+import org.pih.warehouse.core.validation.PlainObjectValidator
 import org.pih.warehouse.shipping.Shipment
 import org.pih.warehouse.shipping.ShipmentStatusCode
 
@@ -15,14 +15,14 @@ import org.pih.warehouse.shipping.ShipmentStatusCode
  * while {@link #validateForReceivingAccess} answers whether the user may work on the receiving.
  */
 @Component
-class ShipmentForReceiptValidator implements DomainValidator<Shipment> {
+class ShipmentForReceiptValidator extends PlainObjectValidator<Shipment> {
 
     /**
      * Whether a new receipt can be opened on the shipment: it has to be shipped, have something left to receive,
      * and not already carry a pending receipt.
      */
     @Override
-    ObjectValidationResult doValidate(Shipment shipment) {
+    protected ObjectValidationResult doValidate(Shipment shipment) {
         return new ObjectValidationResult(
                 validateShipmentHasBeenShipped(shipment),
                 validateShipmentNotFullyReceived(shipment),

--- a/src/test/groovy/org/pih/warehouse/api/receiving/v2/ReceiptV2ServiceSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/api/receiving/v2/ReceiptV2ServiceSpec.groovy
@@ -209,8 +209,8 @@ class ReceiptV2ServiceSpec extends Specification implements ServiceUnitTest<Rece
         service.startReceipt(shipment.id)
 
         then:
-        thrown(ValidationException)
-        assert shipment.errors.getFieldError("receipts").code == "shipment.pendingReceiptExists.message"
+        ValidationException e = thrown(ValidationException)
+        assert e.errors.getFieldError("receipts").code == "shipment.pendingReceiptExists.message"
     }
 
     void 'startReceipt should reject a shipment that has not been shipped yet'() {
@@ -224,8 +224,8 @@ class ReceiptV2ServiceSpec extends Specification implements ServiceUnitTest<Rece
         service.startReceipt(shipment.id)
 
         then:
-        thrown(ValidationException)
-        assert shipment.errors.getFieldError("currentStatus").code == "stockMovement.hasNotBeenShipped.message"
+        ValidationException e = thrown(ValidationException)
+        assert e.errors.getFieldError("currentStatus").code == "stockMovement.hasNotBeenShipped.message"
     }
 
     void 'startReceipt should reject a shipment already fully consumed by lines received against an edited product'() {
@@ -242,8 +242,8 @@ class ReceiptV2ServiceSpec extends Specification implements ServiceUnitTest<Rece
         service.startReceipt(shipment.id)
 
         then: 'the legacy product-filtered check would still see 60 to receive - the v2 math rejects the start'
-        thrown(ValidationException)
-        assert shipment.errors.getFieldError("shipmentItems").code == "stockMovement.hasAlreadyBeenReceived.message"
+        ValidationException e = thrown(ValidationException)
+        assert e.errors.getFieldError("shipmentItems").code == "stockMovement.hasAlreadyBeenReceived.message"
     }
 
     // ----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
@alannadolny I didn't know where to do this so I'm testing out making a PR stack.

I modified how the validators work in response to your PR. I added the `PlainObjectValidator` for the case you've ran into: where you only care about triggering the specific validation that you've defined in the validator (and don't want to trigger Grails constraint validation on the object).

I tested it out and the validation error seems to work the same as it does in your PR.