### PR TITLE
Fix upgrade failure when new event log tables FK into converted tables

### DIFF
--- a/grails-app/migrations/0.9.x/changelog-2026-02-10-0000-create-table-event-log.xml
+++ b/grails-app/migrations/0.9.x/changelog-2026-02-10-0000-create-table-event-log.xml
@@ -50,6 +50,20 @@
         </createTable>
     </changeSet>
 
+    <changeSet author="christianallen" id="100220260000-1-align-event_id" dbms="mysql,mariadb">
+        <comment>Align event_log.event_id charset/collation to event.id before adding the FK; no-op when they already match or when the schema is not as expected.</comment>
+        <sql><![CDATA[
+SET @ref_charset = (SELECT c.CHARACTER_SET_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'event' AND c.COLUMN_NAME = 'id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @ref_collation = (SELECT c.COLLATION_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'event' AND c.COLUMN_NAME = 'id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @cur_collation = (SELECT c.COLLATION_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'event_log' AND c.COLUMN_NAME = 'event_id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @cur_shape = (SELECT CONCAT(c.DATA_TYPE, ':', c.CHARACTER_MAXIMUM_LENGTH, ':', c.IS_NULLABLE) FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'event_log' AND c.COLUMN_NAME = 'event_id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @align_ddl = IF(@ref_charset IS NULL OR @ref_collation IS NULL OR @cur_collation IS NULL OR @cur_shape IS NULL OR @cur_collation = @ref_collation OR @cur_shape <> 'char:38:YES', 'SELECT 1', CONCAT('ALTER TABLE `event_log` MODIFY `event_id` CHAR(38) CHARACTER SET ', @ref_charset, ' COLLATE ', @ref_collation, ' NULL'));
+PREPARE align_stmt FROM @align_ddl;
+EXECUTE align_stmt;
+DEALLOCATE PREPARE align_stmt;
+]]></sql>
+    </changeSet>
+
     <changeSet author="ewaterman" id="100220260000-1">
         <preConditions onFail="MARK_RAN">
             <not>
@@ -65,6 +79,20 @@
                 referencedColumnNames="id"
                 referencedTableName="event"
         />
+    </changeSet>
+
+    <changeSet author="christianallen" id="100220260000-2-align-location_id" dbms="mysql,mariadb">
+        <comment>Align event_log.location_id charset/collation to location.id before adding the FK; no-op when they already match or when the schema is not as expected.</comment>
+        <sql><![CDATA[
+SET @ref_charset = (SELECT c.CHARACTER_SET_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'location' AND c.COLUMN_NAME = 'id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @ref_collation = (SELECT c.COLLATION_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'location' AND c.COLUMN_NAME = 'id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @cur_collation = (SELECT c.COLLATION_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'event_log' AND c.COLUMN_NAME = 'location_id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @cur_shape = (SELECT CONCAT(c.DATA_TYPE, ':', c.CHARACTER_MAXIMUM_LENGTH, ':', c.IS_NULLABLE) FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'event_log' AND c.COLUMN_NAME = 'location_id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @align_ddl = IF(@ref_charset IS NULL OR @ref_collation IS NULL OR @cur_collation IS NULL OR @cur_shape IS NULL OR @cur_collation = @ref_collation OR @cur_shape <> 'char:38:YES', 'SELECT 1', CONCAT('ALTER TABLE `event_log` MODIFY `location_id` CHAR(38) CHARACTER SET ', @ref_charset, ' COLLATE ', @ref_collation, ' NULL'));
+PREPARE align_stmt FROM @align_ddl;
+EXECUTE align_stmt;
+DEALLOCATE PREPARE align_stmt;
+]]></sql>
     </changeSet>
 
     <changeSet author="ewaterman" id="100220260000-2">
@@ -84,6 +112,20 @@
         />
     </changeSet>
 
+    <changeSet author="christianallen" id="100220260000-3-align-created_by_id" dbms="mysql,mariadb">
+        <comment>Align event_log.created_by_id charset/collation to user.id before adding the FK; no-op when they already match or when the schema is not as expected.</comment>
+        <sql><![CDATA[
+SET @ref_charset = (SELECT c.CHARACTER_SET_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'user' AND c.COLUMN_NAME = 'id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @ref_collation = (SELECT c.COLLATION_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'user' AND c.COLUMN_NAME = 'id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @cur_collation = (SELECT c.COLLATION_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'event_log' AND c.COLUMN_NAME = 'created_by_id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @cur_shape = (SELECT CONCAT(c.DATA_TYPE, ':', c.CHARACTER_MAXIMUM_LENGTH, ':', c.IS_NULLABLE) FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'event_log' AND c.COLUMN_NAME = 'created_by_id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @align_ddl = IF(@ref_charset IS NULL OR @ref_collation IS NULL OR @cur_collation IS NULL OR @cur_shape IS NULL OR @cur_collation = @ref_collation OR @cur_shape <> 'char:38:NO', 'SELECT 1', CONCAT('ALTER TABLE `event_log` MODIFY `created_by_id` CHAR(38) CHARACTER SET ', @ref_charset, ' COLLATE ', @ref_collation, ' NOT NULL'));
+PREPARE align_stmt FROM @align_ddl;
+EXECUTE align_stmt;
+DEALLOCATE PREPARE align_stmt;
+]]></sql>
+    </changeSet>
+
     <changeSet author="ewaterman" id="100220260000-3">
         <preConditions onFail="MARK_RAN">
             <not>
@@ -99,6 +141,20 @@
                 referencedColumnNames="id"
                 referencedTableName="user"
         />
+    </changeSet>
+
+    <changeSet author="christianallen" id="100220260000-4-align-updated_by_id" dbms="mysql,mariadb">
+        <comment>Align event_log.updated_by_id charset/collation to user.id before adding the FK; no-op when they already match or when the schema is not as expected.</comment>
+        <sql><![CDATA[
+SET @ref_charset = (SELECT c.CHARACTER_SET_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'user' AND c.COLUMN_NAME = 'id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @ref_collation = (SELECT c.COLLATION_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'user' AND c.COLUMN_NAME = 'id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @cur_collation = (SELECT c.COLLATION_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'event_log' AND c.COLUMN_NAME = 'updated_by_id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @cur_shape = (SELECT CONCAT(c.DATA_TYPE, ':', c.CHARACTER_MAXIMUM_LENGTH, ':', c.IS_NULLABLE) FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'event_log' AND c.COLUMN_NAME = 'updated_by_id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @align_ddl = IF(@ref_charset IS NULL OR @ref_collation IS NULL OR @cur_collation IS NULL OR @cur_shape IS NULL OR @cur_collation = @ref_collation OR @cur_shape <> 'char:38:NO', 'SELECT 1', CONCAT('ALTER TABLE `event_log` MODIFY `updated_by_id` CHAR(38) CHARACTER SET ', @ref_charset, ' COLLATE ', @ref_collation, ' NOT NULL'));
+PREPARE align_stmt FROM @align_ddl;
+EXECUTE align_stmt;
+DEALLOCATE PREPARE align_stmt;
+]]></sql>
     </changeSet>
 
     <changeSet author="ewaterman" id="100220260000-4">

--- a/grails-app/migrations/0.9.x/changelog-2026-02-10-1200-create-table-shipment-event-log.xml
+++ b/grails-app/migrations/0.9.x/changelog-2026-02-10-1200-create-table-shipment-event-log.xml
@@ -22,6 +22,20 @@
         </createTable>
     </changeSet>
 
+    <changeSet author="christianallen" id="100220261200-1-align-shipment_id" dbms="mysql,mariadb">
+        <comment>Align shipment_event_log.shipment_id charset/collation to shipment.id before adding the FK; no-op when they already match or when the schema is not as expected.</comment>
+        <sql><![CDATA[
+SET @ref_charset = (SELECT c.CHARACTER_SET_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'shipment' AND c.COLUMN_NAME = 'id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @ref_collation = (SELECT c.COLLATION_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'shipment' AND c.COLUMN_NAME = 'id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @cur_collation = (SELECT c.COLLATION_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'shipment_event_log' AND c.COLUMN_NAME = 'shipment_id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @cur_shape = (SELECT CONCAT(c.DATA_TYPE, ':', c.CHARACTER_MAXIMUM_LENGTH, ':', c.IS_NULLABLE) FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'shipment_event_log' AND c.COLUMN_NAME = 'shipment_id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @align_ddl = IF(@ref_charset IS NULL OR @ref_collation IS NULL OR @cur_collation IS NULL OR @cur_shape IS NULL OR @cur_collation = @ref_collation OR @cur_shape <> 'char:38:NO', 'SELECT 1', CONCAT('ALTER TABLE `shipment_event_log` MODIFY `shipment_id` CHAR(38) CHARACTER SET ', @ref_charset, ' COLLATE ', @ref_collation, ' NOT NULL'));
+PREPARE align_stmt FROM @align_ddl;
+EXECUTE align_stmt;
+DEALLOCATE PREPARE align_stmt;
+]]></sql>
+    </changeSet>
+
     <changeSet author="ewaterman" id="100220261200-1">
         <preConditions onFail="MARK_RAN">
             <not>
@@ -37,6 +51,20 @@
                 referencedColumnNames="id"
                 referencedTableName="shipment"
         />
+    </changeSet>
+
+    <changeSet author="christianallen" id="100220261200-2-align-event_log_id" dbms="mysql,mariadb">
+        <comment>Align shipment_event_log.event_log_id charset/collation to event_log.id before adding the FK; no-op when they already match or when the schema is not as expected.</comment>
+        <sql><![CDATA[
+SET @ref_charset = (SELECT c.CHARACTER_SET_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'event_log' AND c.COLUMN_NAME = 'id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @ref_collation = (SELECT c.COLLATION_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'event_log' AND c.COLUMN_NAME = 'id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @cur_collation = (SELECT c.COLLATION_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'shipment_event_log' AND c.COLUMN_NAME = 'event_log_id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @cur_shape = (SELECT CONCAT(c.DATA_TYPE, ':', c.CHARACTER_MAXIMUM_LENGTH, ':', c.IS_NULLABLE) FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'shipment_event_log' AND c.COLUMN_NAME = 'event_log_id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @align_ddl = IF(@ref_charset IS NULL OR @ref_collation IS NULL OR @cur_collation IS NULL OR @cur_shape IS NULL OR @cur_collation = @ref_collation OR @cur_shape <> 'char:38:NO', 'SELECT 1', CONCAT('ALTER TABLE `shipment_event_log` MODIFY `event_log_id` CHAR(38) CHARACTER SET ', @ref_charset, ' COLLATE ', @ref_collation, ' NOT NULL'));
+PREPARE align_stmt FROM @align_ddl;
+EXECUTE align_stmt;
+DEALLOCATE PREPARE align_stmt;
+]]></sql>
     </changeSet>
 
     <changeSet author="ewaterman" id="100220261200-2">

--- a/grails-app/migrations/0.9.x/changelog-2026-03-30-0000-create-table-order-event-log.xml
+++ b/grails-app/migrations/0.9.x/changelog-2026-03-30-0000-create-table-order-event-log.xml
@@ -22,6 +22,20 @@
         </createTable>
     </changeSet>
 
+    <changeSet author="christianallen" id="300320260000-1-align-order_id" dbms="mysql,mariadb">
+        <comment>Align order_event_log.order_id charset/collation to order.id before adding the FK; no-op when they already match or when the schema is not as expected.</comment>
+        <sql><![CDATA[
+SET @ref_charset = (SELECT c.CHARACTER_SET_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'order' AND c.COLUMN_NAME = 'id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @ref_collation = (SELECT c.COLLATION_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'order' AND c.COLUMN_NAME = 'id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @cur_collation = (SELECT c.COLLATION_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'order_event_log' AND c.COLUMN_NAME = 'order_id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @cur_shape = (SELECT CONCAT(c.DATA_TYPE, ':', c.CHARACTER_MAXIMUM_LENGTH, ':', c.IS_NULLABLE) FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'order_event_log' AND c.COLUMN_NAME = 'order_id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @align_ddl = IF(@ref_charset IS NULL OR @ref_collation IS NULL OR @cur_collation IS NULL OR @cur_shape IS NULL OR @cur_collation = @ref_collation OR @cur_shape <> 'char:38:NO', 'SELECT 1', CONCAT('ALTER TABLE `order_event_log` MODIFY `order_id` CHAR(38) CHARACTER SET ', @ref_charset, ' COLLATE ', @ref_collation, ' NOT NULL'));
+PREPARE align_stmt FROM @align_ddl;
+EXECUTE align_stmt;
+DEALLOCATE PREPARE align_stmt;
+]]></sql>
+    </changeSet>
+
     <changeSet author="ewaterman" id="300320260000-1">
         <preConditions onFail="MARK_RAN">
             <not>
@@ -37,6 +51,20 @@
                 referencedColumnNames="id"
                 referencedTableName="order"
         />
+    </changeSet>
+
+    <changeSet author="christianallen" id="300320260000-2-align-event_log_id" dbms="mysql,mariadb">
+        <comment>Align order_event_log.event_log_id charset/collation to event_log.id before adding the FK; no-op when they already match or when the schema is not as expected.</comment>
+        <sql><![CDATA[
+SET @ref_charset = (SELECT c.CHARACTER_SET_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'event_log' AND c.COLUMN_NAME = 'id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @ref_collation = (SELECT c.COLLATION_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'event_log' AND c.COLUMN_NAME = 'id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @cur_collation = (SELECT c.COLLATION_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'order_event_log' AND c.COLUMN_NAME = 'event_log_id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @cur_shape = (SELECT CONCAT(c.DATA_TYPE, ':', c.CHARACTER_MAXIMUM_LENGTH, ':', c.IS_NULLABLE) FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = 'order_event_log' AND c.COLUMN_NAME = 'event_log_id' AND t.TABLE_TYPE = 'BASE TABLE');
+SET @align_ddl = IF(@ref_charset IS NULL OR @ref_collation IS NULL OR @cur_collation IS NULL OR @cur_shape IS NULL OR @cur_collation = @ref_collation OR @cur_shape <> 'char:38:NO', 'SELECT 1', CONCAT('ALTER TABLE `order_event_log` MODIFY `event_log_id` CHAR(38) CHARACTER SET ', @ref_charset, ' COLLATE ', @ref_collation, ' NOT NULL'));
+PREPARE align_stmt FROM @align_ddl;
+EXECUTE align_stmt;
+DEALLOCATE PREPARE align_stmt;
+]]></sql>
     </changeSet>
 
     <changeSet author="ewaterman" id="300320260000-2">

--- a/src/integration-test/groovy/org/pih/warehouse/smoke/spec/MigrationCharsetAlignmentSpec.groovy
+++ b/src/integration-test/groovy/org/pih/warehouse/smoke/spec/MigrationCharsetAlignmentSpec.groovy
@@ -1,0 +1,155 @@
+package org.pih.warehouse.smoke.spec
+
+import javax.sql.DataSource
+
+import groovy.sql.Sql
+import org.springframework.beans.factory.annotation.Autowired
+
+import org.pih.warehouse.smoke.spec.base.SmokeSpec
+
+/**
+ * Tests the charset-alignment changesets that guard the event log foreign keys
+ * (0.9.x create-table-event-log / shipment-event-log / order-event-log).
+ *
+ * New tables inherit the database default charset, so on databases whose
+ * referenced tables carry a different charset (converted over time on
+ * long-lived installs) the FK adds fail with errno 150. The alignment
+ * changesets convert each FK child column to whatever its referenced column
+ * actually uses, and no-op everywhere else. The mechanism cases below build
+ * scratch tables with deliberately mismatched collations, since the test
+ * database itself is charset-uniform (see testcontainers/my.cnf).
+ */
+class MigrationCharsetAlignmentSpec extends SmokeSpec {
+
+    private static final List<String> EVENT_LOG_FK_NAMES = [
+            'fk_event_log_event',
+            'fk_event_log_location',
+            'fk_event_log_created_by',
+            'fk_event_log_updated_by',
+            'fk_shipment_event_log_shipment',
+            'fk_shipment_event_log_event_log',
+            'fk_order_event_log_order',
+            'fk_order_event_log_event_log',
+    ]
+
+    @Autowired
+    DataSource dataSource
+
+    // A single cached connection so the SET @... session variables used by the
+    // alignment SQL survive across statements, exactly as they do when
+    // Liquibase runs a multi-statement <sql> changeset on one connection.
+    Sql sql
+
+    void setup() {
+        sql = new Sql(dataSource.connection)
+        dropScratchTables()
+    }
+
+    void cleanup() {
+        try {
+            dropScratchTables()
+        } finally {
+            sql?.close()
+        }
+    }
+
+    private void dropScratchTables() {
+        sql.execute('DROP TABLE IF EXISTS mcas_child')
+        sql.execute('DROP TABLE IF EXISTS mcas_parent')
+    }
+
+    /**
+     * Runs the same guarded statement sequence the alignment changesets use,
+     * targeting a scratch child/parent column pair.
+     */
+    private void runAlignment(String childTable, String childColumn, String parentTable, String expectedShape, String nullability) {
+        sql.execute("SET @ref_charset = (SELECT c.CHARACTER_SET_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = '${parentTable}' AND c.COLUMN_NAME = 'id' AND t.TABLE_TYPE = 'BASE TABLE')".toString())
+        sql.execute("SET @ref_collation = (SELECT c.COLLATION_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = '${parentTable}' AND c.COLUMN_NAME = 'id' AND t.TABLE_TYPE = 'BASE TABLE')".toString())
+        sql.execute("SET @cur_collation = (SELECT c.COLLATION_NAME FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = '${childTable}' AND c.COLUMN_NAME = '${childColumn}' AND t.TABLE_TYPE = 'BASE TABLE')".toString())
+        sql.execute("SET @cur_shape = (SELECT CONCAT(c.DATA_TYPE, ':', c.CHARACTER_MAXIMUM_LENGTH, ':', c.IS_NULLABLE) FROM information_schema.COLUMNS c JOIN information_schema.TABLES t ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = '${childTable}' AND c.COLUMN_NAME = '${childColumn}' AND t.TABLE_TYPE = 'BASE TABLE')".toString())
+        sql.execute("SET @align_ddl = IF(@ref_charset IS NULL OR @ref_collation IS NULL OR @cur_collation IS NULL OR @cur_shape IS NULL OR @cur_collation = @ref_collation OR @cur_shape <> '${expectedShape}', 'SELECT 1', CONCAT('ALTER TABLE `${childTable}` MODIFY `${childColumn}` CHAR(38) CHARACTER SET ', @ref_charset, ' COLLATE ', @ref_collation, ' ${nullability}'))".toString())
+        sql.execute('PREPARE align_stmt FROM @align_ddl')
+        sql.execute('EXECUTE align_stmt')
+        sql.execute('DEALLOCATE PREPARE align_stmt')
+    }
+
+    private String collationOf(String table, String column) {
+        sql.firstRow("SELECT COLLATION_NAME AS c FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :t AND COLUMN_NAME = :c", [t: table, c: column]).c
+    }
+
+    void "event log migrations applied cleanly with all foreign keys and column definitions intact"() {
+        when:
+        List<String> fkNames = sql.rows("""
+            SELECT CONSTRAINT_NAME AS name FROM information_schema.REFERENTIAL_CONSTRAINTS
+            WHERE CONSTRAINT_SCHEMA = DATABASE() AND CONSTRAINT_NAME IN ('${EVENT_LOG_FK_NAMES.join("','")}')
+        """.toString())*.name
+
+        List<Map> columns = sql.rows("""
+            SELECT TABLE_NAME AS tbl, COLUMN_NAME AS col, DATA_TYPE AS dataType,
+                   CHARACTER_MAXIMUM_LENGTH AS maxLength, IS_NULLABLE AS nullable
+            FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME IN ('event_log', 'shipment_event_log', 'order_event_log')
+              AND COLUMN_NAME IN ('event_id', 'location_id', 'created_by_id', 'updated_by_id',
+                                  'shipment_id', 'order_id', 'event_log_id')
+        """.toString())
+
+        then:
+        // The alignment changesets ran during boot migrations (no-op path on
+        // this charset-uniform database) and every FK still got created.
+        assert fkNames.toSet() == EVENT_LOG_FK_NAMES.toSet()
+
+        // Column definitions were not altered by the alignment changesets.
+        assert columns.every { it.dataType == 'char' && it.maxLength == 38 }
+        assert columns.findAll { it.tbl == 'event_log' && it.col in ['event_id', 'location_id'] }.every { it.nullable == 'YES' }
+        assert columns.findAll { !(it.tbl == 'event_log' && it.col in ['event_id', 'location_id']) }.every { it.nullable == 'NO' }
+    }
+
+    void "alignment converts a mismatched child column to the referenced column's charset so the FK add succeeds"() {
+        given:
+        // Parent deliberately differs from the database default charset.
+        sql.execute('CREATE TABLE mcas_parent (id CHAR(38) NOT NULL PRIMARY KEY) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci')
+        sql.execute('CREATE TABLE mcas_child (id CHAR(38) NOT NULL PRIMARY KEY, parent_id CHAR(38) NULL)')
+        assert collationOf('mcas_child', 'parent_id') != collationOf('mcas_parent', 'id')
+
+        when:
+        runAlignment('mcas_child', 'parent_id', 'mcas_parent', 'char:38:YES', 'NULL')
+
+        then:
+        assert collationOf('mcas_child', 'parent_id') == collationOf('mcas_parent', 'id')
+
+        when:
+        sql.execute('ALTER TABLE mcas_child ADD CONSTRAINT fk_mcas_parent FOREIGN KEY (parent_id) REFERENCES mcas_parent (id)')
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "alignment leaves the child column untouched when collations already match"() {
+        given:
+        sql.execute('CREATE TABLE mcas_parent (id CHAR(38) NOT NULL PRIMARY KEY)')
+        sql.execute('CREATE TABLE mcas_child (id CHAR(38) NOT NULL PRIMARY KEY, parent_id CHAR(38) NULL)')
+        String before = collationOf('mcas_child', 'parent_id')
+        assert before == collationOf('mcas_parent', 'id')
+
+        when:
+        runAlignment('mcas_child', 'parent_id', 'mcas_parent', 'char:38:YES', 'NULL')
+
+        then:
+        assert collationOf('mcas_child', 'parent_id') == before
+    }
+
+    void "alignment no-ops when the child column does not have the expected definition"() {
+        given:
+        sql.execute('CREATE TABLE mcas_parent (id CHAR(38) NOT NULL PRIMARY KEY) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci')
+        sql.execute('CREATE TABLE mcas_child (id CHAR(38) NOT NULL PRIMARY KEY, parent_id VARCHAR(38) NULL)')
+
+        when:
+        runAlignment('mcas_child', 'parent_id', 'mcas_parent', 'char:38:YES', 'NULL')
+
+        then:
+        // Drifted definition: left exactly as found, never rewritten.
+        Map row = sql.firstRow("SELECT DATA_TYPE AS dataType, CHARACTER_MAXIMUM_LENGTH AS maxLength FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'mcas_child' AND COLUMN_NAME = 'parent_id'")
+        assert row.dataType == 'varchar' && row.maxLength == 38
+    }
+}


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:** Part of #2401

**Description:**

**Symptom.** Upgrading a long-lived database to a build containing the 0.9.x event-log changesets can fail at boot with:

```
Migration failed for change set 0.9.x/changelog-2026-02-10-0000-create-table-event-log.xml
Caused by: liquibase.exception.DatabaseException: Can't create table `openboxes`.`event_log`
  (errno: 150 "Foreign key constraint is incorrectly formed")
```

Because migrations retry on every boot, it appears that the instance will not start after the upgrade.

*How to reproduce* The sequence below models charset drift by changing the database default, which touches no existing table; the field case I hit was a mirror of this - a referenced table converted to utf8mb4 while the default stayed utf8mb3 - same mechanism, same error:

1. `CREATE DATABASE openboxes DEFAULT CHARSET utf8;` (utf8 = utf8mb3 on both engines; matches the install docs)
2. Load a pre-0.9.9 schema (e.g. a 0.9.6 backup).
3. `ALTER DATABASE openboxes CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;`
4. Start the app on `develop` - `event_log` inherits utf8mb4, `event.id` is utf8mb3, and then adding the FK fails as described above.

**Root cause.** The three event-log `createTable` changesets specify no character set, so the new tables inherit the database default. InnoDB requires FK column pairs to match in both charset and collation; on databases whose per-table charsets have drifted from the default over the years (operational conversions, dump/restore cycles across server generations - see the community report https://community.openboxes.com/t/migrate-data-from-0-8-17-hotfix1-to-0-8-22/767 for an earlier undiagnosed instance of the same class on `product_merge_logger`), the FK add is rejected. The test suite does not hit this naturally because `src/test/resources/testcontainers/my.cnf` pins the server to utf8mb3 (per #2401), so test schemas are always charset-uniform.

**The fix.** Insert one guarded changeset before each of the eight `addForeignKeyConstraint` changesets in the three files. Each new changeset reads the referenced column's actual charset/collation from `information_schema` at migration time and, only when the child column differs, converts the child column to match. No existing changeset is edited, so checksums stay valid for every database that already ran the original changesets.

*Why not a fixed charset?* Installs differ (fresh MySQL 8 defaults to utf8mb4_0900_ai_ci, MariaDB 10.3 to latin1, docs-created databases to utf8/utf8mb3), so pinning any one value breaks part of the population, and moving the database default to utf8mb4 runs into the index key-length limits already documented in #2401. Matching each FK column to its referenced column is the only rule that works for all cases.

Behavior by database state:
- Charset-uniform database (fresh installs, CI, both engines): every guard finds equal collations and no-ops (`SELECT 1`).
- Mixed-charset database, first upgrade attempt: the just-created (empty) table's FK columns are converted to match their parents; the FK additions succeed.
- Database already broken by a failed attempt: the failed FK changeset was never recorded, so Liquibase re-runs it; the new changeset heals the column first and the retry succeeds.
- Database already migrated: a live FK proves the pair matches; no-op.
- Anything unexpected (missing column, view with the same name, drifted type or nullability): the guard no-ops and the following original changeset behaves exactly as it does today - this change is designed to remove a failure but not add one.

**Blast radius.** Migration files only; no application code. The alignment runs where the tables were just created and empty, so there is no data conversion on the affected path.

**Tests.** `MigrationCharsetAlignmentSpec` (integration and smoke test): asserts the changesets execute cleanly through boot migrations with all eight FKs created and column definitions preserved, plus checks the cases described above on scratch tables with deliberately mismatched collations (conversion, no-op, and drift paths). Verified additionally by running the changed changelog files with Liquibase 3.10.1 + mysql-connector 8.0.22 against MySQL 8.0.36 and MariaDB 10.3.39 in six scenarios (reproduction, fix in both mix directions, uniform no-op, retry-heal of a half-applied database, table drift) - all green on both engines. Full backend suite green on both engines locally.

The same unpinned-charset pattern exists in earlier 0.9.x migrations (the cycle_count family, transaction_source and its column renames, and a few columns added to existing tables). I plan to follow up with the same treatment for those under #2401 - kept them out of this PR to keep this one reviewable.
