### PR TITLE
OBLS-935 Pick queue does not lock/refresh fast enough

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/api/picking/PickTaskApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/picking/PickTaskApiController.groovy
@@ -50,7 +50,7 @@ class PickTaskApiController extends RestfulController<PickTask> {
             throw new ValidationException("Validation errors", command.errors)
         }
 
-        def data = pickTaskService.countOrdersByDeliveryType(command.facility, command.excludeAssignedRequisitions ?: false)
+        def data = pickTaskService.countOrdersByDeliveryType(command.facility, command.excludeAssignedRequisitions )
 
         render([data: data] as JSON)
     }

--- a/grails-app/controllers/org/pih/warehouse/api/picking/PickTaskApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/picking/PickTaskApiController.groovy
@@ -50,7 +50,7 @@ class PickTaskApiController extends RestfulController<PickTask> {
             throw new ValidationException("Validation errors", command.errors)
         }
 
-        def data = pickTaskService.countOrdersByDeliveryType(command.facility, command.excludeAssignedRequisitions)
+        def data = pickTaskService.countOrdersByDeliveryType(command.facility, command.excludeAssignedRequisitions ?: false)
 
         render([data: data] as JSON)
     }

--- a/grails-app/controllers/org/pih/warehouse/api/picking/PickTaskApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/picking/PickTaskApiController.groovy
@@ -50,7 +50,7 @@ class PickTaskApiController extends RestfulController<PickTask> {
             throw new ValidationException("Validation errors", command.errors)
         }
 
-        def data = pickTaskService.countOrdersByDeliveryType(command.facility, command.excludeAssignedRequisitions )
+        def data = pickTaskService.countOrdersByDeliveryType(command.facility, command.excludeAssignedRequisitions)
 
         render([data: data] as JSON)
     }

--- a/grails-app/controllers/org/pih/warehouse/api/picking/SearchPickTaskCommand.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/picking/SearchPickTaskCommand.groovy
@@ -15,7 +15,7 @@ class SearchPickTaskCommand implements Validateable {
     Integer priority
     String outboundContainerId
     String requisitionId
-    Boolean excludeAssignedRequisitions
+    Boolean excludeAssignedRequisitions = false
 
     static constraints = {
         facility nullable: false

--- a/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
+++ b/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
@@ -204,6 +204,11 @@ class PickTaskService {
     }
 
     void start(PickTask task, String assigneeId) {
+        if (task.assignee && task.assignee.id != assigneeId) {
+            task.errors.reject("assignee", "Pick task ${task.id} is already assigned to another user")
+            throw new ValidationException("Pick task ${task.id} is already assigned to another user", task.errors)
+        }
+
         executeStateTransition(task, PickTaskStatus.PICKING)
         webhookPublisherService.publishRequisitionEvent(task.requisition, WebhookEventType.PICK_STARTED)
 


### PR DESCRIPTION
fallback when excludeAssignedRequisitions is null

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:**
https://openboxes.atlassian.net/browse/OBLS-935

**Description:**


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
