### PR TITLE
fix: keep translation mode locale out of user language choices

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -563,7 +563,7 @@ openboxes:
             enabled: false
         defaultLocale: 'en'
         localizationModeLocale: 'ach'
-        supportedLocales: ['ar', 'ach', 'de', 'en', 'es', 'es_MX', 'fr', 'ht', 'it', 'pt', 'fi', 'zh']
+        supportedLocales: ['ar', 'de', 'en', 'es', 'es_MX', 'fr', 'ht', 'it', 'pt', 'fi', 'zh']
         # Currency configuration
         defaultCurrencyCode: "USD"
         defaultCurrencySymbol: '\$'

--- a/grails-app/controllers/org/pih/warehouse/api/ApiController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/api/ApiController.groovy
@@ -180,7 +180,7 @@ class ApiController {
         def logoLabel = grailsApplication.config.openboxes.logo.label
         def pageSize = grailsApplication.config.openboxes.api.pagination.pageSize
         def logoUrl = location?.logo ? "${createLink(controller: 'location', action: 'viewLogo', id: location?.id)}" : grailsApplication.config.openboxes.logo.url
-        def locales = grailsApplication.config.openboxes.locale.supportedLocales
+        def locales = LocalizationUtil.supportedLocaleCodes
         def browserConnectionTimeout = grailsApplication.config.openboxes.browser.connection.status.timeout
         def isAutosaveEnabled = grailsApplication.config.openboxes.client.autosave.enabled &&
                 supportedActivities.contains(ActivityCode.AUTOSAVE.name())

--- a/grails-app/services/org/pih/warehouse/core/LocalizationService.groovy
+++ b/grails-app/services/org/pih/warehouse/core/LocalizationService.groovy
@@ -31,8 +31,9 @@ class LocalizationService {
     @Value('${openboxes.locale.custom.enabled}')
     boolean localizationDatabaseEnabled
 
-    @Value('${openboxes.locale.supportedLocales}')
-    String[] supportedLocales
+    String[] getSupportedLocales() {
+        return LocalizationUtil.supportedLocaleCodes as String[]
+    }
 
     String formatMetadata(Object object) {
         def format = grailsApplication.mainContext.getBean('org.pih.warehouse.FormatTagLib')

--- a/grails-app/services/org/pih/warehouse/importer/ProductSynonymImportDataService.groovy
+++ b/grails-app/services/org/pih/warehouse/importer/ProductSynonymImportDataService.groovy
@@ -57,7 +57,7 @@ class ProductSynonymImportDataService implements ImportDataService {
             }
 
             if (params['locale']) {
-                List<String> supportedLocales = grailsApplication.config.openboxes.locale.supportedLocales
+                List<String> supportedLocales = LocalizationUtil.supportedLocaleCodes
                 String foundLocale = supportedLocales.find {
                     it.toLowerCase() == params['locale']?.toLowerCase() || LocalizationUtil.getLocale(it).displayName?.toLowerCase() == params['locale']?.toLowerCase()
                 }

--- a/grails-app/taglib/org/pih/warehouse/SelectTagLib.groovy
+++ b/grails-app/taglib/org/pih/warehouse/SelectTagLib.groovy
@@ -759,7 +759,7 @@ class SelectTagLib {
     }
 
     def selectLocale = { attrs, body ->
-        attrs.from = grailsApplication.config.openboxes.locale.supportedLocales?.sort()
+        attrs.from = LocalizationUtil.supportedLocaleCodes?.sort()
         attrs.optionValue = { LocalizationUtil.getLocale(it).getDisplayName(LocalizationUtil.currentLocale) }
         out << g.select(attrs)
     }

--- a/grails-app/utils/org/pih/warehouse/LocalizationUtil.groovy
+++ b/grails-app/utils/org/pih/warehouse/LocalizationUtil.groovy
@@ -49,9 +49,18 @@ class LocalizationUtil {
         return StringUtils.parseLocaleString(localeCode)
     }
 
+    /**
+     * Locales that users can select. The Crowdin locale is reserved for the dedicated localization mode,
+     * even when an existing installation still includes it in supportedLocales.
+     */
+    static List<String> getSupportedLocaleCodes() {
+        def localeConfig = Holders.config.openboxes.locale
+        Locale localizationModeLocale = getLocale(localeConfig.localizationModeLocale)
+        return localeConfig.supportedLocales.findAll { getLocale(it) != localizationModeLocale }
+    }
+
     static List<Locale> getSupportedLocales() {
-        def supportedLocales = Holders.config.openboxes.locale.supportedLocales
-        return supportedLocales.collect { getLocale(it) }
+        return supportedLocaleCodes.collect { getLocale(it) }
     }
 
     static String getLocalizedString(Transaction transaction) {

--- a/grails-app/views/admin/showSettings.gsp
+++ b/grails-app/views/admin/showSettings.gsp
@@ -138,7 +138,7 @@
                                 </td>
                                 <td class="value">
                                     <ul>
-                                    <g:each in="${grailsApplication.config.openboxes.locale.supportedLocales}" var="l">
+                                    <g:each in="${LocalizationUtil.supportedLocaleCodes}" var="l">
                                         <li>
                                         <g:set var="locale" value="${LocalizationUtil.getLocale(l)}"/>
                                         <g:set var="defaultLocale" value="${new Locale(grailsApplication.config.openboxes.locale.defaultLocale)}"/>

--- a/grails-app/views/common/_footer.gsp
+++ b/grails-app/views/common/_footer.gsp
@@ -20,7 +20,7 @@
 		<g:message code="default.locale.label"/>: &nbsp;
 		<!-- show all supported locales -->
 		<g:set var="targetUri" value="${(request.forwardURI - request.contextPath) + '?' + (request.queryString?:'') }"/>
-		<g:each in="${grailsApplication.config.openboxes.locale.supportedLocales}" var="l">
+		<g:each in="${LocalizationUtil.supportedLocaleCodes}" var="l">
 			<g:set var="locale" value="${LocalizationUtil.getLocale(l)}"/>
 			<g:set var="selected" value="${locale == (session?.locale ?: session?.user?.locale)}"/>
             <g:set var="localizationModeLocale" value="${new Locale(grailsApplication.config.openboxes.locale.localizationModeLocale)}" />

--- a/grails-app/views/user/create.gsp
+++ b/grails-app/views/user/create.gsp
@@ -86,7 +86,7 @@
 	                                  <label for="locale"><warehouse:message code="default.locale.label"/></label>
 	                                </td>
 	                                <td valign="top" class="value ${hasErrors(bean: userInstance, field: 'locale', 'errors')}">
-	                                    <g:select name="locale" from="${ grailsApplication.config.openboxes.locale.supportedLocales.collect{ LocalizationUtil.getLocale(it) } }" optionValue="displayName" value="${userInstance?.locale}" noSelection="['':'']"/>
+	                                    <g:select name="locale" from="${ LocalizationUtil.supportedLocaleCodes.collect{ LocalizationUtil.getLocale(it) } }" optionValue="displayName" value="${userInstance?.locale}" noSelection="['':'']"/>
 	                                </td>
 	                         </tr>
 	                         <tr class="prop">

--- a/grails-app/views/user/edit.gsp
+++ b/grails-app/views/user/edit.gsp
@@ -96,7 +96,7 @@
                                               <label for="locale"><warehouse:message code="default.locale.label"/></label>
                                             </td>
                                             <td data-testid="locale-select" valign="top" class="value ${hasErrors(bean: userInstance, field: 'locale', 'errors')}">
-                                                <g:select name="locale" from="${ grailsApplication.config.openboxes.locale.supportedLocales.collect{ LocalizationUtil.getLocale(it) } }"
+                                                <g:select name="locale" from="${ LocalizationUtil.supportedLocaleCodes.collect{ LocalizationUtil.getLocale(it) } }"
                                                           optionValue="displayName" value="${userInstance?.locale}" noSelection="['':'']" class="chzn-select-deselect"/>
                                             </td>
                                         </tr>

--- a/src/integration-test/groovy/org/pih/warehouse/api/spec/core/LocalizationApiSpec.groovy
+++ b/src/integration-test/groovy/org/pih/warehouse/api/spec/core/LocalizationApiSpec.groovy
@@ -12,6 +12,17 @@ class LocalizationApiSpec extends ApiSpec {
     @Autowired
     LocalizationApiWrapper localizationApiWrapper
 
+    void 'localization mode messages remain available without offering its locale for selection'() {
+        when:
+        LocalizedMessagesDto messages = localizationApiWrapper.listOK('ach', 'default.lot.label')
+
+        then:
+        assert messages.currentLocale == new Locale('ach')
+        assert messages.messages.get('default.lot.label').startsWith('crwdns')
+        assert !messages.supportedLocales.contains('ach')
+        assert messages.supportedLocales.contains('en')
+    }
+
     void 'listing the messages returns without error for all supported locales'() {
         when: 'we fetch the default locale messages'
         LocalizedMessagesDto messages = localizationApiWrapper.listOK()

--- a/src/js/MainRouter.jsx
+++ b/src/js/MainRouter.jsx
@@ -21,7 +21,11 @@ class MainRouter extends React.Component {
   componentDidMount() {
     this.props.fetchSessionInfo().then(() => {
       this.props.initialize({
-        languages: this.props.supportedLocales,
+        // Register Crowdin for translation mode without exposing it in ordinary locale selectors.
+        languages: [...this.props.supportedLocales, {
+          code: this.props.localizationModeLocale,
+          name: this.props.localizationModeLocale,
+        }],
         options: {
           renderToStaticMarkup,
           onMissingTranslation,
@@ -55,6 +59,7 @@ class MainRouter extends React.Component {
 const mapStateToProps = (state) => ({
   locale: state.session.activeLanguage,
   supportedLocales: state.session.supportedLocales,
+  localizationModeLocale: state.session.localizationModeLocale,
 });
 
 export default withLocalize(connect(mapStateToProps, {
@@ -64,6 +69,7 @@ export default withLocalize(connect(mapStateToProps, {
 MainRouter.propTypes = {
   initialize: PropTypes.func.isRequired,
   locale: PropTypes.string.isRequired,
+  localizationModeLocale: PropTypes.string.isRequired,
   fetchTranslations: PropTypes.func.isRequired,
   setActiveLanguage: PropTypes.func.isRequired,
   /** Function called to get the currently selected location */

--- a/src/js/components/Layout/Footer.jsx
+++ b/src/js/components/Layout/Footer.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import { getLanguages, setActiveLanguage } from 'react-localize-redux';
+import { setActiveLanguage } from 'react-localize-redux';
 import { connect } from 'react-redux';
 
 import { changeCurrentLocale } from 'actions';
-import { DISABLE_LOCALIZATION, ENABLE_LOCALIZATION } from 'api/urls';
+import { DISABLE_LOCALIZATION } from 'api/urls';
 import Translate from 'utils/Translate';
 
 const Footer = ({
@@ -25,7 +25,6 @@ const Footer = ({
   environment,
   buildDate,
   localizationModeEnabled,
-  localizationModeLocale,
 }) => (
   <div className="border-top align-self-end text-center py-2 w-100 footer">
     <div className="d-flex flex-row justify-content-center m-2 flex-wrap">
@@ -98,18 +97,6 @@ const Footer = ({
         {' '}
         {' '}
         { _.map(languages, (language) => {
-          // When clicking on language that is a translation mode language, enable localization mode
-          if (language.code === localizationModeLocale) {
-            return (
-              <a
-                className={`${locale === language.code ? 'selected' : ''}`}
-                key={language.code}
-                href={ENABLE_LOCALIZATION}
-              >
-                {language.name}
-              </a>
-            );
-          }
           // If we are in localization mode and we click on non-translation mode language,
           // we want to disable the localization mode
           if (localizationModeEnabled) {
@@ -184,9 +171,8 @@ const mapStateToProps = (state) => ({
   hostname: state.session.hostname,
   timezone: state.session.timezone,
   ipAddress: state.session.ipAddress,
-  languages: getLanguages(state.localize),
+  languages: state.session.supportedLocales,
   localizationModeEnabled: state.session.localizationModeEnabled,
-  localizationModeLocale: state.session.localizationModeLocale,
 });
 
 const mapDispatchToProps = {
@@ -212,5 +198,4 @@ Footer.propTypes = {
   timezone: PropTypes.string.isRequired,
   ipAddress: PropTypes.string.isRequired,
   localizationModeEnabled: PropTypes.bool.isRequired,
-  localizationModeLocale: PropTypes.string.isRequired,
 };

--- a/src/js/tests/menu/FooterLocales.test.jsx
+++ b/src/js/tests/menu/FooterLocales.test.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+import { DISABLE_LOCALIZATION } from 'api/urls';
+import Footer from 'components/Layout/Footer';
+
+jest.mock('utils/Translate', () => ({ defaultMessage }) => defaultMessage);
+jest.mock('actions', () => ({
+  changeCurrentLocale: (locale) => ({ type: 'CHANGE_LOCALE', locale }),
+}));
+
+const supportedLocales = [{ code: 'en', name: 'English' }, { code: 'fr', name: 'French' }];
+
+const createStore = (localizationModeEnabled = false) => configureStore()({
+  session: {
+    activeLanguage: localizationModeEnabled ? 'ach' : 'en',
+    supportedLocales,
+    localizationModeLocale: 'ach',
+    localizationModeEnabled,
+    grailsVersion: '',
+    appVersion: '',
+    branchName: '',
+    buildNumber: '',
+    environment: '',
+    buildDate: '',
+    hostname: '',
+    timezone: '',
+    ipAddress: '',
+  },
+  // Translation resources include Crowdin, but the selectable languages must not.
+  localize: {
+    languages: [...supportedLocales, { code: 'ach', name: 'Acholi' }],
+  },
+});
+
+describe('footer locale choices', () => {
+  it('offers only supported user locales even when Crowdin is registered for translation', () => {
+    const store = createStore();
+    render(<Provider store={store}><Footer /></Provider>);
+
+    expect(screen.queryByText('Acholi')).toBeNull();
+    expect(screen.getAllByRole('button').map((button) => button.textContent))
+      .toEqual(['English', 'French']);
+
+    fireEvent.click(screen.getByRole('button', { name: 'French' }));
+    expect(store.getActions()).toContainEqual({ type: 'CHANGE_LOCALE', locale: 'fr' });
+  });
+
+  it('keeps ordinary languages available to leave localization mode', () => {
+    render(<Provider store={createStore(true)}><Footer /></Provider>);
+
+    expect(screen.queryByText('Acholi')).toBeNull();
+    expect(screen.getByRole('link', { name: 'French' }).getAttribute('href'))
+      .toBe(DISABLE_LOCALIZATION('fr'));
+    expect(screen.getByRole('link', { name: 'English' }).getAttribute('href'))
+      .toBe(DISABLE_LOCALIZATION('en'));
+  });
+});

--- a/src/js/tests/menu/MainRouterLocales.test.jsx
+++ b/src/js/tests/menu/MainRouterLocales.test.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import { render, waitFor } from '@testing-library/react';
+import {
+  getActiveLanguage, initialize, localizeReducer, setActiveLanguage,
+} from 'react-localize-redux';
+
+import MainRouter from '../../MainRouter';
+
+jest.mock('components/Router', () => () => null);
+jest.mock('actions', () => ({}));
+jest.mock('react-redux/es/connect/connect', () => () => (component) => component);
+jest.mock('react-localize-redux', () => ({
+  ...jest.requireActual('react-localize-redux'),
+  withLocalize: (component) => component,
+}));
+
+describe('translation mode language registration', () => {
+  it('can activate Crowdin without adding it to selectable user locales', async () => {
+    const supportedLocales = [{ code: 'en', name: 'English' }, { code: 'fr', name: 'French' }];
+    let localizationState;
+    const initializeLanguages = jest.fn((settings) => {
+      localizationState = localizeReducer(undefined, initialize(settings));
+    });
+    const activateLanguage = jest.fn((code) => {
+      localizationState = localizeReducer(localizationState, setActiveLanguage(code));
+    });
+
+    render(
+      <MainRouter
+        supportedLocales={supportedLocales}
+        localizationModeLocale="ach"
+        locale="ach"
+        initialize={initializeLanguages}
+        setActiveLanguage={activateLanguage}
+        fetchSessionInfo={() => Promise.resolve()}
+        fetchTranslations={jest.fn()}
+        fetchMenuConfig={jest.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(activateLanguage).toHaveBeenCalledWith('ach'));
+    expect(getActiveLanguage(localizationState).code).toBe('ach');
+    expect(supportedLocales.map(({ code }) => code)).toEqual(['en', 'fr']);
+  });
+});

--- a/src/test/groovy/org/pih/warehouse/core/SupportedLocalesSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/core/SupportedLocalesSpec.groovy
@@ -1,0 +1,94 @@
+package org.pih.warehouse.core
+
+import org.grails.testing.GrailsUnitTest
+import org.grails.core.io.ResourceLocator
+import org.springframework.core.io.ClassPathResource
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import org.pih.warehouse.LocalizationUtil
+import org.pih.warehouse.core.localization.LocaleManager
+import org.pih.warehouse.core.localization.LocalizedMessagesDto
+import org.pih.warehouse.core.session.SessionManager
+
+class SupportedLocalesSpec extends Specification implements GrailsUnitTest {
+
+    void 'localization service loads Crowdin resources without advertising them as a selectable locale'() {
+        given:
+        grailsApplication.config.openboxes.locale.supportedLocales = ['en', 'ach', 'fr']
+        grailsApplication.config.openboxes.locale.localizationModeLocale = 'ach'
+        LocalizationService localizationService = new LocalizationService(
+                localeManager: new LocaleManager(defaultLocale: Locale.ENGLISH),
+                grailsResourceLocator: Stub(ResourceLocator) {
+                    findResourceForURI(_) >> { String uri -> new ClassPathResource(uri - 'classpath:') }
+                },
+        )
+
+        when:
+        LocalizedMessagesDto messages = localizationService.list('ach', 'default.lot.label')
+
+        then:
+        messages.currentLocale == new Locale('ach')
+        messages.messages.get('default.lot.label').startsWith('crwdns')
+        messages.supportedLocales as List == ['en', 'fr']
+    }
+
+    @Unroll
+    void 'supported locales exclude the configured localization mode locale: #translationLocale'() {
+        given:
+        grailsApplication.config.openboxes.locale.supportedLocales = configuredLocales
+        grailsApplication.config.openboxes.locale.localizationModeLocale = translationLocale
+
+        expect:
+        LocalizationUtil.supportedLocaleCodes == expectedCodes
+        LocalizationUtil.supportedLocales == expectedCodes.collect { LocalizationUtil.getLocale(it) }
+
+        and: 'reading the selectable locales does not alter the configured translation resources'
+        grailsApplication.config.openboxes.locale.supportedLocales == configuredLocales
+
+        where:
+        configuredLocales                 | translationLocale || expectedCodes
+        ['en', 'ach', 'fr', 'es_MX']       | 'ach'             || ['en', 'fr', 'es_MX']
+        ['en', 'fr', 'es_MX']              | 'ach'             || ['en', 'fr', 'es_MX']
+        ['en', 'ach', 'fr', 'es_MX']       | 'fr'              || ['en', 'ach', 'es_MX']
+        ['en', 'es_MX', 'es-MX', 'es']     | 'es_MX'           || ['en', 'es']
+        []                                | 'ach'             || []
+    }
+
+    void 'dedicated localization mode remains available when its locale is not selectable'() {
+        given:
+        grailsApplication.config.openboxes.locale.supportedLocales = ['en', 'fr']
+        grailsApplication.config.openboxes.locale.localizationModeLocale = 'ach'
+        Locale sessionLocale = Locale.FRENCH
+        Locale previousLocale
+        boolean localizationMode = false
+        SessionManager sessionManager = Stub(SessionManager) {
+            getLocale() >> { sessionLocale }
+            setLocale(_) >> { Locale locale -> sessionLocale = locale }
+            getPreviousLocale() >> { previousLocale }
+            setPreviousLocale(_) >> { Locale locale -> previousLocale = locale }
+            isInLocalizationMode() >> { localizationMode }
+            setIsInLocalizationMode(_) >> { boolean enabled -> localizationMode = enabled }
+        }
+        LocaleManager localeManager = new LocaleManager(
+                sessionManager: sessionManager,
+                defaultLocale: Locale.ENGLISH,
+                localizationModeLocale: new Locale('ach'),
+        )
+
+        when:
+        localeManager.enableLocalizationMode()
+
+        then:
+        sessionLocale == new Locale('ach')
+        localizationMode
+        LocalizationUtil.supportedLocaleCodes == ['en', 'fr']
+
+        when:
+        localeManager.disableLocalizationMode(null)
+
+        then:
+        sessionLocale == Locale.FRENCH
+        !localizationMode
+    }
+}


### PR DESCRIPTION
### Description of Change

Fixes #5484.

Ordinary language choices currently include the internal Crowdin locale, which can leave users in translation mode without a Crowdin account. This follows the issue's final clarification by excluding the configured `localizationModeLocale` from supported user locales across the application.

- Add one filtered locale source used by the session/localization APIs, React and GSP selectors, account forms, and product locale handling. Filter legacy configuration too, without mutating it; remove `ach` from the default selectable list.
- Register the internal locale separately with `react-localize-redux`, so the dedicated translation-mode controls and message loading remain available.
- Add regression coverage for legacy/custom locale configuration, regional spellings, translation-mode entry/exit, actual Crowdin message resources, React language registration, and footer choices. Add an API integration test for requesting Crowdin messages while excluding its locale from selectable choices.

### Validation

- Backend unit suite: 1,296 passed, 11 skipped (`./gradlew test -x npm_run_bundle --no-daemon`, Java 8).
- After adding the resource-loading check: all 7 cases in `SupportedLocalesSpec` passed.
- Frontend suite: 216 passed, 9 skipped; 23 snapshots passed (`npm test -- --runInBand`, Node 14).
- GSP views and integration tests compile (`compileGroovyPages compileIntegrationTestGroovy -x npm_run_bundle`).
- ESLint on changed JS/test files: no errors; 14 prop-destructuring warnings in `MainRouter`. `git diff --check` passes.

All **8 localization API integration tests passed on both MySQL 8.0.36 and MariaDB 10.3.39** on isolated GitHub-hosted runners: [verification run](https://github.com/Z-Lemke/openboxes/actions/runs/34075808216). The separate verification workflow checks out the exact PR commit `b6b3a68ab1a080a7b8967a90178fed83bde3d4b4`; its CI-only changes are not included in this PR.

The complete integration suite and manual authenticated browser testing have not been run. Upstream CI still needs maintainer approval; the fork run is additional evidence, not a substitute for required project checks.

### Agent authorship

Prepared, tested, and submitted by **OpenAI Codex, an AI agent**, at @Z-Lemke's explicit request to contribute to public-interest software. Another AI agent reviewed the implementation. No human code review or personal-testing attestation is claimed.
