### PR TITLE
OBLS-858 Handled different cross-dock cases

### DIFF
--- a/grails-app/conf/spring/resources.groovy
+++ b/grails-app/conf/spring/resources.groovy
@@ -38,7 +38,9 @@ beans = {
     transactionalEventListenerFactory(TransactionalEventListenerFactory)
 
     // Putaway strategies
-    crossDockPutawayStrategy(CrossDockPutawayStrategy)
+    crossDockPutawayStrategy(CrossDockPutawayStrategy) {
+        backorderMatchingService = ref('backorderMatchingService')
+    }
     directedPutawayStrategy(DirectedPutawayStrategy)
     // randomPutawayStrategy(RandomPutawayStrategy)
     putawayStrategyService(PutawayStrategyService) {

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -77,7 +77,8 @@ auth.email.newUserAccountCreated.message=New User Created
 analytics.label=Analytics
 # Backorder
 backorder.notFound.message=Backorder {0} not found
-backorder.unavailable.message=No unallocated lines found for product {0} on backorder {1}
+backorder.unavailable.message=No demand left for product {0} on backorder {1}
+putaway.quantityNotAssigned.message=Could not assign a putaway location for {0} of product {1}
 # Barcode
 barcode.label=Barcode
 # Batch operations

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -79,6 +79,7 @@ analytics.label=Analytics
 backorder.notFound.message=Backorder {0} not found
 backorder.unavailable.message=No demand left for product {0} on backorder {1}
 putaway.quantityNotAssigned.message=Could not assign a putaway location for {0} of product {1}
+putaway.crossDockDeclined.message=Product {0} on backorder {1} was not cross-docked. Check that the backorder still has uncovered demand and that a cross-dock zone exists for its delivery type.
 # Barcode
 barcode.label=Barcode
 # Batch operations

--- a/grails-app/jobs/org/pih/warehouse/jobs/AutomaticBackorderReallocationJob.groovy
+++ b/grails-app/jobs/org/pih/warehouse/jobs/AutomaticBackorderReallocationJob.groovy
@@ -5,7 +5,10 @@ import org.pih.warehouse.allocation.AllocationMode
 import org.pih.warehouse.allocation.AllocationRequest
 import org.pih.warehouse.allocation.AllocationResult
 import org.pih.warehouse.allocation.AllocationSourceStrategy
+import org.pih.warehouse.allocation.BackorderMatch
+import org.pih.warehouse.core.ReasonCode
 import org.pih.warehouse.requisition.Requisition
+import org.pih.warehouse.requisition.RequisitionItem
 import org.pih.warehouse.requisition.RequisitionStatus
 import org.pih.warehouse.shipping.Shipment
 import org.pih.warehouse.shipping.ShipmentItem
@@ -16,6 +19,8 @@ class AutomaticBackorderReallocationJob {
     def shipmentService
     def allocationService
     def stockMovementService
+    def putawayTaskService
+    def backorderMatchingService
 
     def sessionRequired = false
 
@@ -39,10 +44,15 @@ class AutomaticBackorderReallocationJob {
                     return
                 }
                 if (shipment.shipmentItems?.any { it.backorderItem || it.backorderReference }) {
+                    if (putawayTaskService.hasOpenCrossDockTask(shipment)) {
+                        log.info("Shipment ${shipmentId} has an open cross-dock putaway, " +
+                                "allocation is deferred until the stock reaches the cross-dock zone")
+                        return
+                    }
                     log.info("Handle backorder re-allocation for shipment ${shipmentId}")
                     def backorderItems = shipment.shipmentItems?.findAll { it.backorderReference || it.backorderItem }
 
-                    List<AllocationSourceStrategy> strategies = [AllocationSourceStrategy.STORAGE_FIRST]
+                    List<AllocationSourceStrategy> strategies = []
                     Set<Requisition> backorders = []
                     backorderItems.forEach { ShipmentItem it ->
                         def backorderedRequisition = it.backorderItem?.requisition
@@ -56,23 +66,7 @@ class AutomaticBackorderReallocationJob {
 
                     backorders.forEach { Requisition requisition ->
                         if (requisition.autoAllocationRequested) {
-                            List<AllocationResult> result = []
-                            requisition?.requisitionItems?.each { requisitionItem ->
-                                def picklistItems = requisitionItem.picklistItems
-                                if (!picklistItems || picklistItems.isEmpty()) {
-                                    AllocationRequest allocationRequest = new AllocationRequest(requisitionItem: requisitionItem, allocationMode: AllocationMode.AUTO, allocationStrategies: strategies)
-                                    AllocationResult singleResult = allocationService.allocate(allocationRequest)
-                                    result.add(singleResult)
-                                }
-                            }
-                            if (result && !result.empty) {
-                                requisition.requisitionItems.forEach {
-                                    it.quantityBackordered = null
-                                    it.backorderedReasonCode = null
-                                }
-                                stockMovementService.updateRequisitionStatus(requisition.id, RequisitionStatus.PICKING)
-                            }
-                            log.info("Re-allocate ${result}")
+                            releaseCrossDockDemand(shipment, requisition, strategies)
                         }
                     }
                 }
@@ -80,5 +74,69 @@ class AutomaticBackorderReallocationJob {
                 log.error("Error processing shipment ${shipmentId}", e)
             }
         }
+    }
+
+    /**
+     * Allocates a backorder once its cross-dock stock has landed in the cross-dock zone. The
+     * quantity covered by the sales link comes from that zone, anything still missing may be taken
+     * from ordinary stock, and whatever is left over stays backordered so the order waits for the
+     * next delivery.
+     */
+    private void releaseCrossDockDemand(Shipment shipment, Requisition requisition, List<AllocationSourceStrategy> strategies) {
+        boolean allocatedAnything = false
+
+        List<BackorderMatch> matches = backorderMatchingService.match(
+                requisition, backorderMatchingService.findInboundItemsForRequisition(shipment, requisition))
+        Set<String> demandItemIds = matches.collect { it.demand?.id }.findAll() as Set
+
+        if (!demandItemIds) {
+            log.info("No demand covered by shipment ${shipment.shipmentNumber} on ${requisition.requestNumber}")
+            return
+        }
+
+        requisition?.requisitionItems?.each { RequisitionItem requisitionItem ->
+            if (!demandItemIds.contains(requisitionItem.id)) {
+                return
+            }
+
+            Integer quantityOutstanding = backorderMatchingService.remainingDemand(requisitionItem)
+            if (quantityOutstanding <= 0) {
+                log.info("Requisition item ${requisitionItem.id} has no demand left, skipping")
+                return
+            }
+
+            AllocationRequest allocationRequest = new AllocationRequest(
+                    quantityRequired: quantityOutstanding,
+                    requisitionItem: requisitionItem,
+                    allocationMode: AllocationMode.AUTO,
+                    allocationStrategies: strategies,
+                    crossDockRelease: true)
+            AllocationResult result = allocationService.allocate(allocationRequest)
+
+            Integer quantityAllocated = result?.suggestedItems?.sum { it.quantityPicked } ?: 0
+            if (quantityAllocated > 0) {
+                allocatedAnything = true
+            }
+            updateQuantityBackordered(requisitionItem, quantityOutstanding, quantityAllocated)
+            log.info("Cross-dock release allocated ${quantityAllocated} for requisition item ${requisitionItem.id}")
+        }
+
+        if (allocatedAnything) {
+            stockMovementService.updateRequisitionStatus(requisition.id, RequisitionStatus.PICKING)
+        }
+    }
+
+    private void updateQuantityBackordered(RequisitionItem requisitionItem, Integer quantityOutstanding,
+                                           Integer quantityAllocated) {
+        Integer quantityRemaining = Math.max(0, (quantityOutstanding ?: 0) - (quantityAllocated ?: 0))
+
+        if (quantityRemaining > 0) {
+            requisitionItem.quantityBackordered = quantityRemaining
+            requisitionItem.backorderedReasonCode = ReasonCode.BACKORDER.toString()
+        } else {
+            requisitionItem.quantityBackordered = null
+            requisitionItem.backorderedReasonCode = null
+        }
+        requisitionItem.save(failOnError: true)
     }
 }

--- a/grails-app/services/org/pih/warehouse/allocation/AllocationService.groovy
+++ b/grails-app/services/org/pih/warehouse/allocation/AllocationService.groovy
@@ -17,6 +17,7 @@ import org.pih.warehouse.api.StockMovement
 import org.pih.warehouse.api.StockMovementItem
 import org.pih.warehouse.api.SuggestedItem
 import org.pih.warehouse.auth.AuthService
+import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.Constants
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.inventory.CycleCountService
@@ -85,8 +86,13 @@ class AllocationService {
             Integer quantityRequired = requisitionItem.calculateQuantityRequired()
             List<SuggestedItem> suggestedItems = getAutoSuggestedItems(requisitionItem, quantityRequired, strategies, [], mode)
 
-            stockMovementService.clearPicklist(requisitionItem)
-            stockMovementService.allocateSuggestedItems(requisitionItem, suggestedItems, true)
+            // No suggestion means allocation declined this line rather than failed to find stock - a
+            // backordered line is left to the cross-dock release. Clearing the picklist would delete
+            // whatever that release has already covered.
+            if (suggestedItems) {
+                stockMovementService.clearPicklist(requisitionItem)
+                stockMovementService.allocateSuggestedItems(requisitionItem, suggestedItems, true)
+            }
         } else if (mode == AllocationMode.MANUAL) {
             List<PicklistItem> existingPickListItems = PicklistItem.findAllByRequisitionItem(requisitionItem)
             Set<String> processedPickIds = []
@@ -146,7 +152,8 @@ class AllocationService {
         Integer quantityRequired = request.quantityRequired ?: requisitionItem.calculateQuantityRequired()
         List<SuggestedItem> suggestedItems
         if (mode == AllocationMode.AUTO) {
-            suggestedItems = getAutoSuggestedItems(requisitionItem, quantityRequired, request.allocationStrategies, [], mode)
+            suggestedItems = getAutoSuggestedItems(requisitionItem, quantityRequired,
+                    request.allocationStrategies, [], request.crossDockRelease)
         } else if (mode == AllocationMode.MANUAL) {
             List<AvailableItem> manualItems = request.availableItems?.findAll { it.inventoryItem.product?.id == requisitionItem.product?.id }
             suggestedItems = stockMovementService.getSuggestedItems(manualItems, quantityRequired)
@@ -160,7 +167,12 @@ class AllocationService {
         }
 
         if (saveAllocation) {
-            stockMovementService.clearPicklist(requisitionItem)
+            // The cross-dock release only ever allocates the quantity still outstanding, so the
+            // picklist is added to rather than rebuilt - clearing it would drop what an earlier
+            // delivery already covered.
+            if (!request.crossDockRelease) {
+                stockMovementService.clearPicklist(requisitionItem)
+            }
             stockMovementService.allocateSuggestedItems(requisitionItem, suggestedItems, mode == AllocationMode.AUTO)
         }
         return new AllocationResult(allocationRequest: request, suggestedItems: suggestedItems)
@@ -222,6 +234,9 @@ class AllocationService {
             } ?: []
 
             results.each { AllocationResult result ->
+                if (!result.suggestedItems) {
+                    return
+                }
                 RequisitionItem requisitionItem = result.allocationRequest.requisitionItem
                 stockMovementService.clearPicklist(requisitionItem)
                 stockMovementService.allocateSuggestedItems(requisitionItem, result.suggestedItems, allocationMode == AllocationMode.AUTO)
@@ -283,10 +298,11 @@ class AllocationService {
         }
     }
 
-    private List<SuggestedItem> getAutoSuggestedItems(RequisitionItem requisitionItem, Integer quantityRequired, List<AllocationSourceStrategy> strategies, List<AvailableItem> excludeList = [], AllocationMode allocationMode = null) {
+    private List<SuggestedItem> getAutoSuggestedItems(RequisitionItem requisitionItem, Integer quantityRequired, List<AllocationSourceStrategy> strategies, List<AvailableItem> excludeList = [], Boolean crossDockRelease = false) {
         Location facility = requisitionItem.requisition.origin
         Product product = requisitionItem.product
-        List<AvailableItem> allAvailableItems = stockMovementService.getAvailableItems(facility, requisitionItem, false)
+        List<AvailableItem> allAvailableItems =
+                stockMovementService.getAvailableItems(facility, requisitionItem, false, !crossDockRelease)
 
         allAvailableItems = allAvailableItems.findAll { !it.binLocation?.isNegativeInventoryFallbackLocation() }
 
@@ -295,8 +311,24 @@ class AllocationService {
             quantityRequired = requisitionItem.quantityBackordered
         }
 
+        // A backordered line waits for its cross-dock delivery and is not covered from ordinary stock.
+        // Until the cross-dock putaway has run there is nothing to allocate
+        if (isBackordered && !crossDockRelease) {
+            log.info("Requisition item ${requisitionItem.id} is backordered, skipping ordinary allocation")
+            return []
+        }
+
         List<AllocationSourceStrategy> resolvedStrategies = resolveStrategies(requisitionItem.requisition, strategies)
         RotationRule rotationRule = getConfiguredRotationRule()
+
+        // Cross-dock release: take the cross-dock zone first and fall back to ordinary stock only for
+        // the quantity no inbound covered
+        if (crossDockRelease) {
+            List<AvailableItem> ordered = crossDockFirst(orderByStrategy(
+                    resolvedStrategies.first(), facility, product,
+                    applyRotation(rotationRule, allAvailableItems)))
+            return stockMovementService.getSuggestedItems(ordered, quantityRequired)
+        }
 
         Integer bestQuantityAvailable = 0
         List<AvailableItem> bestItems = []
@@ -431,6 +463,13 @@ class AllocationService {
 
     private RotationRule getConfiguredRotationRule() {
         return (grailsApplication.config.openboxes.order.allocation.rotation ?: RotationRule.FEFO) as RotationRule
+    }
+
+    private List<AvailableItem> crossDockFirst(List<AvailableItem> availableItems) {
+        List<AvailableItem> crossDockItems = availableItems.findAll {
+            it.binLocation?.supports(ActivityCode.CROSS_DOCKING)
+        }
+        return crossDockItems + (availableItems - crossDockItems)
     }
 
     private List<AvailableItem> orderByStrategy(AllocationSourceStrategy strategy, Location facility, Product product, List<AvailableItem> availableItems) {

--- a/grails-app/services/org/pih/warehouse/allocation/BackorderMatchingService.groovy
+++ b/grails-app/services/org/pih/warehouse/allocation/BackorderMatchingService.groovy
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2012 Partners In Health.  All rights reserved.
+ * The use and distribution terms for this software are covered by the
+ * Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+ * which can be found in the file epl-v10.html at the root of this distribution.
+ * By using this software in any fashion, you are agreeing to be bound by
+ * the terms of this license.
+ * You must not remove this notice, or any other, from this software.
+ **/
+package org.pih.warehouse.allocation
+
+import grails.gorm.transactions.Transactional
+import org.pih.warehouse.product.Product
+import org.pih.warehouse.requisition.Requisition
+import org.pih.warehouse.requisition.RequisitionItem
+import org.pih.warehouse.shipping.Shipment
+import org.pih.warehouse.shipping.ShipmentItem
+
+/**
+ * Single place that decides which inbound quantity covers which outbound demand line.
+ */
+@Transactional
+class BackorderMatchingService {
+
+    List<BackorderMatch> match(Requisition backorder, Collection<ShipmentItem> inboundItems) {
+        List<BackorderMatch> matches = []
+        Map<String, Integer> quantityRemainingByDemand = [:]
+        backorder.requisitionItems.each { RequisitionItem demand ->
+            quantityRemainingByDemand[demand.id] = remainingDemand(demand)
+        }
+
+        for (ShipmentItem inboundItem : inboundItems) {
+            int quantityToMatch = inboundItem.quantity ?: 0
+            for (RequisitionItem demand : candidatesFor(backorder, inboundItem.product, quantityRemainingByDemand)) {
+                if (quantityToMatch <= 0) {
+                    break
+                }
+                int quantityMatched = Math.min(quantityToMatch, quantityRemainingByDemand[demand.id])
+                matches << new BackorderMatch(
+                        inboundItem: inboundItem,
+                        demand: demand,
+                        quantityMatched: quantityMatched)
+                quantityRemainingByDemand[demand.id] -= quantityMatched
+                quantityToMatch -= quantityMatched
+            }
+        }
+        return matches
+    }
+
+    /**
+     * Resolves how much of the quantity on hand should be cross-docked, and against which demand line.
+     * Returns null when there is no demand left to cover, in which case the quantity belongs in storage.
+     */
+    BackorderMatch resolveCrossDockMatch(String backorderReference, RequisitionItem backorderItem,
+                                        Product product, Integer quantityAvailable) {
+        int quantity = quantityAvailable ?: 0
+        if (quantity <= 0) {
+            return null
+        }
+
+        RequisitionItem demand = backorderItem
+        if (!demand) {
+            Requisition backorder = backorderReference ? Requisition.findByRequestNumber(backorderReference) : null
+            if (!backorder) {
+                return null
+            }
+            demand = backorder.requisitionItems
+                    .findAll { it.product == product && remainingDemand(it) > 0 }
+                    .sort { remainingDemand(it) }
+                    .find()
+        }
+        if (!demand) {
+            return null
+        }
+
+        int quantityMatched = Math.min(quantity, remainingDemand(demand))
+        if (quantityMatched <= 0) {
+            return null
+        }
+        return new BackorderMatch(demand: demand, quantityMatched: quantityMatched)
+    }
+
+    /**
+     * Quantity still to be covered on a demand line
+     */
+    Integer remainingDemand(RequisitionItem demand) {
+        if (demand.isBackordered()) {
+            return Math.max(0, demand.quantityBackordered ?: 0)
+        }
+        Integer quantityRequired = demand.calculateQuantityRequired() ?: 0
+        Integer quantityAllocated = demand.calculateQuantityAllocated() ?: 0
+        return Math.max(0, quantityRequired - quantityAllocated)
+    }
+
+    /**
+     * Inbound items covering the given backorder through either link: the soft reference used before
+     * the demand line is resolved, or the direct one once it is. findInboundItems only sees the soft
+     * form, which is what the receipt validation needs but would silently skip a hard linked item.
+     */
+    Collection<ShipmentItem> findInboundItemsForRequisition(Shipment shipment, Requisition backorder) {
+        return shipment.shipmentItems.findAll {
+            it.backorderReference == backorder.requestNumber ||
+                    it.backorderItem?.requisition?.id == backorder.id
+        }
+    }
+
+    Collection<ShipmentItem> findInboundItems(Shipment shipment, String requisitionNumber) {
+        return shipment.shipmentItems.findAll {
+            it.backorderReference == requisitionNumber && !it.backorderItem
+        }
+    }
+
+    /**
+     * Demand lines for the product that still need cover
+     */
+    private List<RequisitionItem> candidatesFor(Requisition backorder, Product product,
+                                                Map<String, Integer> quantityRemainingByDemand) {
+        return backorder.requisitionItems
+                .findAll { it.product == product && quantityRemainingByDemand[it.id] > 0 }
+                .sort { quantityRemainingByDemand[it.id] }
+    }
+}

--- a/grails-app/services/org/pih/warehouse/allocation/BackorderService.groovy
+++ b/grails-app/services/org/pih/warehouse/allocation/BackorderService.groovy
@@ -2,21 +2,14 @@ package org.pih.warehouse.allocation
 
 import grails.gorm.transactions.Transactional
 import org.pih.warehouse.requisition.Requisition
-import org.pih.warehouse.requisition.RequisitionItem
 import org.pih.warehouse.shipping.Shipment
 import org.pih.warehouse.shipping.ShipmentItem
 
 @Transactional
 class BackorderService {
 
-    // UPDATE: now the inbound item has to be at least equal to the outbound demand, no longer an exact match
-    // Special case: we only fulfill a backorder with an inbound item that exactly matches
-    // the outbound demand. The general behaviour of backorder fulfillment is partial matching
-    // (any inbound quantity reduces the demanded quantity, even if it only partially fulfills
-    // the backorder), but our ASN contains a separate shipment item per backordered demand
-    // line, so inbound and demanded quantities are expected to match one-to-one.
-    // This hard-coded equality rule will eventually be replaced by a strategy pattern
-    // (shared with AutomaticBackorderReallocationJob) - here the strategy is equality match.
+    BackorderMatchingService backorderMatchingService
+
     void validateBackorderReferences(Shipment shipment) {
         for (String requisitionNumber : shipment.uniqueBackorderReferences) {
             Requisition backorder = Requisition.findByRequestNumber(requisitionNumber)
@@ -27,25 +20,18 @@ class BackorderService {
                         "Backorder ${requisitionNumber} not found")
                 continue
             }
-            Collection<ShipmentItem> inboundItems = shipment.shipmentItems.findAll {
-                it.backorderReference == requisitionNumber && !it.backorderItem
-            }
-            Set consumedRequisitionItems = [] as Set
+
+            Collection<ShipmentItem> inboundItems = backorderMatchingService
+                    .findInboundItems(shipment, requisitionNumber)
+            List<BackorderMatch> matches = backorderMatchingService.match(backorder, inboundItems)
+
             for (ShipmentItem inboundItem : inboundItems) {
-                def matchingBackorderItem = backorder.requisitionItems.find { RequisitionItem demand ->
-                    demand.product == inboundItem.product &&
-                            demand.quantity <= inboundItem.quantity &&
-                            !demand.isAllocated() &&
-                            !consumedRequisitionItems.contains(demand)
-                }
-                if (!matchingBackorderItem) {
+                if (!matches.any { it.inboundItem == inboundItem }) {
                     shipment.errors.reject(
                             "backorder.unavailable.message",
                             [inboundItem.product?.productCode, requisitionNumber] as Object[],
-                            "No unallocated lines for ${inboundItem.product?.productCode} on ${requisitionNumber}")
-                    continue
+                            "No demand left for ${inboundItem.product?.productCode} on ${requisitionNumber}")
                 }
-                consumedRequisitionItems.add(matchingBackorderItem)
             }
         }
     }

--- a/grails-app/services/org/pih/warehouse/allocation/BackorderService.groovy
+++ b/grails-app/services/org/pih/warehouse/allocation/BackorderService.groovy
@@ -10,6 +10,10 @@ class BackorderService {
 
     BackorderMatchingService backorderMatchingService
 
+    /**
+     * Rejects the shipment when a backorder reference does not resolve, or when an inbound item has no
+     * uncovered demand left to match on that backorder. Inbound and demanded quantities need not match.
+     */
     void validateBackorderReferences(Shipment shipment) {
         for (String requisitionNumber : shipment.uniqueBackorderReferences) {
             Requisition backorder = Requisition.findByRequestNumber(requisitionNumber)

--- a/grails-app/services/org/pih/warehouse/inboundSortation/InboundSortationService.groovy
+++ b/grails-app/services/org/pih/warehouse/inboundSortation/InboundSortationService.groovy
@@ -6,18 +6,23 @@ import org.pih.warehouse.api.PutawayItem
 import org.pih.warehouse.api.PutawayStatus
 import org.pih.warehouse.api.PutawayTaskStatus
 import org.pih.warehouse.core.ActivityCode
+import org.pih.warehouse.core.Comment
+import org.pih.warehouse.core.CommentType
 import org.pih.warehouse.core.User
 import org.pih.warehouse.order.Order
 import org.pih.warehouse.order.OrderItem
 import org.pih.warehouse.putaway.PutawayTask
 import org.pih.warehouse.receiving.Receipt
 import org.pih.warehouse.receiving.ReceiptItem
+import org.pih.warehouse.shipping.Shipment
+import org.springframework.context.i18n.LocaleContextHolder
 
 @Transactional
 class InboundSortationService {
 
     def orderIdentifierService
     def putawayService
+    def messageSource
     PutawayStrategyService putawayStrategyService
 
     void createPutawayOrdersFromReceipt(Receipt receipt) {
@@ -40,6 +45,7 @@ class InboundSortationService {
                     putawayService.savePutaway(putaway)
                 }
             }
+            reportUnassignedQuantity(receipt.shipment, putawayContext, results)
         }
     }
 
@@ -60,6 +66,8 @@ class InboundSortationService {
                 preferredBin: task.product.getInventoryLevel(task.facility.id)?.preferredBinLocation,
                 internalLocation: task.product.getDefaultPutawayLocation(task.facility),
                 quantity: task.quantity.intValue(),
+                backorderReference: task.shipmentItem?.backorderReference,
+                backorderItem: task.shipmentItem?.backorderItem,
                 deliveryTypeCode: task.deliveryTypeCode,
         )
 
@@ -115,5 +123,31 @@ class InboundSortationService {
                 putawayStatus: PutawayStatus.PENDING,
                 comment: task.comment
         )
+    }
+
+    private void reportUnassignedQuantity(Shipment shipment, PutawayContext context, List<PutawayResult> results) {
+        if (!shipment) {
+            return
+        }
+        int quantityAssigned = results ? results*.quantity.sum(0) as int : 0
+        int quantityUnassigned = (context.quantity ?: 0) - quantityAssigned
+        if (quantityUnassigned <= 0) {
+            return
+        }
+
+        String message = messageSource.getMessage(
+                "putaway.quantityNotAssigned.message",
+                [quantityUnassigned, context.product?.productCode] as Object[],
+                "Could not assign a putaway location for ${quantityUnassigned} of product ${context.product?.productCode}",
+                LocaleContextHolder.locale)
+
+        boolean alreadyLogged = shipment.comments.any {
+            it.type == CommentType.SYSTEM && it.comment == message
+        }
+        if (!alreadyLogged) {
+            shipment.addToComments(new Comment(comment: message, sender: null))
+            shipment.save(failOnError: true)
+        }
+        log.warn("Shipment ${shipment.id}: ${message}")
     }
 }

--- a/grails-app/services/org/pih/warehouse/inboundSortation/InboundSortationService.groovy
+++ b/grails-app/services/org/pih/warehouse/inboundSortation/InboundSortationService.groovy
@@ -46,6 +46,7 @@ class InboundSortationService {
                 }
             }
             reportUnassignedQuantity(receipt.shipment, putawayContext, results)
+            reportCrossDockDeclined(receipt.shipment, putawayContext, results)
         }
     }
 
@@ -125,6 +126,9 @@ class InboundSortationService {
         )
     }
 
+    /**
+     * Records the quantity that no strategy was able to place
+     */
     private void reportUnassignedQuantity(Shipment shipment, PutawayContext context, List<PutawayResult> results) {
         if (!shipment) {
             return
@@ -141,6 +145,31 @@ class InboundSortationService {
                 "Could not assign a putaway location for ${quantityUnassigned} of product ${context.product?.productCode}",
                 LocaleContextHolder.locale)
 
+        addSystemComment(shipment, message)
+    }
+
+    /**
+     * Records that an inbound item carrying a backorder link was not cross-docked
+     */
+    private void reportCrossDockDeclined(Shipment shipment, PutawayContext context, List<PutawayResult> results) {
+        if (!shipment || (!context.backorderReference && !context.backorderItem)) {
+            return
+        }
+        if (results?.any { it.destination?.supports(ActivityCode.CROSS_DOCKING) }) {
+            return
+        }
+
+        String backorderNumber = context.backorderReference ?: context.backorderItem?.requisition?.requestNumber
+        String message = messageSource.getMessage(
+                "putaway.crossDockDeclined.message",
+                [context.product?.productCode, backorderNumber] as Object[],
+                "Product ${context.product?.productCode} on backorder ${backorderNumber} was not cross-docked",
+                LocaleContextHolder.locale)
+
+        addSystemComment(shipment, message)
+    }
+
+    private void addSystemComment(Shipment shipment, String message) {
         boolean alreadyLogged = shipment.comments.any {
             it.type == CommentType.SYSTEM && it.comment == message
         }

--- a/grails-app/services/org/pih/warehouse/inboundSortation/PutawayStrategyService.groovy
+++ b/grails-app/services/org/pih/warehouse/inboundSortation/PutawayStrategyService.groovy
@@ -25,11 +25,9 @@ class PutawayStrategyService {
             }
         }
 
-        // FIXME There should not be any quantity remaining at this point unless
-        //  we've create a strategy that takes location capacity into account
-        //  (i.e. strategies that limit the quantity allowed per strategy)
         if (quantityRemaining > 0) {
-            throw new RuntimeException("Quantity remaining should be 0 at this point. Something went wrong.")
+            log.warn("No putaway destination for ${quantityRemaining} of product " +
+                    "${context.product?.productCode} in facility ${context.facility?.name}")
         }
 
         return results

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -2233,11 +2233,21 @@ class StockMovementService {
     }
 
     List<AvailableItem> getAvailableItems(Location location, RequisitionItem requisitionItem, Boolean calculateStatus) {
+        return getAvailableItems(location, requisitionItem, calculateStatus, true)
+    }
+
+    List<AvailableItem> getAvailableItems(Location location, RequisitionItem requisitionItem, Boolean calculateStatus, Boolean releaseOwnAllocation) {
         List<AvailableItem> availableItems = productAvailabilityService.getAllAvailableBinLocations(location, requisitionItem.product?.id)
         def picklistItems = getPicklistItems(requisitionItem)
 
         availableItems = availableItems.findAll { it.quantityOnHand > 0 }
-        availableItems = calculateQuantityAvailableToPromise(availableItems, picklistItems)
+        availableItems = availableItems.findAll {
+            !it.binLocation?.supports(ActivityCode.INBOUND_SORTATION) &&
+                    !it.binLocation?.supports(ActivityCode.PUTAWAY_CART)
+        }
+        if (releaseOwnAllocation) {
+            availableItems = calculateQuantityAvailableToPromise(availableItems, picklistItems)
+        }
 
         if (calculateStatus) {
             return calculateAvailableItemsStatus(requisitionItem, availableItems)

--- a/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/StockMovementService.groovy
@@ -2241,6 +2241,7 @@ class StockMovementService {
         def picklistItems = getPicklistItems(requisitionItem)
 
         availableItems = availableItems.findAll { it.quantityOnHand > 0 }
+        // FIXME Replace these activity markers with a dedicated ALLOCATE_STOCK activity code.
         availableItems = availableItems.findAll {
             !it.binLocation?.supports(ActivityCode.INBOUND_SORTATION) &&
                     !it.binLocation?.supports(ActivityCode.PUTAWAY_CART)

--- a/grails-app/services/org/pih/warehouse/putaway/PutawayTaskCompletedEventService.groovy
+++ b/grails-app/services/org/pih/warehouse/putaway/PutawayTaskCompletedEventService.groovy
@@ -9,17 +9,42 @@
  **/
 package org.pih.warehouse.putaway
 
+import grails.core.GrailsApplication
+import org.pih.warehouse.allocation.AutomaticBackorderReallocationEvent
+import org.pih.warehouse.core.PutawayTypeCode
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
 
 class PutawayTaskCompletedEventService {
 
     def productAvailabilityService
+    GrailsApplication grailsApplication
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     void onPutawayTaskCompleted(PutawayTaskCompletedEvent event) {
         PutawayTask task = (PutawayTask) event.source
         log.info "Putaway ${task?.id} completed; refreshing PA for facility=${task?.facility?.id}, product=${task?.product?.id}"
         productAvailabilityService.triggerRefreshProductAvailability(task?.facility?.id, [task?.product?.id], event?.forceRefresh)
+
+        requestBackorderAllocation(task?.id)
+    }
+
+    private void requestBackorderAllocation(String taskId) {
+        if (!taskId) {
+            return
+        }
+        PutawayTask.withNewTransaction {
+            PutawayTask task = PutawayTask.get(taskId)
+            if (task?.putawayTypeCode != PutawayTypeCode.CROSS_DOCK) {
+                return
+            }
+            String shipmentId = task.shipmentItem?.shipment?.id
+            if (!shipmentId) {
+                log.warn "Cross-dock putaway ${taskId} has no shipment, cannot trigger backorder allocation"
+                return
+            }
+            log.info "Cross-dock putaway ${taskId} completed; requesting backorder allocation for shipment ${shipmentId}"
+            grailsApplication.mainContext.publishEvent(new AutomaticBackorderReallocationEvent(shipmentId))
+        }
     }
 }

--- a/grails-app/services/org/pih/warehouse/putaway/PutawayTaskService.groovy
+++ b/grails-app/services/org/pih/warehouse/putaway/PutawayTaskService.groovy
@@ -14,6 +14,7 @@ import org.pih.warehouse.auth.AuthService
 import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.core.Person
+import org.pih.warehouse.core.PutawayTypeCode
 import org.pih.warehouse.core.ReasonCode
 import org.pih.warehouse.inventory.InventoryLevel
 import org.pih.warehouse.inventory.InventoryService
@@ -24,6 +25,7 @@ import org.pih.warehouse.order.OrderItem
 import org.pih.warehouse.order.OrderItemStatusCode
 import org.pih.warehouse.order.OrderStatus
 import org.pih.warehouse.putaway.discrepancy.PutawayDiscrepancyEvent
+import org.pih.warehouse.shipping.Shipment
 
 @Transactional
 class PutawayTaskService {
@@ -553,7 +555,13 @@ class PutawayTaskService {
         task.discard()
 
         // Create transaction
-        inventoryService.transferStock(command)
+        Transaction transaction = inventoryService.transferStock(command)
+        if (transaction?.hasErrors()) {
+            String errorMessage = transaction.errors.allErrors.collect { it.defaultMessage ?: it.code }.join('; ')
+            throw new ValidationException(
+                    "Unable to transfer stock for putaway task ${task?.identifier}: ${errorMessage}",
+                    transaction.errors)
+        }
 
         // Emit putawayTask.completed event which will refresh the product availability table
         grailsApplication.mainContext.publishEvent(new PutawayTaskCompletedEvent(task))
@@ -639,6 +647,32 @@ class PutawayTaskService {
         }
 
         return discrepancyLocation
+    }
+
+    /**
+     * Whether the shipment still has a cross-dock putaway that has not been completed or canceled.
+     * Allocation has to wait for it, because until the putaway runs the stock is still sitting in
+     * inbound sortation where it must not be allocated from.
+     */
+    @Transactional(readOnly = true)
+    boolean hasOpenCrossDockTask(Shipment shipment) {
+        if (!shipment) {
+            return false
+        }
+        List<PutawayTask> openTasks = PutawayTask.createCriteria().list {
+            not {
+                'in'('status', [PutawayTaskStatus.COMPLETED, PutawayTaskStatus.CANCELED])
+            }
+            putawayOrderItem {
+                receiptItem {
+                    shipmentItem {
+                        eq('shipment', shipment)
+                    }
+                }
+            }
+        } as List<PutawayTask>
+
+        return openTasks.any { it.putawayTypeCode == PutawayTypeCode.CROSS_DOCK }
     }
 
     List<Location> getAlternateDestinations(PutawayTask task) {

--- a/src/main/groovy/org/pih/warehouse/allocation/AllocationRequest.groovy
+++ b/src/main/groovy/org/pih/warehouse/allocation/AllocationRequest.groovy
@@ -21,7 +21,7 @@ class AllocationRequest {
 
     /**
      * Set only by the cross-dock release, once the putaway has moved the stock into the cross-dock
-     * zone. Ordinary allocation must leave a sales linked demand alone until then.
+     * zone. Ordinary allocation must leave a backordered demand alone until then.
      */
     Boolean crossDockRelease = false
 }

--- a/src/main/groovy/org/pih/warehouse/allocation/BackorderMatch.groovy
+++ b/src/main/groovy/org/pih/warehouse/allocation/BackorderMatch.groovy
@@ -9,19 +9,17 @@
  **/
 package org.pih.warehouse.allocation
 
-import org.pih.warehouse.api.AvailableItem
 import org.pih.warehouse.requisition.RequisitionItem
+import org.pih.warehouse.shipping.ShipmentItem
 
-class AllocationRequest {
-    Integer quantityRequired
-    RequisitionItem requisitionItem
-    AllocationMode allocationMode
-    List<AvailableItem> availableItems
-    List<AllocationSourceStrategy> allocationStrategies
+class BackorderMatch {
 
-    /**
-     * Set only by the cross-dock release, once the putaway has moved the stock into the cross-dock
-     * zone. Ordinary allocation must leave a sales linked demand alone until then.
-     */
-    Boolean crossDockRelease = false
+    ShipmentItem inboundItem
+    RequisitionItem demand
+    Integer quantityMatched
+
+    @Override
+    String toString() {
+        return "BackorderMatch(demand=${demand?.id}, product=${demand?.product?.productCode}, quantity=${quantityMatched})"
+    }
 }

--- a/src/main/groovy/org/pih/warehouse/inboundSortation/PutawayContext.groovy
+++ b/src/main/groovy/org/pih/warehouse/inboundSortation/PutawayContext.groovy
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2012 Partners In Health.  All rights reserved.
+ * The use and distribution terms for this software are covered by the
+ * Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+ * which can be found in the file epl-v10.html at the root of this distribution.
+ * By using this software in any fashion, you are agreeing to be bound by
+ * the terms of this license.
+ * You must not remove this notice, or any other, from this software.
+ **/
 package org.pih.warehouse.inboundSortation
 
 import org.pih.warehouse.core.DeliveryTypeCode

--- a/src/main/groovy/org/pih/warehouse/inboundSortation/strategy/CrossDockPutawayStrategy.groovy
+++ b/src/main/groovy/org/pih/warehouse/inboundSortation/strategy/CrossDockPutawayStrategy.groovy
@@ -1,15 +1,26 @@
+/**
+ * Copyright (c) 2012 Partners In Health.  All rights reserved.
+ * The use and distribution terms for this software are covered by the
+ * Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+ * which can be found in the file epl-v10.html at the root of this distribution.
+ * By using this software in any fashion, you are agreeing to be bound by
+ * the terms of this license.
+ * You must not remove this notice, or any other, from this software.
+ **/
 package org.pih.warehouse.inboundSortation.strategy
 
+import groovy.util.logging.Slf4j
+import org.pih.warehouse.allocation.BackorderMatch
+import org.pih.warehouse.allocation.BackorderMatchingService
 import org.pih.warehouse.core.ActivityCode
 import org.pih.warehouse.core.Location
 import org.pih.warehouse.inboundSortation.PutawayContext
 import org.pih.warehouse.inboundSortation.PutawayResult
-import org.pih.warehouse.requisition.Requisition
-import org.pih.warehouse.requisition.RequisitionItem
 
-import javax.xml.bind.ValidationException
-
+@Slf4j
 class CrossDockPutawayStrategy implements PutawayStrategy {
+
+    BackorderMatchingService backorderMatchingService
 
     @Override
     List<PutawayResult> execute(PutawayContext context, List<Location> locations, Integer quantityRemaining, List<PutawayResult> putawayResults) {
@@ -19,36 +30,38 @@ class CrossDockPutawayStrategy implements PutawayStrategy {
             return putawayTasks
         }
 
-        def requisitionItem = context.backorderItem
-        if (!requisitionItem) {
-            Requisition backorder = Requisition.findByRequestNumber(context.backorderReference)
-            if (!backorder) {
-                throw new ValidationException("No backorder found for '${context.backorderReference}' backorderReference")
-            }
-            requisitionItem = backorder.requisitionItems.find {
-                it.product == context.product && it.quantity <= context.quantity && !it.isAllocated()
-            } as RequisitionItem
-        }
-        if (!requisitionItem) {
-            throw new ValidationException("No match for product '${context.product}' and quantity '${context.quantity}'")
+        BackorderMatch match = backorderMatchingService.resolveCrossDockMatch(
+                context.backorderReference, context.backorderItem, context.product, quantityRemaining)
+        if (!match) {
+            log.warn("No demand left to cover for product ${context.product?.productCode} on backorder " +
+                    "${context.backorderReference ?: context.backorderItem?.requisition?.requestNumber}. " +
+                    "Quantity will be putaway to storage.")
+            return putawayTasks
         }
 
         // delivery type is only known once the backorder/requisition has been resolved, so populate it on the context
         // before delegating the container assignment to the facility-configured strategy
-        context.deliveryTypeCode = requisitionItem.requisition.deliveryTypeCode
+        context.deliveryTypeCode = match.demand.requisition.deliveryTypeCode
         ActivityCode deliveryActivityCode = context.deliveryTypeCode?.activityCode
-        Location destination = locations.find { (deliveryActivityCode && it.supports(deliveryActivityCode)) && it.supports(ActivityCode.STAGING_LOCATION) }
-        if (destination) {
-            putawayTasks << new PutawayResult(
-                    facility: context.facility,
-                    product: context.product,
-                    inventoryItem: context.inventoryItem,
-                    location: context.currentBinLocation,
-                    destination: destination,
-                    container: resolvePutawayContainer(context, locations, destination),
-                    quantity: requisitionItem.quantity,
-            )
+        Location destination = locations.find {
+            deliveryActivityCode && it.supports(ActivityCode.CROSS_DOCKING) && it.supports(deliveryActivityCode)
         }
+        if (!destination) {
+            log.warn("No cross-dock zone found for delivery type ${context.deliveryTypeCode} in facility " +
+                    "${context.facility?.name}. Quantity will be putaway to storage.")
+            return putawayTasks
+        }
+
+        putawayTasks << new PutawayResult(
+                facility: context.facility,
+                product: context.product,
+                inventoryItem: context.inventoryItem,
+                location: context.currentBinLocation,
+                destination: destination,
+                container: resolvePutawayContainer(context, locations, destination),
+                quantity: Math.min(match.quantityMatched, quantityRemaining),
+                comment: "Cross-Docking",
+        )
         return putawayTasks
     }
 }

--- a/src/main/groovy/org/pih/warehouse/inboundSortation/strategy/DirectedPutawayStrategy.groovy
+++ b/src/main/groovy/org/pih/warehouse/inboundSortation/strategy/DirectedPutawayStrategy.groovy
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2012 Partners In Health.  All rights reserved.
+ * The use and distribution terms for this software are covered by the
+ * Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+ * which can be found in the file epl-v10.html at the root of this distribution.
+ * By using this software in any fashion, you are agreeing to be bound by
+ * the terms of this license.
+ * You must not remove this notice, or any other, from this software.
+ **/
 package org.pih.warehouse.inboundSortation.strategy
 
 import org.pih.warehouse.core.ActivityCode


### PR DESCRIPTION
PR resolves different issues related to cross dock issues. Related ticket: 
* https://openboxes.atlassian.net/browse/OBLS-858
* https://openboxes.atlassian.net/browse/OBLS-851
* https://openboxes.atlassian.net/browse/OBLS-883
* https://openboxes.atlassian.net/browse/OBLS-906
* (maybe some other as well)

This handles all three quantity relations between an inbound carrying a sales link (`ShipmentItem.backorderReference`) and the outbound demand it covers, and moves cross-dock allocation to the moment the putaway is completed.

* inbound qty = demand qty --> one cross-dock putaway; nothing is allocated while the stock sits in inbound sortation
* inbound qty > demand qty --> demanded quantity to the cross-dock zone, surplus to storage
* inbound qty < demand qty --> what arrived goes to cross-dock, remainder may come from ordinary stock, anything left stays backordered for the next

Two separate locations per delivery type:
 - **cross-dock location** - `CROSS_DOCKING` + one `DELIVERY_TYPE_*` + `PICK_STOCK`, **no** `HOLD_STOCK`
- **staging location** - `STAGING_LOCATION` + `HOLD_STOCK` + one `DELIVERY_TYPE_*`, **no** `CROSS_DOCKING`

Allocating from Inbound Sortation locations is disallowed now.