### PR TITLE
OBLS-955 Properly display negative inventory on the product's stock card

### DIFF
--- a/grails-app/domain/org/pih/warehouse/core/Location.groovy
+++ b/grails-app/domain/org/pih/warehouse/core/Location.groovy
@@ -410,6 +410,14 @@ class Location implements Comparable<Location>, java.io.Serializable {
         return supports(ActivityCode.NEGATIVE_INVENTORY_FALLBACK)
     }
 
+    /**
+     * Whether this location may legitimately hold a negative quantity, either because it directly allows
+     * negative inventory or because it's the fallback location that absorbs negative inventory.
+     */
+    Boolean isNegativeInventorySupported() {
+        return isNegativeInventoryAllowed() || isNegativeInventoryFallbackLocation()
+    }
+
     LocationPurpose getLocationPurpose() {
         if (supports(ActivityCode.DISPLAY_STOCK)) {
             return LocationPurpose.DISPLAY

--- a/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
@@ -1280,8 +1280,9 @@ class InventoryService implements ApplicationContextAware {
                     def quantityAvailableMap = quantityAvailableInventoryItemMap[product][inventoryItem]
                     Integer quantityAvailable = quantityAvailableMap ? quantityAvailableMap[binLocation?.id] : 0
 
-                    // We don't want to show the negative values on the frontend
-                    quantityAvailable = quantityAvailable > 0 ? quantityAvailable : 0
+                    // A negative available quantity is normally a data anomaly and gets hidden as 0, but on a
+                    // bin that supports negative inventory it's a legitimate quantity and should be shown as-is
+                    quantityAvailable = (quantityAvailable > 0 || binLocation?.isNegativeInventoryAllowed()) ? quantityAvailable : 0
 
                     // Exclude bin locations with quantity 0 (include negative quantity for data quality purposes)
                     if (quantityOnHand != 0) {
@@ -1328,17 +1329,19 @@ class InventoryService implements ApplicationContextAware {
     }
 
     Integer getQuantityAvailableToPromise(Product product, Location location) {
-        def productAvailability = ProductAvailability.createCriteria().get {
-            projections {
-                sum("quantityAvailableToPromise")
-            }
+        List<ProductAvailability> productAvailabilityRecords = ProductAvailability.createCriteria().list {
             eq("location", location)
             eq("product", product)
-            // Filter out negative quantity available to promise (in a case when a record was picked and then recalled)
-            ge("quantityAvailableToPromise", 0)
         }
 
-        return productAvailability ?: 0
+        // A negative ATP record is normally a data anomaly (e.g. a pick that was later recalled) and should not
+        // pull down the total, but on a bin that supports negative inventory it's a legitimate quantity and
+        // must still be counted, otherwise the total would be overstated
+        Integer quantityAvailableToPromise = productAvailabilityRecords?.sum {
+            (it.quantityAvailableToPromise >= 0 || it.binLocation?.isNegativeInventoryAllowed()) ? it.quantityAvailableToPromise : 0
+        } as Integer ?: 0
+
+        return quantityAvailableToPromise ?: 0
     }
 
 

--- a/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
+++ b/grails-app/services/org/pih/warehouse/inventory/InventoryService.groovy
@@ -1282,7 +1282,7 @@ class InventoryService implements ApplicationContextAware {
 
                     // A negative available quantity is normally a data anomaly and gets hidden as 0, but on a
                     // bin that supports negative inventory it's a legitimate quantity and should be shown as-is
-                    quantityAvailable = (quantityAvailable > 0 || binLocation?.isNegativeInventoryAllowed()) ? quantityAvailable : 0
+                    quantityAvailable = (quantityAvailable > 0 || binLocation?.isNegativeInventorySupported()) ? quantityAvailable : 0
 
                     // Exclude bin locations with quantity 0 (include negative quantity for data quality purposes)
                     if (quantityOnHand != 0) {
@@ -1338,7 +1338,7 @@ class InventoryService implements ApplicationContextAware {
         // pull down the total, but on a bin that supports negative inventory it's a legitimate quantity and
         // must still be counted, otherwise the total would be overstated
         Integer quantityAvailableToPromise = productAvailabilityRecords?.sum {
-            (it.quantityAvailableToPromise >= 0 || it.binLocation?.isNegativeInventoryAllowed()) ? it.quantityAvailableToPromise : 0
+            (it.quantityAvailableToPromise >= 0 || it.binLocation?.isNegativeInventorySupported()) ? it.quantityAvailableToPromise : 0
         } as Integer ?: 0
 
         return quantityAvailableToPromise ?: 0

--- a/grails-app/views/inventoryItem/_productDetails.gsp
+++ b/grails-app/views/inventoryItem/_productDetails.gsp
@@ -27,7 +27,7 @@ ul.assigned-locations li {
                     <label><warehouse:message code="product.onHandQuantity.label"/></label>
                 </td>
                 <td class="value">
-                    <div>
+                    <div class="${totalQuantity < 0 ? 'negative-quantity' : ''}">
                         ${g.formatNumber(number: totalQuantity, format: '###,###,###') }
                         <g:if test="${productInstance?.unitOfMeasure }">
                             <format:metadata obj="${productInstance?.unitOfMeasure}"/>
@@ -51,24 +51,22 @@ ul.assigned-locations li {
                     </g:if>
                 </td>
             </tr>
-            <g:if test="${totalQuantityAvailableToPromise >= 0}">
-                <tr class="prop">
-                    <td class="label">
-                        <label><warehouse:message code="product.quantityAvailableToPromise.label" default="Quantity Available"/></label>
-                    </td>
-                    <td class="value">
-                        <div>
-                            ${g.formatNumber(number: totalQuantityAvailableToPromise, format: '###,###,###') }
-                            <g:if test="${productInstance?.unitOfMeasure }">
-                                <format:metadata obj="${productInstance?.unitOfMeasure}"/>
-                            </g:if>
-                            <g:else>
-                                ${warehouse.message(code:'default.each.label') }
-                            </g:else>
-                        </div>
-                    </td>
-                </tr>
-            </g:if>
+            <tr class="prop">
+                <td class="label">
+                    <label><warehouse:message code="product.quantityAvailableToPromise.label" default="Quantity Available"/></label>
+                </td>
+                <td class="value">
+                    <div class="${totalQuantityAvailableToPromise < 0 ? 'negative-quantity' : ''}">
+                        ${g.formatNumber(number: totalQuantityAvailableToPromise, format: '###,###,###') }
+                        <g:if test="${productInstance?.unitOfMeasure }">
+                            <format:metadata obj="${productInstance?.unitOfMeasure}"/>
+                        </g:if>
+                        <g:else>
+                            ${warehouse.message(code:'default.each.label') }
+                        </g:else>
+                    </div>
+                </td>
+            </tr>
             <g:if test="${grailsApplication.config.openboxes.forecasting.enabled}">
                 <tr class="prop">
                     <td class="label">

--- a/grails-app/views/inventoryItem/_showCurrentStock.gsp
+++ b/grails-app/views/inventoryItem/_showCurrentStock.gsp
@@ -36,6 +36,8 @@
             </g:isSuperuser>
             <g:each var="entry" in="${commandInstance.availableItems}" status="status">
                 <g:set var="styleClass" value="${(status%2==0)?'even':'odd' } ${entry?.recalled ? 'recalled' : (entry?.onHold ? 'restricted' : '')}"/>
+                <g:set var="quantityOnHandStyleClass" value="${entry?.quantityOnHand < 0 ? 'negative-quantity' : ''}"/>
+                <g:set var="quantityAvailableStyleClass" value="${entry?.quantityAvailable < 0 ? 'negative-quantity' : ''}"/>
                 <tr class="prop ${styleClass}" title="${entry?.inventoryItem?.lotStatus == LotStatusCode.RECALLED ? warehouse.message(code: 'inventoryItem.recalledLot.label') : (entry?.onHold ?  warehouse.message(code: 'inventoryItem.restrictedBin.label') : '')}">
                     <td class="middle" style="text-align: left; width: 10%" nowrap="nowrap">
                         <g:render template="actionsCurrentStock"
@@ -65,11 +67,11 @@
                     <td>
                         <g:expirationDate date="${entry?.inventoryItem?.expirationDate}"/>
                     </td>
-                    <td>
+                    <td class="${quantityOnHandStyleClass}">
                         ${g.formatNumber(number: entry?.quantityOnHand, format: '###,###,###') }
                         ${entry?.inventoryItem?.product?.unitOfMeasure}
                     </td>
-                    <td>
+                    <td class="${quantityAvailableStyleClass}">
                         ${g.formatNumber(number: entry?.quantityAvailable, format: '###,###,###') }
                         ${entry?.inventoryItem?.product?.unitOfMeasure}
                     </td>
@@ -103,14 +105,8 @@
                 </td>
                 <td>
                     <div class="large">
-                        <g:set var="styleClass" value="color: black;"/>
-                        <g:if test="${commandInstance.totalQuantity < 0}">
-                            <g:set var="styleClass" value="color: red;"/>
-                        </g:if>
-                        <span style="${styleClass }" id="totalQuantity">
+                        <span class="${commandInstance.totalQuantity < 0 ? 'negative-quantity' : ''}" id="totalQuantity">
                             ${g.formatNumber(number: commandInstance.totalQuantity, format: '###,###,###') }
-                        </span>
-                        <span class="">
                             <g:if test="${commandInstance?.product?.unitOfMeasure }">
                                 <format:metadata obj="${commandInstance?.product?.unitOfMeasure}"/>
                             </g:if>
@@ -122,14 +118,8 @@
                 </td>
                 <td>
                     <div class="large">
-                        <g:set var="styleClass" value="color: black;"/>
-                        <g:if test="${commandInstance.totalQuantityAvailableToPromise < 0}">
-                            <g:set var="styleClass" value="color: red;"/>
-                        </g:if>
-                        <span style="${styleClass }" id="totalQuantityAvailableToPromise">
+                        <span class="${commandInstance.totalQuantityAvailableToPromise < 0 ? 'negative-quantity' : ''}" id="totalQuantityAvailableToPromise">
                             ${g.formatNumber(number: commandInstance.totalQuantityAvailableToPromise, format: '###,###,###') }
-                        </span>
-                        <span class="">
                             <g:if test="${commandInstance?.product?.unitOfMeasure }">
                                 <format:metadata obj="${commandInstance?.product?.unitOfMeasure}"/>
                             </g:if>

--- a/grails-app/views/layouts/stockCard.gsp
+++ b/grails-app/views/layouts/stockCard.gsp
@@ -37,6 +37,11 @@
 		.restricted {
 			background-color: #fff3cd !important;
 		}
+
+		.negative-quantity {
+			color: #d9534f;
+			font-weight: bold;
+		}
 	</style>
 </head>
 <body>


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-955

<img width="1899" height="874" alt="image" src="https://github.com/user-attachments/assets/ab235998-2b01-40b4-b2d3-24b90b0da02c" />


FYI: If there is someone out of the loop looking into this PR, negative stock on a specific bin is allowed in VVG project (if configured properly)