### PR TITLE
OBLS-825 OBLS-838 Assign location to splitted putaway task not to canceled original task

### DIFF
--- a/grails-app/jobs/org/pih/warehouse/jobs/PutawayLocationReassignJob.groovy
+++ b/grails-app/jobs/org/pih/warehouse/jobs/PutawayLocationReassignJob.groovy
@@ -65,7 +65,7 @@ class PutawayLocationReassignmentJob {
     }
 
     private void setPutawayLocation(PutawayItem putawayItem, Location putawayLocation) {
-        if (putawayItem?.putawayStatus == PutawayStatus.PENDING) {
+        if (putawayItem?.putawayStatus != PutawayStatus.COMPLETED && putawayItem?.putawayStatus != PutawayStatus.CANCELED) {
             putawayItem.putawayLocation = putawayLocation
             log.debug "Modified putawayLocation as ${putawayLocation} for ${putawayItem.id}"
         }


### PR DESCRIPTION

modify location for all status except COMPLETED and CANCELED

### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:**
https://openboxes.atlassian.net/browse/OBLS-825
https://openboxes.atlassian.net/browse/OBLS-838

**Description:**


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)
