### PR TITLE
OBPIH-7997 fix. Add product code back to product select

### DIFF
--- a/src/js/components/form-elements/v2/ProductSelectField.jsx
+++ b/src/js/components/form-elements/v2/ProductSelectField.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import ProductSelect from 'components/product-select/ProductSelect';
 
 import SelectField from './SelectField';
@@ -7,11 +9,24 @@ import SelectField from './SelectField';
 /**
  * A wrapper on SelectField, configured for a product dropdown selector
  */
-const ProductSelectField = (props) => (
+const ProductSelectField = ({
+  // Strip out any provided labelKey to ensure we always get the default display text behaviour
+  // from ProductSelect (which is triggered when labelKey is falsy).
+  labelKey,
+  ...props
+}) => (
   <SelectField
     {...props}
     selectComponent={ProductSelect}
   />
 );
+
+ProductSelectField.propTypes = {
+  labelKey: PropTypes.string,
+};
+
+ProductSelectField.defaultProps = {
+  labelKey: undefined,
+};
 
 export default ProductSelectField;

--- a/src/js/components/form-elements/v2/ProductSelectField.jsx
+++ b/src/js/components/form-elements/v2/ProductSelectField.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import ProductSelect from 'components/product-select/ProductSelect';
+
+import SelectField from './SelectField';
+
+/**
+ * A wrapper on SelectField, configured for a product dropdown selector
+ */
+const ProductSelectField = (props) => (
+  <SelectField
+    {...props}
+    selectComponent={ProductSelect}
+  />
+);
+
+export default ProductSelectField;

--- a/src/js/components/form-elements/v2/SelectField.jsx
+++ b/src/js/components/form-elements/v2/SelectField.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import PropTypes from 'prop-types';
 
-import ProductSelect from 'components/product-select/ProductSelect';
 import componentType from 'consts/componentType';
 import useFocusOnMatch from 'hooks/useFocusOnMatch';
 import Select from 'utils/Select';
@@ -24,7 +23,7 @@ const SelectField = ({
   defaultValue,
   multiple,
   onChange,
-  productSelect,
+  selectComponent: SelectComponent,
   hasErrors,
   className,
   warning,
@@ -36,6 +35,7 @@ const SelectField = ({
   ariaLabel,
   locationId,
   onExactProductSelected,
+  labelKey,
   ...fieldProps
 }) => {
   const [value, setValue] = useState(defaultValue);
@@ -55,8 +55,6 @@ const SelectField = ({
     onChange?.(selectedOption);
     setValue(selectedOption);
   };
-
-  const SelectComponent = productSelect ? ProductSelect : Select;
 
   const fieldRef = useRef(null);
 
@@ -89,6 +87,7 @@ const SelectField = ({
         locationId={locationId}
         onExactProductSelected={onExactProductSelected}
         valueKey="id"
+        labelKey={labelKey}
         {...asyncProps}
         {...fieldProps}
       />
@@ -135,7 +134,8 @@ SelectField.propTypes = {
   multiple: PropTypes.bool,
   // Function triggered on change
   onChange: PropTypes.func,
-  productSelect: PropTypes.bool,
+  // The Select component to render, e.g. the base Select or ProductSelect
+  selectComponent: PropTypes.elementType,
   // indicator whether field should be marked as invalid
   hasErrors: PropTypes.bool,
   className: PropTypes.string,
@@ -157,6 +157,7 @@ SelectField.propTypes = {
   }),
   locationId: PropTypes.string,
   onExactProductSelected: PropTypes.func,
+  labelKey: PropTypes.string,
 };
 
 SelectField.defaultProps = {
@@ -173,7 +174,7 @@ SelectField.defaultProps = {
   defaultValue: null,
   multiple: false,
   onChange: () => {},
-  productSelect: false,
+  selectComponent: Select,
   hasErrors: false,
   className: '',
   hideErrorMessageWrapper: false,
@@ -185,4 +186,5 @@ SelectField.defaultProps = {
   ariaLabel: null,
   locationId: null,
   onExactProductSelected: () => {},
+  labelKey: null,
 };

--- a/src/js/components/productSupplier/create/subsections/BasicDetails.jsx
+++ b/src/js/components/productSupplier/create/subsections/BasicDetails.jsx
@@ -7,6 +7,7 @@ import {
   getFormatLocalizedDate,
 } from 'selectors';
 
+import ProductSelectField from 'components/form-elements/v2/ProductSelectField';
 import SelectField from 'components/form-elements/v2/SelectField';
 import Switch from 'components/form-elements/v2/Switch';
 import TextInput from 'components/form-elements/v2/TextInput';
@@ -73,9 +74,8 @@ const BasicDetails = ({ control, errors, getValues }) => {
             name="basicDetails.product"
             control={control}
             render={({ field }) => (
-              <SelectField
+              <ProductSelectField
                 title={{ id: 'react.productSupplier.form.product.title', defaultMessage: 'Product Name' }}
-                productSelect
                 placeholder="Search for a product"
                 required
                 async

--- a/src/js/hooks/inboundV2/addItems/useInboundAddItemsColumns.jsx
+++ b/src/js/hooks/inboundV2/addItems/useInboundAddItemsColumns.jsx
@@ -22,6 +22,7 @@ import {
 import { TableCell } from 'components/DataTable';
 import TableHeaderCell from 'components/DataTable/TableHeaderCell';
 import DateFieldDateFns from 'components/form-elements/v2/DateFieldDateFns';
+import ProductSelectField from 'components/form-elements/v2/ProductSelectField';
 import SelectField from 'components/form-elements/v2/SelectField';
 import TextInput from 'components/form-elements/v2/TextInput';
 import inboundColumns from 'consts/inboundColumns';
@@ -262,7 +263,7 @@ const useInboundAddItemsColumns = ({
               name={`values.lineItems.${row.index}.product`}
               control={control}
               render={({ field }) => (
-                <SelectField
+                <ProductSelectField
                   {...field}
                   onKeyDown={(e) => handleKeyDown(e, row.index, column.id)}
                   onBlur={() => handleBlur(field, quantityField)}
@@ -282,7 +283,6 @@ const useInboundAddItemsColumns = ({
                     }
                   }}
                   hasErrors={hasErrors}
-                  productSelect
                   // When using ProductSelect instead of Select, ProductSelect sets
                   // showValueTooltip to true by default. This causes the old tooltip
                   // to appear, which we don't want because we're using the new tooltip.

--- a/src/js/hooks/receiving/v2/useReceivedLineItemColumns.jsx
+++ b/src/js/hooks/receiving/v2/useReceivedLineItemColumns.jsx
@@ -15,6 +15,7 @@ import LocationAutofillHeader from 'components/receivingV2/LocationAutofillHeade
 import receivingColumns from 'consts/receivingColumns';
 import { DateFormatDateFns } from 'consts/timeFormat';
 import useTranslate from 'hooks/useTranslate';
+import ProductSelectCell from 'utils/cells/ProductSelectCell';
 import SelectCell from 'utils/cells/SelectCell';
 
 /**
@@ -40,9 +41,8 @@ const useReceivedLineItemColumns = ({ control, copyToReceive }) => {
           name={`receivedItems.${row.index}.product`}
           control={control}
           render={({ field }) => (
-            <SelectCell
+            <ProductSelectCell
               {...field}
-              productSelect
               locationId={locationId}
               disabled
               label="react.receiving.product.label"

--- a/src/js/hooks/receiving/v2/useReceivingLineItemColumns.jsx
+++ b/src/js/hooks/receiving/v2/useReceivingLineItemColumns.jsx
@@ -22,6 +22,7 @@ import LocationAutofillHeader from 'components/receivingV2/LocationAutofillHeade
 import receivingColumns from 'consts/receivingColumns';
 import { DateFormatDateFns } from 'consts/timeFormat';
 import useTranslate from 'hooks/useTranslate';
+import ProductSelectCell from 'utils/cells/ProductSelectCell';
 import QuantityInputCell from 'utils/cells/QuantityInputCell';
 import SelectCell from 'utils/cells/SelectCell';
 import { debouncePeopleFetch } from 'utils/option-utils';
@@ -74,9 +75,8 @@ const useReceivingLineItemColumns = ({
           name={`lineItems.${row.index}.product`}
           control={control}
           render={({ field }) => (
-            <SelectCell
+            <ProductSelectCell
               {...field}
-              productSelect
               locationId={locationId}
               disabled={isOriginalLine(row)}
               label="react.receiving.product.label"

--- a/src/js/utils/cells/ProductSelectCell.jsx
+++ b/src/js/utils/cells/ProductSelectCell.jsx
@@ -11,8 +11,6 @@ const ProductSelectCell = (props) => (
   <SelectCell
     {...props}
     selectFieldComponent={ProductSelectField}
-    // The ProductSelect component handles specifying the display text for the select options.
-    labelKey=""
   />
 );
 

--- a/src/js/utils/cells/ProductSelectCell.jsx
+++ b/src/js/utils/cells/ProductSelectCell.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import ProductSelectField from 'components/form-elements/v2/ProductSelectField';
+
+import SelectCell from './SelectCell';
+
+/**
+ * A wrapper on SelectCell, configured for a product dropdown selector.
+ */
+const ProductSelectCell = (props) => (
+  <SelectCell
+    {...props}
+    selectFieldComponent={ProductSelectField}
+    // The ProductSelect component handles specifying the display text for the select options.
+    labelKey=""
+  />
+);
+
+export default ProductSelectCell;

--- a/src/js/utils/cells/SelectCell.jsx
+++ b/src/js/utils/cells/SelectCell.jsx
@@ -17,7 +17,8 @@ const SelectCell = React.memo(({
   defaultLabel,
   placeholder,
   disabled,
-  productSelect,
+  selectFieldComponent: SelectFieldComponent,
+  labelKey,
   locationId,
   async,
   loadOptions,
@@ -29,15 +30,14 @@ const SelectCell = React.memo(({
   return (
     <TableCell className="rt-td">
       <div className="w-100" aria-label={translate(label, defaultLabel)}>
-        <SelectField
+        <SelectFieldComponent
           options={options}
           value={value}
           onChange={onChange}
-          labelKey="name"
+          labelKey={labelKey}
           placeholder={placeholder}
           disabled={disabled}
           hideErrorMessageWrapper
-          productSelect={productSelect}
           locationId={locationId}
           async={async}
           loadOptions={loadOptions}
@@ -59,7 +59,8 @@ SelectCell.propTypes = {
   defaultLabel: PropTypes.string.isRequired,
   placeholder: PropTypes.string,
   disabled: PropTypes.bool,
-  productSelect: PropTypes.bool,
+  selectFieldComponent: PropTypes.elementType,
+  labelKey: PropTypes.string,
   locationId: PropTypes.string,
   async: PropTypes.bool,
   loadOptions: PropTypes.func,
@@ -73,7 +74,8 @@ SelectCell.defaultProps = {
   onChange: undefined,
   placeholder: '',
   disabled: false,
-  productSelect: false,
+  selectFieldComponent: SelectField,
+  labelKey: 'name',
   locationId: null,
   async: false,
   loadOptions: () => [],


### PR DESCRIPTION
### :sparkles: Description of Change

[//]: <> (A concise summary of what is being changed. Please provide enough context for reviewers to be able to understand the change and why it is necessary.)

**Link to GitHub issue or Jira ticket:** https://pihemr.atlassian.net/browse/OBPIH-7997

**Description:**  Properly override labelKey to be falsy for product select so that it defaults to the behaviour in ProductSelect.


---
### :camera: Screenshots & Recordings (optional)

[//]: <> (If this PR contains a UI change, consider attaching one or more screenshots or recordings to help reviewers visualize the change. Otherwise, you can remove this section.)

before fix:
<img width="1024" height="478" alt="image" src="https://github.com/user-attachments/assets/580b43bc-c4f7-4f8b-a66c-180e97d14112" />

after fix:
<img width="467" height="582" alt="image" src="https://github.com/user-attachments/assets/6eefc8ce-ff15-46df-bbcd-eb250a9cfaaf" />
