### PR TITLE
OBPIH-7995 root cause not deserializing in Cycle Count

### DIFF
--- a/src/js/hooks/cycleCount/useResolveStep.js
+++ b/src/js/hooks/cycleCount/useResolveStep.js
@@ -133,9 +133,9 @@ const useResolveStep = () => {
   }, [currentLocation?.id]);
 
   const mapRootCauseToSelectedOption = (rootCause) => (rootCause ? ({
-    id: rootCause?.name,
-    label: reasonCodes?.find?.((reasonCode) => reasonCode?.id === rootCause?.name)?.label,
-    value: rootCause?.name,
+    id: rootCause,
+    label: reasonCodes?.find?.((reasonCode) => reasonCode?.id === rootCause)?.label,
+    value: rootCause,
   }) : null);
 
   const mergeCycleCountItems = (items) => {


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7995

**Description:** This is because the structure of how enums are represented in JSON has changed with the new object mapper.

new format:

```
"discrepancyReasonCode": "DAMAGED",
```
old format:

```
"discrepancyReasonCode": {
    "enumType": "org.pih.warehouse.core.ReasonCode",
    "name": "DAMAGED"
},
```
I fixed the frontend to account for this. This only impacts APIs that use the new BaseController, which currently is just CC and receiving