### PR TITLE
OBLS-837 Report order level pick progress on pick task search

### DIFF
--- a/grails-app/domain/org/pih/warehouse/picking/PickTask.groovy
+++ b/grails-app/domain/org/pih/warehouse/picking/PickTask.groovy
@@ -49,12 +49,10 @@ class PickTask {
     Date dateCreated
     Date lastUpdated
 
-    // Order level pick progress, populated by PickTaskService.search and never persisted.
+    // Order level pick progress, aggregated across the whole requisition by the pick_task view.
     Integer orderTotalTaskCount
     Integer orderOpenTaskCount
     PickStatusCode orderPickStatusCode
-
-    static transients = ['orderTotalTaskCount', 'orderOpenTaskCount', 'orderPickStatusCode']
 
     static constraints = {
         requisition nullable: false
@@ -83,6 +81,9 @@ class PickTask {
         dateStaged nullable: true
         reasonCode nullable: true
         status nullable: false
+        orderTotalTaskCount nullable: true
+        orderOpenTaskCount nullable: true
+        orderPickStatusCode nullable: true
     }
 
     static mapping = {

--- a/grails-app/domain/org/pih/warehouse/picking/PickTask.groovy
+++ b/grails-app/domain/org/pih/warehouse/picking/PickTask.groovy
@@ -1,5 +1,6 @@
 package org.pih.warehouse.picking
 
+import org.pih.warehouse.api.PickStatusCode
 import org.pih.warehouse.api.PickTaskStatus
 import org.pih.warehouse.core.DeliveryTypeCode
 import org.pih.warehouse.core.Location
@@ -47,6 +48,13 @@ class PickTask {
 
     Date dateCreated
     Date lastUpdated
+
+    // Order level pick progress, populated by PickTaskService.search and never persisted.
+    Integer orderTotalTaskCount
+    Integer orderOpenTaskCount
+    PickStatusCode orderPickStatusCode
+
+    static transients = ['orderTotalTaskCount', 'orderOpenTaskCount', 'orderPickStatusCode']
 
     static constraints = {
         requisition nullable: false
@@ -116,6 +124,9 @@ class PickTask {
                 dateStaged      : dateStaged,
                 reasonCode      : reasonCode,
                 status          : status?.name(),
+                orderTotalTaskCount: orderTotalTaskCount,
+                orderOpenTaskCount : orderOpenTaskCount,
+                orderPickStatusCode: orderPickStatusCode?.name(),
                 dateCreated     : dateCreated,
                 lastUpdated     : lastUpdated,
         ]

--- a/grails-app/migrations/views/pick-task.sql
+++ b/grails-app/migrations/views/pick-task.sql
@@ -72,25 +72,32 @@ SELECT
     pli.date_created AS date_created,
     pli.last_updated AS last_updated,
 
-    CAST(SUM(CASE WHEN NOT (COALESCE(pli.status, 'PENDING') = 'STAGED'
-                            AND COALESCE(pli.quantity_picked, 0) = 0)
-                  THEN 1 ELSE 0 END) OVER w AS SIGNED) AS order_total_task_count,
-    CAST(SUM(CASE WHEN COALESCE(pli.status, 'PENDING') NOT IN ('PICKED', 'STAGED')
-                  THEN 1 ELSE 0 END) OVER w AS SIGNED) AS order_open_task_count,
+    CAST(progress.order_total_task_count AS SIGNED) AS order_total_task_count,
+    CAST(progress.order_open_task_count AS SIGNED) AS order_open_task_count,
     CASE
-        WHEN SUM(CASE WHEN COALESCE(pli.status, 'PENDING') NOT IN ('PICKED', 'STAGED')
-                      THEN 1 ELSE 0 END) OVER w = 0
-            THEN 'PICKED'
-        WHEN MAX(CASE WHEN COALESCE(pli.status, 'PENDING') IN ('PICKING', 'PICKED')
-                        OR (COALESCE(pli.status, 'PENDING') = 'STAGED'
-                            AND COALESCE(pli.quantity_picked, 0) > 0)
-                      THEN 1 ELSE 0 END) OVER w = 1
-            THEN 'PARTIALLY_PICKED'
+        WHEN progress.order_open_task_count = 0 THEN 'PICKED'
+        WHEN progress.has_pick_progress = 1 THEN 'PARTIALLY_PICKED'
         ELSE 'NOT_PICKED'
     END AS order_pick_status_code
 FROM picklist_item pli
          JOIN picklist pl ON pl.id = pli.picklist_id
          JOIN requisition r ON r.id = pl.requisition_id
          LEFT JOIN requisition_item ri ON ri.id = pli.requisition_item_id
-WHERE r.status IN ('PICKING', 'PICKED', 'STAGED')
-WINDOW w AS (PARTITION BY r.id);
+         LEFT JOIN (
+             SELECT pl.requisition_id AS requisition_id,
+                    SUM(CASE WHEN NOT (COALESCE(pli.status, 'PENDING') = 'STAGED'
+                                       AND COALESCE(pli.quantity_picked, 0) = 0)
+                             THEN 1 ELSE 0 END) AS order_total_task_count,
+                    SUM(CASE WHEN COALESCE(pli.status, 'PENDING') NOT IN ('PICKED', 'STAGED')
+                             THEN 1 ELSE 0 END) AS order_open_task_count,
+                    MAX(CASE WHEN COALESCE(pli.status, 'PENDING') IN ('PICKING', 'PICKED')
+                               OR (COALESCE(pli.status, 'PENDING') = 'STAGED'
+                                   AND COALESCE(pli.quantity_picked, 0) > 0)
+                             THEN 1 ELSE 0 END) AS has_pick_progress
+             FROM picklist_item pli
+                      JOIN picklist pl ON pl.id = pli.picklist_id
+                      JOIN requisition r ON r.id = pl.requisition_id
+             WHERE r.status IN ('PICKING', 'PICKED', 'STAGED')
+             GROUP BY pl.requisition_id
+         ) progress ON progress.requisition_id = r.id
+WHERE r.status IN ('PICKING', 'PICKED', 'STAGED');

--- a/grails-app/migrations/views/pick-task.sql
+++ b/grails-app/migrations/views/pick-task.sql
@@ -70,9 +70,27 @@ SELECT
     END AS status,
 
     pli.date_created AS date_created,
-    pli.last_updated AS last_updated
+    pli.last_updated AS last_updated,
+
+    CAST(SUM(CASE WHEN NOT (COALESCE(pli.status, 'PENDING') = 'STAGED'
+                            AND COALESCE(pli.quantity_picked, 0) = 0)
+                  THEN 1 ELSE 0 END) OVER w AS SIGNED) AS order_total_task_count,
+    CAST(SUM(CASE WHEN COALESCE(pli.status, 'PENDING') NOT IN ('PICKED', 'STAGED')
+                  THEN 1 ELSE 0 END) OVER w AS SIGNED) AS order_open_task_count,
+    CASE
+        WHEN SUM(CASE WHEN COALESCE(pli.status, 'PENDING') NOT IN ('PICKED', 'STAGED')
+                      THEN 1 ELSE 0 END) OVER w = 0
+            THEN 'PICKED'
+        WHEN MAX(CASE WHEN COALESCE(pli.status, 'PENDING') IN ('PICKING', 'PICKED')
+                        OR (COALESCE(pli.status, 'PENDING') = 'STAGED'
+                            AND COALESCE(pli.quantity_picked, 0) > 0)
+                      THEN 1 ELSE 0 END) OVER w = 1
+            THEN 'PARTIALLY_PICKED'
+        ELSE 'NOT_PICKED'
+    END AS order_pick_status_code
 FROM picklist_item pli
          JOIN picklist pl ON pl.id = pli.picklist_id
          JOIN requisition r ON r.id = pl.requisition_id
          LEFT JOIN requisition_item ri ON ri.id = pli.requisition_item_id
-WHERE r.status IN ('PICKING', 'PICKED', 'STAGED');
+WHERE r.status IN ('PICKING', 'PICKED', 'STAGED')
+WINDOW w AS (PARTITION BY r.id);

--- a/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
+++ b/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
@@ -6,6 +6,7 @@ import grails.validation.ValidationException
 import org.hibernate.ObjectNotFoundException
 import org.hibernate.criterion.CriteriaSpecification
 import org.pih.warehouse.api.AvailableItem
+import org.pih.warehouse.api.PickStatusCode
 import org.pih.warehouse.api.PickTaskStatus
 import org.pih.warehouse.api.picking.SearchPickTaskCommand
 import org.pih.warehouse.core.ActivityCode
@@ -117,7 +118,81 @@ class PickTaskService {
             order("l.name", "asc")
         }
 
+        applyOrderPickProgress(command.facility, tasks)
+
         return tasks
+    }
+
+    // Status filtered callers only see part of an order, so carry the whole order's progress along.
+    private void applyOrderPickProgress(Location facility, List<PickTask> tasks) {
+        List<String> requisitionIds = tasks.collect { it.requisition?.id }.findAll().unique()
+        if (!requisitionIds) {
+            return
+        }
+
+        Map<String, Map> progressByRequisition = calculateOrderPickProgress(facility, requisitionIds)
+
+        tasks.each { PickTask task ->
+            Map progress = progressByRequisition[task.requisition?.id]
+            if (progress) {
+                task.orderTotalTaskCount = progress.totalTaskCount as Integer
+                task.orderOpenTaskCount = progress.openTaskCount as Integer
+                task.orderPickStatusCode = progress.pickStatusCode as PickStatusCode
+            }
+        }
+    }
+
+    @Transactional(readOnly = true)
+    Map<String, Map> calculateOrderPickProgress(Location facility, List<String> requisitionIds) {
+        if (!requisitionIds) {
+            return [:]
+        }
+
+        List rows = PickTask.createCriteria().list {
+            createAlias("requisition", "r")
+            projections {
+                property("r.id")
+                property("status")
+                property("quantityPicked")
+            }
+            if (facility) {
+                eq("facility", facility)
+            }
+            'in'("r.id", requisitionIds)
+        }
+
+        return rows.groupBy { it[0] as String }.collectEntries { String requisitionId, List taskRows ->
+            [(requisitionId): summarizeOrderPickProgress(taskRows)]
+        }
+    }
+
+    private Map summarizeOrderPickProgress(List taskRows) {
+        // STAGED with nothing picked is a canceled line, not a line anybody has to pick.
+        List countedRows = taskRows.findAll { row ->
+            !(row[1] == PickTaskStatus.STAGED && !((row[2] ?: 0) > 0))
+        }
+
+        int openTaskCount = countedRows.count { row ->
+            row[1] == PickTaskStatus.PENDING || row[1] == PickTaskStatus.PICKING
+        }
+        boolean anythingPicked = countedRows.any { row ->
+            row[1] == PickTaskStatus.PICKING || row[1] == PickTaskStatus.PICKED || row[1] == PickTaskStatus.STAGED
+        }
+
+        PickStatusCode pickStatusCode
+        if (openTaskCount == 0) {
+            pickStatusCode = PickStatusCode.PICKED
+        } else if (anythingPicked) {
+            pickStatusCode = PickStatusCode.PARTIALLY_PICKED
+        } else {
+            pickStatusCode = PickStatusCode.NOT_PICKED
+        }
+
+        return [
+                totalTaskCount: countedRows.size(),
+                openTaskCount : openTaskCount,
+                pickStatusCode: pickStatusCode,
+        ]
     }
 
     @Transactional(readOnly = true)

--- a/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
+++ b/grails-app/services/org/pih/warehouse/picking/PickTaskService.groovy
@@ -6,7 +6,6 @@ import grails.validation.ValidationException
 import org.hibernate.ObjectNotFoundException
 import org.hibernate.criterion.CriteriaSpecification
 import org.pih.warehouse.api.AvailableItem
-import org.pih.warehouse.api.PickStatusCode
 import org.pih.warehouse.api.PickTaskStatus
 import org.pih.warehouse.api.picking.SearchPickTaskCommand
 import org.pih.warehouse.core.ActivityCode
@@ -118,81 +117,7 @@ class PickTaskService {
             order("l.name", "asc")
         }
 
-        applyOrderPickProgress(command.facility, tasks)
-
         return tasks
-    }
-
-    // Status filtered callers only see part of an order, so carry the whole order's progress along.
-    private void applyOrderPickProgress(Location facility, List<PickTask> tasks) {
-        List<String> requisitionIds = tasks.collect { it.requisition?.id }.findAll().unique()
-        if (!requisitionIds) {
-            return
-        }
-
-        Map<String, Map> progressByRequisition = calculateOrderPickProgress(facility, requisitionIds)
-
-        tasks.each { PickTask task ->
-            Map progress = progressByRequisition[task.requisition?.id]
-            if (progress) {
-                task.orderTotalTaskCount = progress.totalTaskCount as Integer
-                task.orderOpenTaskCount = progress.openTaskCount as Integer
-                task.orderPickStatusCode = progress.pickStatusCode as PickStatusCode
-            }
-        }
-    }
-
-    @Transactional(readOnly = true)
-    Map<String, Map> calculateOrderPickProgress(Location facility, List<String> requisitionIds) {
-        if (!requisitionIds) {
-            return [:]
-        }
-
-        List rows = PickTask.createCriteria().list {
-            createAlias("requisition", "r")
-            projections {
-                property("r.id")
-                property("status")
-                property("quantityPicked")
-            }
-            if (facility) {
-                eq("facility", facility)
-            }
-            'in'("r.id", requisitionIds)
-        }
-
-        return rows.groupBy { it[0] as String }.collectEntries { String requisitionId, List taskRows ->
-            [(requisitionId): summarizeOrderPickProgress(taskRows)]
-        }
-    }
-
-    private Map summarizeOrderPickProgress(List taskRows) {
-        // STAGED with nothing picked is a canceled line, not a line anybody has to pick.
-        List countedRows = taskRows.findAll { row ->
-            !(row[1] == PickTaskStatus.STAGED && !((row[2] ?: 0) > 0))
-        }
-
-        int openTaskCount = countedRows.count { row ->
-            row[1] == PickTaskStatus.PENDING || row[1] == PickTaskStatus.PICKING
-        }
-        boolean anythingPicked = countedRows.any { row ->
-            row[1] == PickTaskStatus.PICKING || row[1] == PickTaskStatus.PICKED || row[1] == PickTaskStatus.STAGED
-        }
-
-        PickStatusCode pickStatusCode
-        if (openTaskCount == 0) {
-            pickStatusCode = PickStatusCode.PICKED
-        } else if (anythingPicked) {
-            pickStatusCode = PickStatusCode.PARTIALLY_PICKED
-        } else {
-            pickStatusCode = PickStatusCode.NOT_PICKED
-        }
-
-        return [
-                totalTaskCount: countedRows.size(),
-                openTaskCount : openTaskCount,
-                pickStatusCode: pickStatusCode,
-        ]
     }
 
     @Transactional(readOnly = true)

--- a/src/main/groovy/org/pih/warehouse/api/PickStatusCode.groovy
+++ b/src/main/groovy/org/pih/warehouse/api/PickStatusCode.groovy
@@ -1,0 +1,11 @@
+package org.pih.warehouse.api
+
+enum PickStatusCode {
+    NOT_PICKED,
+    PARTIALLY_PICKED,
+    PICKED
+
+    static List<PickStatusCode> list() {
+        return values().toList()
+    }
+}

--- a/src/main/groovy/org/pih/warehouse/api/ReplenishmentPickPageItem.groovy
+++ b/src/main/groovy/org/pih/warehouse/api/ReplenishmentPickPageItem.groovy
@@ -72,11 +72,11 @@ class ReplenishmentPickPageItem {
     String getStatusCode() {
 
         if (quantityRequired == quantityPicked && quantityRemaining == 0) {
-            return "PICKED"
+            return PickStatusCode.PICKED.name()
         } else if (quantityPicked > 0 && quantityRemaining > 0) {
-            return "PARTIALLY_PICKED"
+            return PickStatusCode.PARTIALLY_PICKED.name()
         } else {
-            return "NOT_PICKED"
+            return PickStatusCode.NOT_PICKED.name()
         }
     }
 

--- a/src/main/groovy/org/pih/warehouse/api/StockMovementItem.groovy
+++ b/src/main/groovy/org/pih/warehouse/api/StockMovementItem.groovy
@@ -823,11 +823,11 @@ class PickPageItem {
     String getStatusCode() {
 
         if (quantityRequired == quantityPicked && quantityRemaining == 0) {
-            return "PICKED"
+            return PickStatusCode.PICKED.name()
         } else if (quantityPicked > 0 && quantityRemaining > 0) {
-            return "PARTIALLY_PICKED"
+            return PickStatusCode.PARTIALLY_PICKED.name()
         } else {
-            return "NOT_PICKED"
+            return PickStatusCode.NOT_PICKED.name()
         }
     }
 


### PR DESCRIPTION
**Link to GitHub issue or Jira ticket:** https://openboxes.atlassian.net/browse/OBLS-837

**Description:**
The pick task search is status filtered, so a caller asking for the open queue (`status=PENDING&status=PICKING`) never receives the lines of an order that are already picked. A partially picked order is therefore indistinguishable from an untouched one: it reports fewer lines than it has and no sign that anybody started it.

**Changes**
- Each task now carries the progress of the order it belongs to: `orderTotalTaskCount`, `orderOpenTaskCount` and `orderPickStatusCode`.
- The fields are transient and populated by `PickTaskService.search` from a single projection query over the requisitions in the page, so there is no schema change. The completed rows are already in the `pick_task` view while the requisition sits in `PICKING`.
- Adds a `PickStatusCode` enum for the `NOT_PICKED` / `PARTIALLY_PICKED` / `PICKED` vocabulary, which until now existed only as duplicated string literals in `PickPageItem.getStatusCode` and `ReplenishmentPickPageItem.getStatusCode`. Both now return `PickStatusCode.X.name()`, so the existing responses are unchanged.
- A `STAGED` line with nothing picked is the terminal marker for a zero quantity short pick with a reason code, so it is excluded from both counts and does not count as progress.