### PR TITLE
Fix package price precision when saving products

### DIFF
--- a/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
+++ b/grails-app/controllers/org/pih/warehouse/product/ProductController.groovy
@@ -37,8 +37,6 @@ import org.pih.warehouse.inventory.InventoryLevel
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.multipart.MultipartHttpServletRequest
 
-import java.math.RoundingMode
-
 class ProductController {
 
     def dataService
@@ -372,7 +370,7 @@ class ProductController {
         BigDecimal parsedUnitPrice = null
         if (params.price) {
             try {
-                parsedUnitPrice = new BigDecimal(params.price).setScale(2, RoundingMode.FLOOR)
+                parsedUnitPrice = new BigDecimal(params.price)
             } catch (Exception e) {
                 log.error("Unable to parse unit price: " + e.message, e)
                 flash.message = "Could not parse unit price with value: ${params.price}."

--- a/src/integration-test/groovy/org/pih/warehouse/smoke/spec/ProductPriceSpec.groovy
+++ b/src/integration-test/groovy/org/pih/warehouse/smoke/spec/ProductPriceSpec.groovy
@@ -1,0 +1,31 @@
+package org.pih.warehouse.smoke.spec
+
+import spock.lang.Unroll
+
+import org.pih.warehouse.core.ProductPrice
+import org.pih.warehouse.smoke.spec.base.SmokeSpec
+
+class ProductPriceSpec extends SmokeSpec {
+
+    @Unroll
+    void "product price #price retains its precision after database reload"() {
+        when:
+        BigDecimal reloadedPrice = ProductPrice.withNewTransaction { status ->
+            try {
+                ProductPrice productPrice = new ProductPrice(price: price).save(flush: true, failOnError: true)
+                String id = productPrice.id
+                productPrice.discard()
+
+                return ProductPrice.get(id).price
+            } finally {
+                status.setRollbackOnly()
+            }
+        }
+
+        then:
+        assert reloadedPrice == price
+
+        where:
+        price << [3.4666, 0.0001, 0.0000, 12.3400]
+    }
+}

--- a/src/test/groovy/org/pih/warehouse/product/ProductControllerSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/product/ProductControllerSpec.groovy
@@ -26,9 +26,7 @@ class ProductControllerSpec extends Specification implements ControllerUnitTest<
         mockTagLib(ValidationTagLib)
         mockTagLib(MessageTagLib)
         if (!applicationContext.containsBean('productValidator')) {
-            applicationContext.beanFactory.registerSingleton('productValidator', Stub(ProductValidator) {
-                validate(_) >> true
-            })
+            applicationContext.beanFactory.registerSingleton('productValidator', new ProductValidator())
         }
     }
 

--- a/src/test/groovy/org/pih/warehouse/product/ProductControllerSpec.groovy
+++ b/src/test/groovy/org/pih/warehouse/product/ProductControllerSpec.groovy
@@ -1,0 +1,100 @@
+package org.pih.warehouse.product
+
+import grails.testing.gorm.DataTest
+import grails.testing.web.controllers.ControllerUnitTest
+import org.grails.plugins.web.taglib.ValidationTagLib
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import org.pih.warehouse.MessageTagLib
+import org.pih.warehouse.core.ProductPrice
+
+class ProductControllerSpec extends Specification implements ControllerUnitTest<ProductController>, DataTest {
+
+    Closure doWithSpring() {
+        return {
+            defaultValidator(LocalValidatorFactoryBean)
+        }
+    }
+
+    void setupSpec() {
+        mockDomains(Product, ProductPackage, ProductPrice, Category, ProductType)
+    }
+
+    void setup() {
+        mockTagLib(ValidationTagLib)
+        mockTagLib(MessageTagLib)
+        if (!applicationContext.containsBean('productValidator')) {
+            applicationContext.beanFactory.registerSingleton('productValidator', Stub(ProductValidator) {
+                validate(_) >> true
+            })
+        }
+    }
+
+    @Unroll
+    void "savePackage preserves price #price when existing package is #existing"() {
+        given:
+        Product product = createProduct()
+        if (existing) {
+            ProductPackage productPackage = new ProductPackage(product: product, quantity: 1,
+                    productPrice: new ProductPrice(price: 1.00)).save(validate: false)
+            product.addToPackages(productPackage)
+            params.id = productPackage.id
+        }
+        params['product.id'] = product.id
+        params.quantity = '1'
+        params.price = price
+
+        when:
+        controller.savePackage()
+
+        then:
+        assert product.packages.size() == 1
+        assert product.packages.first().productPrice.price == new BigDecimal(price ?: '0')
+        assert response.redirectedUrl == "/product/edit/${product.id}"
+
+        where:
+        price    | existing
+        '3.4666' | false
+        '3.4666' | true
+        '0.0001' | false
+        '0.0001' | true
+        '0'      | false
+        '0'      | true
+        '12.34'  | false
+        '12.34'  | true
+        ''       | false
+        ''       | true
+    }
+
+    @Unroll
+    void "savePackage rejects invalid price #price"() {
+        given:
+        Product product = createProduct()
+        params['product.id'] = product.id
+        params.quantity = '1'
+        params.price = price
+
+        when:
+        controller.savePackage()
+
+        then:
+        assert ProductPackage.count() == 0
+        assert flash.message.startsWith(message)
+        assert response.redirectedUrl == "/product/edit/${product.id}"
+
+        where:
+        price      | message
+        'invalid'  | 'Could not parse unit price with value: invalid.'
+        '-1'       | 'Wrong unit price value: -1'
+    }
+
+    private Product createProduct() {
+        Category category = new Category(name: "Test category").save(failOnError: true)
+        ProductType productType = new ProductType(name: "Test type",
+                productTypeCode: ProductTypeCode.GOOD).save(failOnError: true)
+        return new Product(name: "Test product", category: category, productType: productType)
+                .save(failOnError: true)
+    }
+}


### PR DESCRIPTION
### :sparkles: Description of Change

**Link to GitHub issue or Jira ticket:** Fixes #4042

**Description:**

Saving a product package currently floors its price to two decimal places: `3.4666` becomes `3.46`, and `0.0001` becomes zero. Parse the submitted price without rounding so the existing four-decimal `product_price.price` column can preserve it. This covers both creating and updating packages through the product form; malformed and negative prices remain rejected, and blank/zero inputs retain their existing behavior.

The controller regression reproduced all four precision failures before the change. The final local product/controller suite passes 53 tests with 3 existing skips, including all 12 new controller cases. GSP compilation passed. A database smoke test saves, detaches and reloads four representative prices to verify that precision survives persistence.

Database validation: [isolated fork CI](https://github.com/Z-Lemke/openboxes/actions/runs/34621507585) passed at `aa4ba2f1a16f2ff50882f9c53bdcb904ab201950` on both MySQL 8.0.36 and MariaDB 10.3.39. Each job passed all four database precision cases (no skips), the 53 product/controller tests (3 existing skips), and GSP compilation. The full integration suite and authenticated browser workflow have not been run locally. No schema migration is needed; previously discarded digits cannot be recovered by this change.

Authorship: I’m Codex, an AI agent contributing at @Z-Lemke’s request. Implementation, test execution and this description are agent-produced; no human review or manual testing by the account owner is claimed.
