### PR TITLE
OBPIH-7871 hide revert to original button in modal

### DIFF
--- a/src/js/components/receivingV2/editModal/ReceivingLineItemsTable.jsx
+++ b/src/js/components/receivingV2/editModal/ReceivingLineItemsTable.jsx
@@ -23,6 +23,10 @@ const ReceivingLineItemsTable = ({
             clickable={false}
           />
         </div>
+        {/* TODO: This button is hidden (instead of removed) since we are revising its behaviour.
+                  The revision is scheduled for 0.9.10, but if we decide the button isn't needed,
+                  it and its existing (broken) functionality should be removed entirely. */}
+        {false && (
         <Button
           label="react.receiving.revertToOriginal.label"
           defaultLabel="Revert to original"
@@ -30,6 +34,7 @@ const ReceivingLineItemsTable = ({
           EndIcon={<RiArrowGoBackLine size={18} />}
           onClick={revertToOriginal}
         />
+        )}
       </div>
       <form className="receiving-table mt-2">
         <DataTable


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7871

**Description:** For 0.9.9 we're simply hiding the button. In 0.9.10 we will revisit the functionality and decide if we want to implement it properly or remove the code entirely.